### PR TITLE
Docs trigger and codecov setting updates

### DIFF
--- a/.github/workflows/mrc_gh_pages.yml
+++ b/.github/workflows/mrc_gh_pages.yml
@@ -1,7 +1,7 @@
-name: Build and Publish Frequency Docs
+name: Build and Publish Frequency Rust Docs
 
 on:
-  workflow_dispatch:
+  push:
     branches: [main]
 
 jobs:

--- a/.github/workflows/rust-code-coverage.yml
+++ b/.github/workflows/rust-code-coverage.yml
@@ -77,5 +77,5 @@ jobs:
         if: ${{ steps.filter.outputs.rust == 'true' }}
         uses: codecov/codecov-action@v3
         with:
-          fail_ci_if_error: true # optional (default = false)
+          fail_ci_if_error: false # optional (default = false)
           verbose: true # optional (default = false)

--- a/codecov.yml
+++ b/codecov.yml
@@ -1,0 +1,14 @@
+coverage:
+  precision: 2
+  round: down
+  range: "60...100"
+  status:                        # this controls whether a pull request will be blocked by a decrease in coverage
+    # Learn more at https://docs.codecov.com/docs/commit-status
+    project:
+      default:
+        threshold: 5%            # allows coverage to drop by up to the percent noted and still post a success status
+        #informational: true     # If true is specified the resulting status will pass no matter what the coverage is or what other settings are specified
+
+ignore:
+  - "node"  # ignore folders and all its contents
+  - "runtime"  # ignore folders and all its contents


### PR DESCRIPTION
# Goal
The goal of this PR is to trigger the doc generation and deployment on every main commit and update the codecov settings to not be as noisy.