### PR TITLE
Enable codecov on main commits

### DIFF
--- a/.github/workflows/rust-code-coverage.yml
+++ b/.github/workflows/rust-code-coverage.yml
@@ -4,6 +4,8 @@ concurrency:
   cancel-in-progress: true
 on:
   pull_request:
+  push:
+    branches: [main]
 jobs:
   codecov:
     name: Code Coverage Report


### PR DESCRIPTION
# Goal
Enables running codecov on main so that codecov has a better base to compare to.
