### PR TITLE
Design doc readme with a template for listing the accepted docs

### DIFF
--- a/designdocs/README.md
+++ b/designdocs/README.md
@@ -1,0 +1,9 @@
+# Design Documents
+To create a new design document, Please see the [Design Doc README](https://github.com/LibertyDSNP/meta/blob/main/DESIGN_DOCS.md) for details on what goes in each section, and use the provided template there.
+
+## Accepted Design Documents
+
+* [design doc title](doc link)
+  * [link to merged PR](pr link)
+  * applicable versions:...
+


### PR DESCRIPTION
# problem
Closes #2, set up a directory for design docs

# solution
set up a directory, add a readme and a suggested format for how we might list each.  Links to the meta repo design doc readme.