### PR TITLE
Call filters #257

### DIFF
--- a/ci/build.sh
+++ b/ci/build.sh
@@ -30,8 +30,7 @@ case $TARGET in
     cargo test --all-features --workspace --release
     ;;
 
-  lint)
-    cargo fmt +nightly
+  lint) 
     cargo fmt -- --check
     SKIP_WASM_BUILD=1 env -u RUSTFLAGS cargo clippy --all-targets
     ;;

--- a/ci/build.sh
+++ b/ci/build.sh
@@ -31,6 +31,7 @@ case $TARGET in
     ;;
 
   lint)
+    cargo fmt +nightly
     cargo fmt -- --check
     SKIP_WASM_BUILD=1 env -u RUSTFLAGS cargo clippy --all-targets
     ;;

--- a/ci/build.sh
+++ b/ci/build.sh
@@ -30,7 +30,7 @@ case $TARGET in
     cargo test --all-features --workspace --release
     ;;
 
-  lint) 
+  lint)
     cargo fmt -- --check
     SKIP_WASM_BUILD=1 env -u RUSTFLAGS cargo clippy --all-targets
     ;;

--- a/runtime/frequency/src/lib.rs
+++ b/runtime/frequency/src/lib.rs
@@ -39,7 +39,7 @@ use frame_support::{
 	construct_runtime,
 	dispatch::DispatchError,
 	parameter_types,
-	traits::{ConstU32, EitherOfDiverse, EnsureOrigin, EqualPrivilegeOnly, Everything},
+	traits::{ConstU32, Contains, EitherOfDiverse, EnsureOrigin, EqualPrivilegeOnly},
 	weights::{
 		constants::{RocksDbWeight, WEIGHT_PER_SECOND},
 		ConstantMultiplier, DispatchClass, Weight, WeightToFeeCoefficient, WeightToFeeCoefficients,
@@ -106,6 +106,12 @@ pub type SignedBlock = generic::SignedBlock<Block>;
 /// BlockId type as expected by this runtime.
 pub type BlockId = generic::BlockId<Block>;
 
+pub struct BaseFilter;
+impl Contains<Call> for BaseFilter {
+	fn contains(call: &Call) -> bool {
+		true
+	}
+}
 /// The SignedExtension to the basic transaction logic.
 pub type SignedExtra = (
 	frame_system::CheckNonZeroSender<Runtime>,
@@ -273,6 +279,8 @@ parameter_types! {
 impl frame_system::Config for Runtime {
 	/// The identifier used to distinguish between accounts.
 	type AccountId = AccountId;
+	/// Base call filter to use in dispatchable.
+	type BaseCallFilter = BaseFilter;
 	/// The aggregated dispatch type that is available for extrinsics.
 	type Call = Call;
 	/// The lookup mechanism to get account ID from whatever is passed in dispatchers.
@@ -305,8 +313,6 @@ impl frame_system::Config for Runtime {
 	type OnKilledAccount = ();
 	/// The weight of database operations that the runtime can invoke.
 	type DbWeight = RocksDbWeight;
-	/// The basic call filter to use in dispatchable.
-	type BaseCallFilter = Everything;
 	/// Weight information for the extrinsics of this pallet.
 	type SystemWeightInfo = ();
 	/// Block & extrinsics weights: base values and limits.

--- a/runtime/frequency/src/lib.rs
+++ b/runtime/frequency/src/lib.rs
@@ -106,10 +106,14 @@ pub type SignedBlock = generic::SignedBlock<Block>;
 /// BlockId type as expected by this runtime.
 pub type BlockId = generic::BlockId<Block>;
 
-pub struct BaseFilter;
-impl Contains<Call> for BaseFilter {
+pub struct BaseCallFilter;
+impl Contains<Call> for BaseCallFilter {
 	fn contains(call: &Call) -> bool {
-		true
+		matches!(
+			call,
+			// These calls are allowed to be dispatched by normal transactions.
+			Call::Sudo(..) | Call::Democracy(_) | Call::Council(_) | Call::TechnicalCommittee(_)
+		)
 	}
 }
 /// The SignedExtension to the basic transaction logic.
@@ -280,7 +284,7 @@ impl frame_system::Config for Runtime {
 	/// The identifier used to distinguish between accounts.
 	type AccountId = AccountId;
 	/// Base call filter to use in dispatchable.
-	type BaseCallFilter = BaseFilter;
+	type BaseCallFilter = BaseCallFilter;
 	/// The aggregated dispatch type that is available for extrinsics.
 	type Call = Call;
 	/// The lookup mechanism to get account ID from whatever is passed in dispatchers.

--- a/runtime/frequency/src/lib.rs
+++ b/runtime/frequency/src/lib.rs
@@ -106,16 +106,24 @@ pub type SignedBlock = generic::SignedBlock<Block>;
 /// BlockId type as expected by this runtime.
 pub type BlockId = generic::BlockId<Block>;
 
+/// Basefilter to only allow specified transactions call to be executed
 pub struct BaseCallFilter;
 impl Contains<Call> for BaseCallFilter {
 	fn contains(call: &Call) -> bool {
-		matches!(
-			call,
-			// These calls are allowed to be dispatched by normal transactions.
-			Call::Sudo(..) | Call::Democracy(_) | Call::Council(_) | Call::TechnicalCommittee(_)
-		)
+		let core_calls = match call {
+			Call::System(..) => true,
+			Call::Timestamp(..) => true,
+			Call::ParachainSystem(..) => true,
+			Call::Sudo(..) => true,
+			Call::TechnicalCommittee(..) => true,
+			Call::Council(..) => true,
+			Call::Democracy(..) => true,
+			_ => false,
+		};
+		core_calls
 	}
 }
+
 /// The SignedExtension to the basic transaction logic.
 pub type SignedExtra = (
 	frame_system::CheckNonZeroSender<Runtime>,


### PR DESCRIPTION
# Goal
The goal of this PR is to add call filters to mainnet runtime
Closes #257 

- [x] Add call filters for Mainnet (aka `frequency` runtime only) that prevent calls to **everything except**:
    - [x] Sudo
    - [x] Governance
    - [x] Should be a positive filter (aka only things listed can go through)
- [ ] Maybe Add a runtime test? #376 

## Acceptance Criteria
- [x] As a normal user I cannot make any calls, even if I have tokens
- [x] As sudo I can do anything, but specifically test:
  - [x] forcedTokenTransfer
  - [ ] Chain Upgrade
- [x] As a member of the upgrade council, I can make the calls needed to propose and trigger an upgrade
- [x] Only on Mainnet
