### PR TITLE
Ensure sudo has tokens on Rococo and Mainnet

### DIFF
--- a/node/service/src/chain_spec/frequency.rs
+++ b/node/service/src/chain_spec/frequency.rs
@@ -4,8 +4,9 @@ use frequency_runtime::{
 	AccountId, AuraId, Balance, CouncilConfig, SudoConfig, TechnicalCommitteeConfig,
 	EXISTENTIAL_DEPOSIT,
 };
+use hex::FromHex;
 use sc_service::ChainType;
-use sp_core::sr25519;
+use sp_core::ByteArray;
 
 /// Specialized `ChainSpec` for the normal parachain runtime.
 pub type ChainSpec = sc_service::GenericChainSpec<frequency_runtime::GenesisConfig, Extensions>;
@@ -13,10 +14,26 @@ pub type ChainSpec = sc_service::GenericChainSpec<frequency_runtime::GenesisConf
 /// The default XCM version to set in genesis config.
 const SAFE_XCM_VERSION: u32 = xcm::prelude::XCM_VERSION;
 
-use super::{get_account_id_from_seed, get_collator_keys_from_seed, get_properties, Extensions};
+use super::{get_properties, Extensions};
 
-//TODO: Define various keys for frequency mainnet
-pub mod frequency_mainnet_keys {}
+//TODO: Define FINAL keys for frequency mainnet
+pub mod frequency_mainnet_keys {
+	//TODO: final sudo key(s) for mainnet
+	pub const MAINNET_FRQ_SUDO: &str =
+		"0xd43593c715fdd31c61141abd04a99fd6822c8558854ccde39a5684e7a56da27d"; // Alice
+
+	//TODO: final collator key(s) for mainnet
+	pub const COLLATOR_1_SR25519: &str =
+		"0xd43593c715fdd31c61141abd04a99fd6822c8558854ccde39a5684e7a56da27d"; // Alice
+	pub const COLLATOR_2_SR25519: &str =
+		"0x8eaf04151687736326c9fea17e25fc5287613693c912909cb226aa4794f26a48"; // Bob
+	pub const COLLATOR_3_SR25519: &str =
+		"0x306721211d5404bd9da88e0204360a1a9ab8b87c66c1bc2fcdd37f3c2222cc20"; // Charlie
+	pub const COLLATOR_4_SR25519: &str =
+		"0x306721211d5404bd9da88e0204360a1a9ab8b87c66c1bc2fcdd37f3c2222cc20"; // Dave
+	pub const COLLATOR_5_SR25519: &str =
+		"0xe659a7a1628cdd93febc04a4e0646ea20e9f5f0ce097d9a05290d4a9e054df4e"; // Eve
+}
 
 // pub fn load_frequency_spec() -> Result<ChainSpec, String> {
 // 	ChainSpec::from_json_bytes(&include_bytes!("../../specs/frequency.json")[..])
@@ -35,14 +52,129 @@ pub fn frequency() -> ChainSpec {
 		move || {
 			frequency_genesis(
 				// TODO: initial collators.
-				vec![(
-					get_account_id_from_seed::<sr25519::Public>("Alice"),
-					get_collator_keys_from_seed("Alice"),
-				)],
-				//TODO: sudo key(s) for mainnet
-				Some(get_account_id_from_seed::<sr25519::Public>("Alice")),
+				vec![
+					(
+						frequency_mainnet_keys::COLLATOR_1_SR25519
+							.parse::<AccountId>()
+							.unwrap()
+							.into(),
+						AuraId::from_slice(
+							&<[u8; 32]>::from_hex(
+								frequency_mainnet_keys::COLLATOR_1_SR25519
+									.strip_prefix("0x")
+									.unwrap(),
+							)
+							.unwrap(),
+						)
+						.unwrap(),
+					),
+					(
+						frequency_mainnet_keys::COLLATOR_2_SR25519
+							.parse::<AccountId>()
+							.unwrap()
+							.into(),
+						AuraId::from_slice(
+							&<[u8; 32]>::from_hex(
+								frequency_mainnet_keys::COLLATOR_2_SR25519
+									.strip_prefix("0x")
+									.unwrap(),
+							)
+							.unwrap(),
+						)
+						.unwrap(),
+					),
+					(
+						frequency_mainnet_keys::COLLATOR_3_SR25519
+							.parse::<AccountId>()
+							.unwrap()
+							.into(),
+						AuraId::from_slice(
+							&<[u8; 32]>::from_hex(
+								frequency_mainnet_keys::COLLATOR_3_SR25519
+									.strip_prefix("0x")
+									.unwrap(),
+							)
+							.unwrap(),
+						)
+						.unwrap(),
+					),
+					(
+						frequency_mainnet_keys::COLLATOR_4_SR25519
+							.parse::<AccountId>()
+							.unwrap()
+							.into(),
+						AuraId::from_slice(
+							&<[u8; 32]>::from_hex(
+								frequency_mainnet_keys::COLLATOR_4_SR25519
+									.strip_prefix("0x")
+									.unwrap(),
+							)
+							.unwrap(),
+						)
+						.unwrap(),
+					),
+					(
+						frequency_mainnet_keys::COLLATOR_5_SR25519
+							.parse::<AccountId>()
+							.unwrap()
+							.into(),
+						AuraId::from_slice(
+							&<[u8; 32]>::from_hex(
+								frequency_mainnet_keys::COLLATOR_5_SR25519
+									.strip_prefix("0x")
+									.unwrap(),
+							)
+							.unwrap(),
+						)
+						.unwrap(),
+					),
+				],
+				Some(frequency_mainnet_keys::MAINNET_FRQ_SUDO.parse::<AccountId>().unwrap().into()),
 				// TODO:: endowed accounts with initial balance.
-				vec![(get_account_id_from_seed::<sr25519::Public>("Alice"), 1 << 60)],
+				vec![
+					(
+						frequency_mainnet_keys::MAINNET_FRQ_SUDO
+							.parse::<AccountId>()
+							.unwrap()
+							.into(),
+						1 << 60,
+					),
+					(
+						frequency_mainnet_keys::COLLATOR_1_SR25519
+							.parse::<AccountId>()
+							.unwrap()
+							.into(),
+						1 << 60,
+					),
+					(
+						frequency_mainnet_keys::COLLATOR_2_SR25519
+							.parse::<AccountId>()
+							.unwrap()
+							.into(),
+						1 << 60,
+					),
+					(
+						frequency_mainnet_keys::COLLATOR_3_SR25519
+							.parse::<AccountId>()
+							.unwrap()
+							.into(),
+						1 << 60,
+					),
+					(
+						frequency_mainnet_keys::COLLATOR_4_SR25519
+							.parse::<AccountId>()
+							.unwrap()
+							.into(),
+						1 << 60,
+					),
+					(
+						frequency_mainnet_keys::COLLATOR_5_SR25519
+							.parse::<AccountId>()
+							.unwrap()
+							.into(),
+						1 << 60,
+					),
+				],
 				// TODO: initial council members
 				Default::default(),
 				// TODO: initial technical committee members

--- a/node/service/src/chain_spec/frequency_rococo.rs
+++ b/node/service/src/chain_spec/frequency_rococo.rs
@@ -78,6 +78,8 @@ pub fn frequency_rococo_testnet() -> ChainSpec {
 					public_testnet_keys::COLLATOR_1_SR25519.parse::<AccountId>().unwrap().into(),
 					// 5CntRvAGYzzorsvN3UKotz5gpFd5BgMwUzALKtbWGn3JsQAu
 					public_testnet_keys::COLLATOR_2_SR25519.parse::<AccountId>().unwrap().into(),
+					// 5FnjAszaYTVfEFDooTN37DCBinQyw4dvsZDr7PbYovmAhEqn
+					public_testnet_keys::ROCOCO_FRQ_SUDO.parse::<AccountId>().unwrap().into(),
 				],
 				Default::default(),
 				Default::default(),


### PR DESCRIPTION
# Goal
The goal of this PR is to:
- Make frequency rococo sudo have tokens
- Make it harder to make this mistake with mainnet

Closes #271 

# Discussion

- For the mainnet spec, I wanted it to be closer to the final version. So this follows the pattern from rococo to have the keys above and then just variables below.
- Will we only launch mainnet with 5 collators? Likely not. We will have more. But our minimum is 5.

# Checklist
- [x] Chain spec updated
- [x] Cargo check
- [x] Cargo fmt
- [x] (N/A) Updated the js/api-augment code if a custom RPC added/changed
- [x]  (N/A) Design doc(s) updated
- [x]  (N/A) Tests added
- [x]  (N/A) Benchmarks added
- [x]  (N/A) Weights updated
