### PR TITLE
Feat/on chain json validation review/111

### DIFF
--- a/pallets/schemas/src/lib.rs
+++ b/pallets/schemas/src/lib.rs
@@ -213,7 +213,6 @@ pub mod pallet {
 		) -> DispatchResult {
 			let sender = ensure_signed(origin)?;
 
-			Self::ensure_valid_schema(&model)?;
 			ensure!(
 				model.len() > T::MinSchemaModelSizeBytes::get() as usize,
 				Error::<T>::LessThanMinSchemaModelBytes

--- a/pallets/schemas/src/lib.rs
+++ b/pallets/schemas/src/lib.rs
@@ -72,7 +72,7 @@ pub use pallet::*;
 pub mod weights;
 pub use types::*;
 pub use weights::*;
-mod serde;
+pub mod serde;
 
 #[frame_support::pallet]
 pub mod pallet {

--- a/pallets/schemas/src/lib.rs
+++ b/pallets/schemas/src/lib.rs
@@ -72,7 +72,7 @@ pub use pallet::*;
 pub mod weights;
 pub use types::*;
 pub use weights::*;
-pub mod serde;
+mod serde;
 
 #[frame_support::pallet]
 pub mod pallet {

--- a/pallets/schemas/src/lib.rs
+++ b/pallets/schemas/src/lib.rs
@@ -223,6 +223,8 @@ pub mod pallet {
 				Error::<T>::ExceedsMaxSchemaModelBytes
 			);
 
+			Self::ensure_valid_schema(&model)?;
+
 			let schema_id = Self::add_schema(model, model_type, payload_location)?;
 
 			Self::deposit_event(Event::SchemaRegistered(sender, schema_id));

--- a/pallets/schemas/src/serde.rs
+++ b/pallets/schemas/src/serde.rs
@@ -42,6 +42,7 @@ fn serde_helper_invalid_schema() {
 		"true",
 		"567",
 		r#"string"#,
+		"",
 		r#"["this","is","a","weird","array"],
 		r#"{"name","John Doe"}"#,
 		r#"{"minimum": -90, 90}"#,

--- a/pallets/schemas/src/serde.rs
+++ b/pallets/schemas/src/serde.rs
@@ -1,4 +1,7 @@
+#[cfg(test)]
 use super::mock::*;
+
+#[allow(unused_imports)]
 use frame_support::assert_noop;
 use serde_json::{from_slice, Value};
 use sp_std::vec::Vec;

--- a/pallets/schemas/src/tests.rs
+++ b/pallets/schemas/src/tests.rs
@@ -71,6 +71,23 @@ fn register_schema_happy_path() {
 }
 
 #[test]
+fn register_schema_unhappy_path() {
+	new_test_ext().execute_with(|| {
+		sudo_set_max_schema_size();
+		let sender: AccountId = 1;
+		assert_noop!(
+			SchemasPallet::register_schema(
+				Origin::signed(sender),
+				create_bounded_schema_vec(r#"{"name", 54, "type": "none"}"#),
+				ModelType::AvroBinary,
+				PayloadLocation::OnChain
+			),
+			Error::<Test>::InvalidSchema
+		);
+	})
+}
+
+#[test]
 fn set_max_schema_size_works_if_root() {
 	new_test_ext().execute_with(|| {
 		let new_size: u32 = 42;

--- a/pallets/schemas/src/tests.rs
+++ b/pallets/schemas/src/tests.rs
@@ -198,13 +198,3 @@ fn validate_schema_is_acceptable() {
 		assert_ok!(result);
 	});
 }
-
-#[test]
-fn reject_null_json_schema() {
-	new_test_ext().execute_with(|| {
-		assert_noop!(
-			SchemasPallet::ensure_valid_schema(&create_bounded_schema_vec("")),
-			Error::<Test>::InvalidSchema
-		);
-	})
-}


### PR DESCRIPTION
# Goal
The goal of this PR is to fix the use of serde-json library with no-std support for on-chain JSON validation

Closes #111 

# Discussion
Serde-Json uses 'Value' enum to deserialize Json to any type. Serde-Json provides no-std support if
- default features are turned off
- only imports that do not rely on std libraries are used. (For example, the compiler will complain if we tried to use serde-Json::Error, which relies on std::Error)

# Checklist
- [x] Tests added