### PR TITLE
[Draft] messages: lightweight retention implementation

### DIFF
--- a/pallets/messages/src/mock.rs
+++ b/pallets/messages/src/mock.rs
@@ -57,6 +57,7 @@ impl system::Config for Test {
 parameter_types! {
 	pub const MaxMessagesPerBlock: u32 = 500;
 	pub const MaxMessageSizeInBytes: u32 = 100;
+	pub const RetentionPeriodBlocks: u32 = 10;
 }
 
 impl std::fmt::Debug for MaxMessageSizeInBytes {
@@ -96,6 +97,7 @@ impl pallet_messages::Config for Test {
 	type WeightInfo = ();
 	type MaxMessagesPerBlock = MaxMessagesPerBlock;
 	type MaxMessageSizeInBytes = MaxMessageSizeInBytes;
+	type RetentionPeriodBlocks = RetentionPeriodBlocks;
 }
 
 pub fn new_test_ext() -> sp_io::TestExternalities {

--- a/runtime/mrc/src/lib.rs
+++ b/runtime/mrc/src/lib.rs
@@ -478,6 +478,10 @@ impl pallet_collator_selection::Config for Runtime {
 parameter_types! {
 	pub const MaxMessagesPerBlock: u32 = 7000;
 	pub const MaxMessageSizeInBytes: u32 = 1024 * 50; // 50K
+
+	// Todo: this is temporary retention period until we are able to get it from schema
+	// https://github.com/LibertyDSNP/mrc/issues/25
+	pub const RetentionPeriodBlocks: u32 = 6 * 30 * 24 * 60 * 10; // ~6 months 6 s/b = 1 year 12 s/b
 }
 
 impl Clone for MaxMessageSizeInBytes {
@@ -492,6 +496,7 @@ impl pallet_messages::Config for Runtime {
 	type AccountProvider = Msa;
 	type MaxMessagesPerBlock = MaxMessagesPerBlock;
 	type MaxMessageSizeInBytes = MaxMessageSizeInBytes;
+	type RetentionPeriodBlocks = RetentionPeriodBlocks;
 }
 
 // Create the runtime by composing the FRAME pallets that were previously configured.


### PR DESCRIPTION
# Problem
We need to be able to prune messages that outside of their retention policy to maintain a manageable on-chain state size.

# Main Idea
To use circular arrays style override in `StorageMap`

