### PR TITLE
Fix publish-next and add some docs

### DIFF
--- a/.github/workflows/publish-next.yml
+++ b/.github/workflows/publish-next.yml
@@ -1,11 +1,11 @@
-name: Publish JS Frequency RPC Package @next
+name: Publish @next JS Frequency API Augment Package
 on:
   push:
     branches: [ main ]
     paths:
-      - 'js/api-augment'
+      - js/api-augment/**
 jobs:
-  test:
+  publish:
     runs-on: ubuntu-20.04
     steps:
       - name: Checkout

--- a/js/api-augment/index.ts
+++ b/js/api-augment/index.ts
@@ -3,6 +3,9 @@ import "./interfaces/augment-api";
 import "./interfaces/augment-types";
 import * as definitions from "./interfaces/definitions";
 
+/**
+ * Build up the types for ApiPromise.create
+ */
 export const types = Object.entries(definitions).reduce((acc, [_key, value]) => {
   return {
     ...acc,
@@ -10,6 +13,9 @@ export const types = Object.entries(definitions).reduce((acc, [_key, value]) => 
   }
 }, {})
 
+/**
+ * Build up the rpc calls for ApiPromise.create
+ */
 export const rpc = Object.entries(definitions).reduce((acc, [key, value]) => {
   return {
     ...acc,
@@ -17,6 +23,16 @@ export const rpc = Object.entries(definitions).reduce((acc, [key, value]) => {
   }
 }, {})
 
+/**
+ * Export for easy use with Polkadot API's ApiPromise
+ *
+ * ```javascript
+ * const api = await ApiPromise.create({
+ *    ...options,
+ *    provider
+ *  });
+ * ```
+ */
 export const options = {
   rpc,
   types


### PR DESCRIPTION
# Goal
The goal of this PR is to fix the github workflow for publish `@next` on the js api-augment library.

Quick follow up fix for #219 so the main builds work.
