### PR TITLE
Added asdf support

### DIFF
--- a/.tool-versions
+++ b/.tool-versions
@@ -1,0 +1,5 @@
+rust 1.62.0
+make 4.3
+cmake 3.24.1
+# clang 14.0.6 # only plugin I could find for clang and not some subset of clang did not work, it was located here https://github.com/srivathsanmurali/asdf-clang.git
+

--- a/README.md
+++ b/README.md
@@ -54,6 +54,20 @@ We run benchmarks with and recommend the same [reference hardware specified by P
 At this point you should have `./target/release` directory generated locally with compiled
 project files.
 
+### asdf Support:
+Install the required plugins for asdf:
+```sh
+asdf plugin-add rust
+asdf plugin-add make
+asdf plugin-add cmake [https://github.com/srivathsanmurali/asdf-cmake.git](https://github.com/srivathsanmurali/asdf-cmake.git)
+```
+Install the dependency versions declared in `.tool-versions`
+```shell
+asdf install
+```
+
+NOTE: I could find no clang plugin that worked so your system still needs clang to be installed.
+
 ## Remote instance such as AWS EC2
 For remote instances running Linux, if you want to check out and build such as on an AWS EC2 instance, the process is slightly different to what is in the [Substrate documentation](https://docs.substrate.io/main-docs/install/linux/).
 ### Ubuntu


### PR DESCRIPTION
Or as much as I could have. Clang proved not to be supportable through
asdf, blegh

# Goal
Add asdf support

Closes
Nothing

# Discussion
Trying to build out the project I noticed I needed some things installed and presumably the project would benefit those things being well versioned.

# Checklist
I would say none of these apply
- [ ] Chain spec updated
- [ ] Updated the js/api-augment code if a custom RPC added/changed
- [ ] Design doc(s) updated
- [ ] Tests added
- [ ] Benchmarks added
- [ ] Weights updated
