### PR TITLE
Remove Collator Endowments for Rococo

### DIFF
--- a/node/service/src/chain_spec/frequency_rococo.rs
+++ b/node/service/src/chain_spec/frequency_rococo.rs
@@ -43,7 +43,7 @@ pub fn frequency_rococo_testnet() -> ChainSpec {
 				// initial collators.
 				vec![
 					(
-						// 5E9QpPsz28HM1JM7AMnDS2aRN5unyf8EuNtz96eW4KvmxRrV
+						// 5DaTHXTHUckbmLK2mUABQDrbwYKEaCLjKpTRB4VHYEbvF9fp
 						public_testnet_keys::COLLATOR_1_SR25519
 							.parse::<AccountId>()
 							.unwrap()
@@ -57,7 +57,7 @@ pub fn frequency_rococo_testnet() -> ChainSpec {
 						.unwrap(),
 					),
 					(
-						// 5CntRvAGYzzorsvN3UKotz5gpFd5BgMwUzALKtbWGn3JsQAu
+						// 5E46myWYmywo8cF9Wk77NZM7TqLqVG7uMYjGuyyfrve9waa9
 						public_testnet_keys::COLLATOR_2_SR25519
 							.parse::<AccountId>()
 							.unwrap()
@@ -74,10 +74,6 @@ pub fn frequency_rococo_testnet() -> ChainSpec {
 				Some(public_testnet_keys::ROCOCO_FRQ_SUDO.parse::<AccountId>().unwrap().into()),
 				// endowed accounts.
 				vec![
-					// 5E9QpPsz28HM1JM7AMnDS2aRN5unyf8EuNtz96eW4KvmxRrV
-					public_testnet_keys::COLLATOR_1_SR25519.parse::<AccountId>().unwrap().into(),
-					// 5CntRvAGYzzorsvN3UKotz5gpFd5BgMwUzALKtbWGn3JsQAu
-					public_testnet_keys::COLLATOR_2_SR25519.parse::<AccountId>().unwrap().into(),
 					// 5FnjAszaYTVfEFDooTN37DCBinQyw4dvsZDr7PbYovmAhEqn
 					public_testnet_keys::ROCOCO_FRQ_SUDO.parse::<AccountId>().unwrap().into(),
 				],


### PR DESCRIPTION
# Goal
The goal of this PR is to remove the collator endowments for Rococo as collators can operate without tokens

Part of https://github.com/LibertyDSNP/frequency/issues/419

# Discussion
- Also updates the comments with the correct ss58 keys
- Testing this locally was a pain, but it does work.
    - If you want to do it
    - Run Rococo-local
    - Run two frequency collators (--collator instead of force-authoring, and second one with --bob, and different ports)
    - Update `node/service/src/chain_spec/frequency_local.rs` to not give any money to Alice or Bob
    - See that blocks are still produced.

# Checklist
- [x] Chain spec updated
- [x] Tested locally
- [x] (N/A) Updated the js/api-augment code if a custom RPC added/changed
- [x] (N/A) Design doc(s) updated
- [x] (N/A) Tests added
- [x] (N/A) Benchmarks added
- [x] (N/A) Weights updated
