### PR TITLE
MRC -> Frequency: Readmes

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -5,7 +5,7 @@ For contributing guidelines see the [Project Liberty Contributing Guidelines](ht
 
 # Path to Beta
 
-While we are trying to get MRC off the ground, the work is slightly different than with a stable project.
+While we are trying to get Frequency off the ground, the work is slightly different than with a stable project.
 Here are our rules of thumb
 How we work while trying to get off the ground.
 Expect this to change as we stabilize.

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# MRC
+# Frequency
 
 ## Build
 
@@ -49,7 +49,7 @@ Alternatively Run `TARGET=tests ./ci/build.sh` to run cargo tests.
 source .env
 ```
 
-### Start local Relay chain(alice and bob) and MRC(alice)
+### Start local Relay chain(alice and bob) and Frequency(alice)
 
 1. Start relay chain
 
@@ -60,11 +60,11 @@ source .env
 1. Relay chain is running on ports:
     | Host | Port | URL |
     | ---- | ---- | --- |
-    | MRC Relay Node | `9945` | [127.0.0.1:9945](https://polkadot.js.org/apps/?rpc=ws%3A%2F%2F127.0.0.1%3A9945#/explorer) |
+    | Frequency Relay Node | `9945` | [127.0.0.1:9945](https://polkadot.js.org/apps/?rpc=ws%3A%2F%2F127.0.0.1%3A9945#/explorer) |
     | Alice Relay Node | `9946` | [127.0.0.1:9946](https://polkadot.js.org/apps/?rpc=ws%3A%2F%2F127.0.0.1%3A9946#/explorer) |
     | Bob Relay Node | `9947` | [127.0.0.1:9947](https://polkadot.js.org/apps/?rpc=ws%3A%2F%2F127.0.0.1%3A9947#/explorer) |
 
-1. Register a new parachain slot (parachain id) for MRC:
+1. Register a new parachain slot (parachain id) for Frequency:
 
     ```bash
     ./scripts/init.sh register-mrc
@@ -72,7 +72,7 @@ source .env
 
 1. Note: if parachain was previously registered on a running relay chain and no new registration is required, then, you can skip the above step.
 
-1. Start mrc as parachain: This step will generate genesis/wasm and onboard the parachain. If new pallets or runtime code changes have been made to mrc, then developer have to generate chain specs again. Refer to [generation spec file](#generating-a-new-spec-file) for more details.
+1. Start Frequency as parachain: This step will generate genesis/wasm and onboard the parachain. If new pallets or runtime code changes have been made to Frequency, then developer have to generate chain specs again. Refer to [generation spec file](#generating-a-new-spec-file) for more details.
 
 1. Note: assumption is that relay chain is running and para id 2000 is registered on relay. If parachain id is not 2000, update the local chain [spec](#generating-a-new-spec-file) with registered parachain id.
 
@@ -82,9 +82,9 @@ source .env
 
 1. Note: set `RUST_LOG=debug RUST_BACKTRACE=1` as the environment variable to enable detailed logs.
 
-1. Alternative to start-mrc: Run ```cargo build --release``` and then run ```./scripts/init.sh start-mrc-docker``` to start mrc in a docker container via docker compose. ```./scripts/init.sh stop-mrc-docker``` to stop mrc container.
+1. Alternative to start-mrc: Run ```cargo build --release``` and then run ```./scripts/init.sh start-mrc-docker``` to start Frequency in a docker container via docker compose. ```./scripts/init.sh stop-mrc-docker``` to stop Frequency container.
 
-1. Onboarding mrc to relay chain
+1. Onboarding Frequency to the relay chain
 
     ```bash
     ./scripts/init.sh onboard-mrc
@@ -94,7 +94,7 @@ source .env
 
 1. Link to parachain [dashboard](https://polkadot.js.org/apps/?rpc=ws%3A%2F%2F127.0.0.1%3A9944)
 
-1. Off-boarding MRC from relay chain
+1. Off-boarding Frequency from relay chain
 
     ```bash
     ./scripts/init.sh offboard-mrc
@@ -104,12 +104,12 @@ Note: Clean up /tmp/mrc directory after off-boarding. This is required to avoid 
 
 ### Ports
 
-- Default ports for MRC are:
+- Default ports for Frequency are:
       - ```30333``` # p2p port
       - ```9933```  # rpc port
       - ```9944```  # ws port
 
-- Default ports for MRC Relay Chain Node are:
+- Default ports for Frequency Relay Chain Node are:
       - ```30334``` # p2p port
       - ```9934```  # rpc port
       - ```9945```  # ws port
@@ -132,17 +132,17 @@ Note: Clean up /tmp/mrc directory after off-boarding. This is required to avoid 
     ./scripts/init.sh stop-relay-chain
     ```
 
-1. Stop MRC running in the terminal.
+1. Stop Frequency running in the terminal.
 
 1. Run ```docker volume prune``` to remove unused volumes.
 
-1. Remove mrc chain data via ```rm -rf /tmp/mrc```.
+1. Remove Frequency chain data via ```rm -rf /tmp/mrc```.
 
 ### Guidelines for writing code documentation
 
 - Rust follows specific style for documenting various code elements. Refer to [rust doc](https://doc.rust-lang.org/rustdoc/how-to-write-documentation.html) and [documentation example](https://doc.rust-lang.org/rust-by-example/meta/doc.html) for more details.
 
-- Running ```RUSTDOCFLAGS="--enable-index-page -Zunstable-options" cargo doc --no-deps``` will generate documentation specific to MRC while ignoring documenting dependencies.
+- Running ```RUSTDOCFLAGS="--enable-index-page -Zunstable-options" cargo doc --no-deps``` will generate documentation specific to Frequency while ignoring documenting dependencies.
 
 - To view generated cargo docs, one can open ```./target/doc/index.html```.
 
@@ -156,9 +156,9 @@ Note: Clean up /tmp/mrc directory after off-boarding. This is required to avoid 
 
 Note: To build spec against specific chain config; specify chain name in the command above.
 
-### Downloading MRC related spec files, generated genesis state and wasm
+### Downloading Frequency related spec files, generated genesis state and wasm
 
-In order to experiment with MRC, spec files and generated genesis state and wasm can be downloaded from [build artifacts](https://github.com/LibertyDSNP/mrc/actions/workflows/main.yml?query=branch%3Amain)
+In order to experiment with Frequency, spec files and generated genesis state and wasm can be downloaded from [build artifacts](https://github.com/LibertyDSNP/mrc/actions/workflows/main.yml?query=branch%3Amain)
 
 ## Linting
 

--- a/README.md
+++ b/README.md
@@ -158,7 +158,7 @@ Note: To build spec against specific chain config; specify chain name in the com
 
 ### Downloading Frequency related spec files, generated genesis state and wasm
 
-In order to experiment with Frequency, spec files and generated genesis state and wasm can be downloaded from [build artifacts](https://github.com/LibertyDSNP/mrc/actions/workflows/main.yml?query=branch%3Amain)
+In order to experiment with Frequency, spec files and generated genesis state and wasm can be downloaded from [build artifacts](https://github.com/LibertyDSNP/frequency/actions/workflows/main.yml?query=branch%3Amain)
 
 ## Linting
 

--- a/designdocs/README.md
+++ b/designdocs/README.md
@@ -4,15 +4,15 @@ To create a new design document, Please see the [Design Doc README](https://gith
 ## Accepted Design Documents
 
 * [Accounts](./ACCOUNTS.md)
-  * [PR](https://github.com/LibertyDSNP/mrc/pull/13)
+  * [PR](https://github.com/LibertyDSNP/frequency/pull/13)
 * [On Chain Message Storage](MESSAGE_STORAGE.md)
-  * [Merged Pull Request](https://github.com/LibertyDSNP/mrc/pull/15)
+  * [Merged Pull Request](https://github.com/LibertyDSNP/frequency/pull/15)
 * [Delegation](./delegation.md)
-  * [PR](https://github.com/LibertyDSNP/mrc/pull/14)
+  * [PR](https://github.com/LibertyDSNP/frequency/pull/14)
 * [Message Schema(s)](./SCHEMA.md)
-  * [Merged Pull Request](https://github.com/LibertyDSNP/mrc/pull/17)
+  * [Merged Pull Request](https://github.com/LibertyDSNP/frequency/pull/17)
 * [Provider Permissions and Grants](./provider_permissions.md)
-  * [Merged Pull Request](https://github.com/LibertyDSNP/mrc/pull/150)
+  * [Merged Pull Request](https://github.com/LibertyDSNP/frequency/pull/150)
 
 ## Basic Data Model
 

--- a/designdocs/README.md
+++ b/designdocs/README.md
@@ -16,7 +16,7 @@ To create a new design document, Please see the [Design Doc README](https://gith
 
 ## Basic Data Model
 
-There are three core data models in MRC and each corresponds to a pallet.
+There are three core data models in Frequency and each corresponds to a pallet.
 
 - [Message Source Account (MSA)](../pallets/msa/)
   - Represents a pseudonymous identity that can be the source of messages or provide access to the chain to others
@@ -30,13 +30,14 @@ There are three core data models in MRC and each corresponds to a pallet.
 
 ![Basic Data Model drawio](https://github.com/LibertyDSNP/DesignDocs/blob/main/img/BasicDataModel.drawio.png?raw=true)
 
-## MRC Glossary
+## Frequency Glossary
 
 * `AccountId`: A public key that could be a `Token Account` and/or associated with an `MSA`
 * `Announcer AccountId`: The `AccountId` that signs a capacity transaction and is associated with an MSA from which capacity will be deducted for that capacity transaction.
 * `Announcer MSA`: The `MSA` associated with the `AccountId` that signs a capacity transaction.
 * `Delegate` (verb): The action of an `MSA` (the `Delegator`) delegating to a `Provider`. *A verb only. Do not use as a noun!*
 * `Delegator`: An `MSA` that has delegated to a `Provider`.
+* `MRC`: The old name for Frequency
 * `MSA Id`: The 64 bit unsigned integer associated with an `MSA`.
 * `MSA`: Message Source Account. A registered identifier with the MSA pallet. `AccountIds` (aka public keys) may only be associated with one `MSA` and that association is immutable.
 * `Message`: A message that matches a registered `Schema` (on-chain or off-chain).

--- a/js/rpc/README.md
+++ b/js/rpc/README.md
@@ -15,9 +15,9 @@
 [![MIT License][license-shield]][license-url]
 
 
-# MRC Custom RPC and Types for Polkadot JS API
+# Frequency Custom RPC and Types for Polkadot JS API
 
-An easy way to get all the custom rpc and types config to be able to easily use [MRC](https://github.com/LibertyDSNP/mrc/) with the [Polkadot JS API library](https://www.npmjs.com/package/@polkadot/api).
+An easy way to get all the custom rpc and types config to be able to easily use [Frequency](https://github.com/LibertyDSNP/mrc/) with the [Polkadot JS API library](https://www.npmjs.com/package/@polkadot/api).
 
 <!-- GETTING STARTED -->
 ## Getting Started

--- a/js/rpc/README.md
+++ b/js/rpc/README.md
@@ -17,7 +17,7 @@
 
 # Frequency Custom RPC and Types for Polkadot JS API
 
-An easy way to get all the custom rpc and types config to be able to easily use [Frequency](https://github.com/LibertyDSNP/mrc/) with the [Polkadot JS API library](https://www.npmjs.com/package/@polkadot/api).
+An easy way to get all the custom rpc and types config to be able to easily use [Frequency](https://github.com/LibertyDSNP/frequency/) with the [Polkadot JS API library](https://www.npmjs.com/package/@polkadot/api).
 
 <!-- GETTING STARTED -->
 ## Getting Started
@@ -92,12 +92,12 @@ Distributed under the Apache 2.0 License. See `LICENSE` for more information.
 <!-- MARKDOWN LINKS & IMAGES -->
 <!-- https://www.markdownguide.org/basic-syntax/#reference-style-links -->
 [contributors-shield]: https://img.shields.io/github/contributors/LibertyDSNP/mrc.svg?style=for-the-badge
-[contributors-url]: https://github.com/LibertyDSNP/mrc/graphs/contributors
+[contributors-url]: https://github.com/LibertyDSNP/frequency/graphs/contributors
 [forks-shield]: https://img.shields.io/github/forks/LibertyDSNP/mrc.svg?style=for-the-badge
-[forks-url]: https://github.com/LibertyDSNP/mrc/network/members
+[forks-url]: https://github.com/LibertyDSNP/frequency/network/members
 [stars-shield]: https://img.shields.io/github/stars/LibertyDSNP/mrc.svg?style=for-the-badge
-[stars-url]: https://github.com/LibertyDSNP/mrc/stargazers
+[stars-url]: https://github.com/LibertyDSNP/frequency/stargazers
 [issues-shield]: https://img.shields.io/github/issues/LibertyDSNP/mrc.svg?style=for-the-badge
-[issues-url]: https://github.com/LibertyDSNP/mrc/issues
+[issues-url]: https://github.com/LibertyDSNP/frequency/issues
 [license-shield]: https://img.shields.io/github/license/LibertyDSNP/mrc.svg?style=for-the-badge
-[license-url]: https://github.com/LibertyDSNP/mrc/blob/master/LICENSE
+[license-url]: https://github.com/LibertyDSNP/frequency/blob/master/LICENSE


### PR DESCRIPTION
We are renaming the chain from MRC to Frequency. This kicks it off by updating the README files switching to the new name and adding a Glossary entry for MRC as the old name.