### PR TITLE
Codecov handle patch values as informational

### DIFF
--- a/codecov.yml
+++ b/codecov.yml
@@ -7,13 +7,15 @@ coverage:
     project:
       default:
         threshold: 5%            # allows coverage to drop by up to the percent noted and still post a success status
-        
-        # Codecov adds Substrate's weight and benchmarking functions to
-        # coverage, which are not testable. The result is a coverage threshold
-        # that we cannot meet. Until we find a way arouund that, let's make the
-        # coverage report informational only.
+        informational: false     # If true is specified the resulting status will pass no matter what the coverage is or what other settings are specified
+    patch:
+      default:
+        target: 0% # No target for patches
+        only_pulls: true
+        # Patches should be informational only as many things can throw off the patch information
         informational: true     # If true is specified the resulting status will pass no matter what the coverage is or what other settings are specified
 
 ignore:
   - "node"  # ignore folders and all its contents
   - "runtime"  # ignore folders and all its contents
+  - "**/weights.rs" # Ignore weights


### PR DESCRIPTION
# Goal
The goal of this PR is make codecov more useful and less annoying

# Checklist
- [ ] Set patch level codecov to informational
- [ ] Set patch level target to 0
- [ ] Make project level non-informational
- [ ] Ignore weights.rs files
