### PR TITLE
Chore Update Delegator and Provider Encoding and Hashing

### DIFF
--- a/common/primitives/src/msa.rs
+++ b/common/primitives/src/msa.rs
@@ -1,17 +1,35 @@
-use codec::{Decode, Encode, MaxEncodedLen};
+use codec::{Decode, Encode, EncodeLike, Error, MaxEncodedLen};
 use frame_support::{dispatch::DispatchResult, traits::Get, BoundedVec};
 use scale_info::TypeInfo;
 #[cfg(feature = "std")]
 use serde::{Deserialize, Serialize};
 use sp_runtime::DispatchError;
+use sp_std::prelude::Vec;
 
 /// Message Source Id or msaId is the unique identifier for Message Source Accounts
 pub type MessageSourceId = u64;
 
 /// A Delegator is a role for an MSA to play.
 /// Delegators delegate to Providers.
-#[derive(TypeInfo, Debug, Clone, Copy, Decode, Encode, PartialEq, MaxEncodedLen, Eq)]
+#[derive(TypeInfo, Debug, Clone, Copy, PartialEq, MaxEncodedLen, Eq)]
 pub struct Delegator(pub MessageSourceId);
+
+impl EncodeLike for Delegator {}
+
+impl Encode for Delegator {
+	fn encode(&self) -> Vec<u8> {
+		self.0.encode()
+	}
+}
+
+impl Decode for Delegator {
+	fn decode<I: codec::Input>(input: &mut I) -> Result<Self, codec::Error> {
+		match <u64>::decode(input) {
+			Ok(x) => Ok(Delegator(x)),
+			_ => Err(Error::from("Could not decode Delegator")),
+		}
+	}
+}
 
 impl From<MessageSourceId> for Delegator {
 	fn from(t: MessageSourceId) -> Self {
@@ -56,8 +74,25 @@ pub struct ProviderInfo<BlockNumber> {
 
 /// Provider is the recipient of a delegation.
 /// It is a subset of an MSA
-#[derive(TypeInfo, Debug, Clone, Copy, Decode, Encode, PartialEq, MaxEncodedLen, Eq)]
+#[derive(TypeInfo, Debug, Clone, Copy, PartialEq, MaxEncodedLen, Eq)]
 pub struct Provider(pub MessageSourceId);
+
+impl EncodeLike for Provider {}
+
+impl Encode for Provider {
+	fn encode(&self) -> Vec<u8> {
+		self.0.encode()
+	}
+}
+
+impl Decode for Provider {
+	fn decode<I: codec::Input>(input: &mut I) -> Result<Self, codec::Error> {
+		match <u64>::decode(input) {
+			Ok(x) => Ok(Provider(x)),
+			_ => Err(Error::from("Could not decode Provider")),
+		}
+	}
+}
 
 /// This is the metadata associated with a provider. As of now it is just a
 /// name, but it will likely be expanded in the future

--- a/pallets/msa/src/lib.rs
+++ b/pallets/msa/src/lib.rs
@@ -144,7 +144,7 @@ pub mod pallet {
 	pub type ProviderRegistry<T: Config> = StorageMap<
 		_,
 		Twox64Concat,
-		MessageSourceId,
+		Provider,
 		ProviderMetadata<T::MaxProviderNameSize>,
 		OptionQuery,
 	>;
@@ -343,7 +343,7 @@ pub mod pallet {
 
 			let provider_msa_id = Self::ensure_valid_msa_key(&provider_key)?.msa_id;
 			ProviderRegistry::<T>::try_mutate(
-				provider_msa_id,
+				Provider(provider_msa_id),
 				|maybe_metadata| -> DispatchResult {
 					ensure!(maybe_metadata.take().is_none(), Error::<T>::DuplicateProviderMetadata);
 					*maybe_metadata = Some(ProviderMetadata { provider_name: bounded_name });

--- a/pallets/msa/src/lib.rs
+++ b/pallets/msa/src/lib.rs
@@ -128,9 +128,9 @@ pub mod pallet {
 	#[pallet::getter(fn get_provider_info_of)]
 	pub type ProviderInfoOf<T: Config> = StorageDoubleMap<
 		_,
-		Blake2_128Concat,
+		Twox64Concat,
 		Delegator,
-		Blake2_128Concat,
+		Twox64Concat,
 		Provider,
 		ProviderInfo<T::BlockNumber>,
 		OptionQuery,
@@ -143,7 +143,7 @@ pub mod pallet {
 	#[pallet::getter(fn get_provider_metadata)]
 	pub type ProviderRegistry<T: Config> = StorageMap<
 		_,
-		Blake2_128Concat,
+		Twox64Concat,
 		MessageSourceId,
 		ProviderMetadata<T::MaxProviderNameSize>,
 		OptionQuery,
@@ -154,8 +154,7 @@ pub mod pallet {
 	/// - Value: [`KeyInfo`](common_primitives::msa::KeyInfo)
 	#[pallet::storage]
 	#[pallet::getter(fn get_key_info)]
-	pub type KeyInfoOf<T: Config> =
-		StorageMap<_, Blake2_128Concat, T::AccountId, KeyInfo, OptionQuery>;
+	pub type KeyInfoOf<T: Config> = StorageMap<_, Twox64Concat, T::AccountId, KeyInfo, OptionQuery>;
 
 	/// Storage for MSA keys
 	/// - Key: MSA Id
@@ -164,7 +163,7 @@ pub mod pallet {
 	#[pallet::getter(fn get_msa_keys)]
 	pub(super) type MsaKeysOf<T: Config> = StorageMap<
 		_,
-		Blake2_128Concat,
+		Twox64Concat,
 		MessageSourceId,
 		BoundedVec<T::AccountId, T::MaxKeys>,
 		ValueQuery,


### PR DESCRIPTION
# Goal
The goal of this PR is to enable Delegator and Provider to use `Twox64Concat`

Closes N/A

# Discussion

- This is from the Frequency and DSNP Spec meeting from 2022-08-25
- Why do we use the structs for Delegator and Provider instead of just type aliases?
    - Because it makes it so that we cannot mix them up by accident
- Encoding is now not derived, but just uses the u64 inside of the struct.

# Checklist
- [ ] (N/A) Chain spec updated
- [ ] (N/A) Updated the js/api-augment code if a custom RPC added/changed
- [ ] (N/A) Design doc(s) updated
- [ ] (N/A) Tests added
- [ ] (N/A) Benchmarks added
- [ ] (N/A) Weights updated
