### PR TITLE
Update Design Docs to use Frequency

### DIFF
--- a/designdocs/ACCOUNTS.md
+++ b/designdocs/ACCOUNTS.md
@@ -1,8 +1,8 @@
 ## Context and Scope
 
-The ability to create an on-chain account without a token to increase user accessibility for MRC.
+The ability to create an on-chain account without a token to increase user accessibility for Frequency.
 
-In Polkadot an on-chain account is created when an existential deposit is made to an address generated from cryptographic keys. In order to be able to make such deposit a user needs to acquire tokens via an exchange or transfer tokens into an account address. The process of creating an on-chain account can discourage users from using MRC and by removing this overhead it allows MRC to extend it services to a wider audience.
+In Polkadot an on-chain account is created when an existential deposit is made to an address generated from cryptographic keys. In order to be able to make such deposit a user needs to acquire tokens via an exchange or transfer tokens into an account address. The process of creating an on-chain account can discourage users from using Frequency and by removing this overhead it allows Frequency to extend it services to a wider audience.
 
 ## Goals
 
@@ -17,7 +17,7 @@ In addition, the message sender must preserve the following characteristics:
 
 ## Proposal
 
-I propose a dual account system in MRC. 
+I propose a dual account system in Frequency. 
 
 These two different types of accounts act as building blocks to facilitate the aforementioned goals. One type of account, [Token] Account, will be responsible for holding a balance, transferring tokens to other accounts, and pay certain transactions [list transactions]. Another account, Message Source Account (MSA), will be used to  broadcast messages and delegate to another MSA account.  
 
@@ -27,7 +27,7 @@ A token account has the ability to transfer value between accounts. More general
 
 Similar to Bitcoin, an account address is derived from cryptographic keys and is created by sending token to a public key. It also carries an existential deposit that keeps an account from being pruned. More on the type of supported keys below.
 
-In Substrate a [Token] Account can be implemented by using the Balances Pallet to create an MRC Token and storing a [Token] balance in System pallet.
+In Substrate a [Token] Account can be implemented by using the Balances Pallet to create a Frequency Token and storing a [Token] balance in System pallet.
 
 ### Message Source Account (MSA)
 
@@ -68,4 +68,5 @@ An alternative solution could be to combine both MSAId and AccountId into one id
 
 This would require accounts to be created deterministically. This could be become a bottleneck for adoption as most users are accustomed an Ethereum/Bitcoin account creation flow.
 
-Moreover, by combining an MSAId and AccountId into one identifier it limits the ability to dissociate from an MSAId.
+Moreover, by combining an MSAId and AccountId into one identifier it limits the
+ability to dissociate from an MSAId.

--- a/designdocs/MESSAGE_STORAGE.md
+++ b/designdocs/MESSAGE_STORAGE.md
@@ -5,7 +5,7 @@ The proposed feature consists of changes that is going to be one (or more) palle
 Substrate based blockchain, and it will be used in all environments including production.
 
 ## Problem Statement
-One of the core features of **MRC** is to facilitate passing messages between different
+One of the core features of **Frequency** is to facilitate passing messages between different
 participants. To implement this core feature, backed with guarantees provided by Blockchain
 technology (in our case **Substrate**) we are looking for architectures and data structures
 that will allow us to store these messages on chain.
@@ -67,7 +67,7 @@ Following is a list of considerations for choosing a serialization format.
 2. **Efficient storage**
    - On chain data storage is a limited resource, and we need to minimize stored data
 3. **Supported on popular Languages**
-   - To facilitate third-party integrations with **MRC** the serialization format should be
+   - To facilitate third-party integrations with **Frequency** the serialization format should be
    widely supported in popular programming languages.
 
 #### Candidates
@@ -128,7 +128,7 @@ from `StartingBlockNumber` until is reaches one of values from `EndBlockNumber` 
 
 #### Mitigations
 1. To be able to achieve high throughput we need to carefully calculate `pre-defined maximum number`
-of messages per block. This number should be sufficiently big enough to satisfy **MRC**
+of messages per block. This number should be sufficiently big enough to satisfy **Frequency**
 requirements without allowing any denial of service attacks.
 2. One way to improve read throughput for sequential data is to index the block numbers that have
 any messages, to eliminate unnecessary DB reads. We can use a BitArray per SchemaId storing

--- a/designdocs/delegation.md
+++ b/designdocs/delegation.md
@@ -22,8 +22,8 @@ The primary motivation for delegation is to support End Users of the DSNP platfo
 
 Market research makes it clear that End Users are extremely reluctant to pay to use applications, particularly social networks.
 This means there needs to be some way to onboard End Users and relay their activity through the DSNP platform without charging them.
-On Ethereum and now on MRC, the use of authorized Delegates enables the creation of End User accounts as well as processing and storing user messages and other data for the End Users, paid for by a Provider, who can recoup these costs by other means (outside the scope of this Design Document).
-The vast majority of this activity will not reside on chain, however, MRC needs to be able to coordinate the exchange of data, and to securely allow an End User or any other type of account holder to manage their Delegates.
+On Ethereum and now on Frequency, the use of authorized Delegates enables the creation of End User accounts as well as processing and storing user messages and other data for the End Users, paid for by a Provider, who can recoup these costs by other means (outside the scope of this Design Document).
+The vast majority of this activity will not reside on chain, however, Frequency needs to be able to coordinate the exchange of data, and to securely allow an End User or any other type of account holder to manage their Delegates.
 The delegation is managed by assigning each account, called a Message Sourcing Account or MSA, an ID number, called an MsaId.
 
 ## Goals and Non-Goals
@@ -226,7 +226,7 @@ Including an effective block range in the provider storage data would allow prov
 Directly adding a provider, with or without a provider's permission, is not to be implemented at this time. The original use case was for a potential wallet app to support browsing and adding providers. Adding/replacing a provider for an existing account with an `MsaId` could still be done using the delegated methods, `add_self_as_delegate` or `replace_delegate_with_self`.  A direct add brought up concerns about potential risks of adding a provider without the provider's knowledge. For example, if the provider has removed the delegator for legitimate reasons, such as if the End User violated the provider's Terms of Service, then the provider ought to be able to prevent them from adding the provider again just by paying for it.
 
 ## Glossary
-* **Provider**: An `MsaId` that has been granted specific permissions by its Delegator. A company or individual operating an on-chain Provider MSA in order to post MRC transactions on behalf of other MSAs.
+* **Provider**: An `MsaId` that has been granted specific permissions by its Delegator. A company or individual operating an on-chain Provider MSA in order to post Frequency transactions on behalf of other MSAs.
 * **Delegator**: An `MsaId` that has granted specific permissions to a Provider.
 * **MSA**: Message Sourcing Account. A collection of key pairs which can have a specific token balance.
 * **Public Key**: A 32-byte (u256) number that is used to refer to an on-chain MSA and verify signatures. It is one of the keys of an MSA key pair

--- a/designdocs/provider_permissions.md
+++ b/designdocs/provider_permissions.md
@@ -109,7 +109,7 @@ An extrinsic to allow a provider to request publish write to list of schemas. Re
 
 - Notes: The weights of this extrinsic should account for required weights when revoking grants at schema level via provider/delegator.
 
-### add_mrc_publisher() : Not in the scope for version 1 of this implementation
+### add_frequency_publisher() : Not in the scope for version 1 of this implementation
 
 An extrinsic to allow (via governance) to set a provider as Frequency publisher. This in turn will give all publish rights on all schemas for any delegator delegating to this provider. Rending them **Publisher** status.
 

--- a/designdocs/provider_permissions.md
+++ b/designdocs/provider_permissions.md
@@ -2,11 +2,11 @@
 
 ## Context and Scope
 
-MRC enables users(read delegators) to have control over their own data. While providers can send and receive messages on behalf of users, there is need for separation of control via **delegator->provider**, **provider<->delegator** relationships in form of Permissions and Grants respectively. This document describes the design of the two types of relationships and recommendation on how to implement them.
+Frequency enables users(read delegators) to have control over their own data. While providers can send and receive messages on behalf of users, there is need for separation of control via **delegator->provider**, **provider<->delegator** relationships in form of Permissions and Grants respectively. This document describes the design of the two types of relationships and recommendation on how to implement them.
 
 ## Problem Statement
 
-Data Access Pattern on MRC, at-minimum, should provide ***RESTRICTED*** ```permissions``` at **delegator->provider**, as well as ***PUBLISH*** and, ***Block***, ```grants``` for specific ```schema_id``` at **provider<->delegator**.This entails users can enable specific permissions for provider to write data on their behalf, while also restricting grants to providers at schema level, rendering providers as restricted. Providers should also be able to opt into publish, on behalf of, users, or block from publication, on behalf of, at schema level. Primarily, the use case can be summarized in following way:
+Data Access Pattern on Frequency, at-minimum, should provide ***RESTRICTED*** ```permissions``` at **delegator->provider**, as well as ***PUBLISH*** and, ***Block***, ```grants``` for specific ```schema_id``` at **provider<->delegator**.This entails users can enable specific permissions for provider to write data on their behalf, while also restricting grants to providers at schema level, rendering providers as restricted. Providers should also be able to opt into publish, on behalf of, users, or block from publication, on behalf of, at schema level. Primarily, the use case can be summarized in following way:
 
 - **As a provider**, I would want to publish data for specific ```schema_id``` on-behalf of a delegator. Defaults to ```publish``` permissions on all schemas registered by provider on behalf of delegator.
 - **As a delegator**, I would like to restrict a provider, by allowing a provider to only publish data for specific ```schema_ids``` on-behalf of me.
@@ -15,20 +15,20 @@ Note: A publish state would mean that a provider is able to publish data on beha
 
 ## Goals and Non-Goals
 
-MRC is a default read only for items stored on and off chain, requiring an explicit process to control writing or publishing of messages via some permissions and grants. Some of the major goals surrounding provider permissions and grants are:
+Frequency is a default read only for items stored on and off chain, requiring an explicit process to control writing or publishing of messages via some permissions and grants. Some of the major goals surrounding provider permissions and grants are:
 
 ### Goals
 
-**Opt In and Duality**: Providers should register users with MRC and delegate on behalf of them, while also specifically allowing a collection of schema(s) for which delegator provide them full publication rights. This ensures default state of providers is ***Restrict***. Delegators can also choose to restrict providers on per-schema basis by blocking them from publishing data on their behalf. This ensures default state of delegators is ***Block*** for all non provider preferred ```schema_ids```. Duality should be implemented at schema level grants.
+**Opt In and Duality**: Providers should register users with Frequency and delegate on behalf of them, while also specifically allowing a collection of schema(s) for which delegator provide them full publication rights. This ensures default state of providers is ***Restrict***. Delegators can also choose to restrict providers on per-schema basis by blocking them from publishing data on their behalf. This ensures default state of delegators is ***Block*** for all non provider preferred ```schema_ids```. Duality should be implemented at schema level grants.
 
-**ToS Baked In**: As a part of this design doc, it is recommended to discuss about baking in ***ToS*** for providers and delegators as a part of permission grants by including a hash of ToS unless there is a re-delegation. Such that MRC can also act as proof of specific agreement established between a provider and a delegator.
+**ToS Baked In**: As a part of this design doc, it is recommended to discuss about baking in ***ToS*** for providers and delegators as a part of permission grants by including a hash of ToS unless there is a re-delegation. Such that Frequency can also act as proof of specific agreement established between a provider and a delegator.
 
-**Time Bound Grants**: Any grants given or revoked by a delegator (allowing provider to publish or block them for certain duration) or any grants are modified by a provider or delegator are valid for the duration of ***ToS***. This can be a control mechanism in MRC which can be a fixed number for version 1 of this implementation and be extensible via a governance mechanism. This also brings the question about, if not time bounded, does permissions and grants are set till they are explicitly revoked. While un-delegation, definitely is an option for user to remove a provider completely from ever publishing on their behalf.
+**Time Bound Grants**: Any grants given or revoked by a delegator (allowing provider to publish or block them for certain duration) or any grants are modified by a provider or delegator are valid for the duration of ***ToS***. This can be a control mechanism in Frequency which can be a fixed number for version 1 of this implementation and be extensible via a governance mechanism. This also brings the question about, if not time bounded, does permissions and grants are set till they are explicitly revoked. While un-delegation, definitely is an option for user to remove a provider completely from ever publishing on their behalf.
 
 ### Non-Goals
 
 - Does not cover the case where a delegator or provider can restrict reading of data on their behalf.
-- MRC enables a valid provider or delegator to be able to read as a default.
+- Frequency enables a valid provider or delegator to be able to read as a default.
 - Only covers basic version 1 of permission and grant implementation details.
 - Does not cover details of economics, governance mechanism.
 - Does not cover details on dynamic expiry time for permissions/grants.
@@ -43,7 +43,7 @@ Note: The terminology and implementation are subject to change at issue resoluti
 
 Permission is a generic option for any user. For version 1 of this implementation, the following options are available:
 
-- ***RESTRICTED***: Where a user grants a provider to publish data on their behalf for specific schema(s) only. This is the default state of a provider on MRC, where a provider has to explicitly provide a list of schema(s) for which they are allowed to publish data on behalf of the user.
+- ***RESTRICTED***: Where a user grants a provider to publish data on their behalf for specific schema(s) only. This is the default state of a provider on Frequency, where a provider has to explicitly provide a list of schema(s) for which they are allowed to publish data on behalf of the user.
 
 An example of permission data structure is as follows:
 
@@ -65,7 +65,7 @@ pub struct Permission {
 
 Grants enable delegators as well as providers to restrict one another from publishing data on specific schema(s). For version 1 of this implementation, the following options are available:
 
-- ***PUBLISH***: Where a delegator grants a provider to publish data on their behalf for specific schema(s) only. This is the default state of a provider on MRC, where a provider has to explicitly provide a list of schema(s) for which they are allowed to publish data on behalf of the delegator. This also enables a delegator to opt in to publish their data.
+- ***PUBLISH***: Where a delegator grants a provider to publish data on their behalf for specific schema(s) only. This is the default state of a provider on Frequency, where a provider has to explicitly provide a list of schema(s) for which they are allowed to publish data on behalf of the delegator. This also enables a delegator to opt in to publish their data.
 
 An example of grant data structure is as follows:
 
@@ -89,7 +89,7 @@ pub struct Grant {
 - ***Grant***: The user level action/result. "A user grants a permission to a provider".
 - ***ToS***: The hash of terms of service between a delegator and provider.
 - ***expiry***: The expiry time of a permission/grant.
-- ***schema_id***: The unique identifier of a registered schema on MRC.
+- ***schema_id***: The unique identifier of a registered schema on Frequency.
 
 ### add_schema_grants()
 
@@ -111,7 +111,7 @@ An extrinsic to allow a provider to request publish write to list of schemas. Re
 
 ### add_mrc_publisher() : Not in the scope for version 1 of this implementation
 
-An extrinsic to allow (via governance) to set a provider as MRC publisher. This in turn will give all publish rights on all schemas for any delegator delegating to this provider. Rending them **Publisher** status.
+An extrinsic to allow (via governance) to set a provider as Frequency publisher. This in turn will give all publish rights on all schemas for any delegator delegating to this provider. Rending them **Publisher** status.
 
 - Parameters:
     1. **provider_msa**: The MSA of the provider/app.
@@ -148,8 +148,8 @@ An extrinsic (or rpc if revoking is paid off while adding) to allow a provider o
 
 ## Time bounded permissions
 
-- Expiry time on permissions for version 1 can be a fixed number of blocks set in MRC.
-- This expiry time can be update via governance or runtime upgrades. Since this is not important for the scope of the design doc, implementation details can define, how MRC is handling expiry time in first version.
+- Expiry time on permissions for version 1 can be a fixed number of blocks set in Frequency.
+- This expiry time can be update via governance or runtime upgrades. Since this is not important for the scope of the design doc, implementation details can define, how Frequency is handling expiry time in first version.
 - However, expiry time can be baked in the above extrinsic call and can be set as a parameter.
 
 ## Validation
@@ -172,7 +172,7 @@ Some risks are primarily at implementation level, such a storage pattern of such
   - Key management for reading private data
 - Delegation for reading vs writing
 - Do we need to have a way for the user to express how their data is used on "3rd party" sites (aka sites you don't have an explicit delegation with)
-  - Maybe not MRC, but perhaps at the DSNP layer?
+  - Maybe not Frequency, but perhaps at the DSNP layer?
   - DSNP data use policy for each announcement (We already assume friends/followers can see it even on 3rd party sites)
 - Do we need extendable/modular permissions or "roles"?
   - Grouping Schemas together somehow?
@@ -185,7 +185,7 @@ Some risks are primarily at implementation level, such a storage pattern of such
   - Sub-permissions CRUD? We really only have Create as a permission
 - Could service permissions be set at the provider MSA level and the delegation only have exclusions?
   - This is more auto-optin which I think is bad.
-- Public "Read" permission (DSNP or MRC?)
+- Public "Read" permission (DSNP or Frequency?)
   - Robots.txt
   - Could this be on a per service basis?
     - aka I grant the public ability to "read" schema 7 from service A but not schema 7 from service B


### PR DESCRIPTION
# Goal
The goal of this PR is to replace occurrences of "MRC" with "Frequency" so our documentation stays up to date with current naming.

Closes #211 

# Checklist
- [x] Design doc(s) updated
