### PR TITLE
Update genesis: Remove Collators

### DIFF
--- a/node/service/src/chain_spec/frequency.rs
+++ b/node/service/src/chain_spec/frequency.rs
@@ -28,7 +28,7 @@ pub mod frequency_mainnet_keys {
 	pub const COLLATOR_2_SR25519: &str =
 		"0x8eaf04151687736326c9fea17e25fc5287613693c912909cb226aa4794f26a48"; // Bob
 	pub const COLLATOR_3_SR25519: &str =
-		"0x306721211d5404bd9da88e0204360a1a9ab8b87c66c1bc2fcdd37f3c2222cc20"; // Charlie
+		"0x90b5ab205c6974c9ea841be688864633dc9ca8a357843eeacf2314649965fe22"; // Charlie
 	pub const COLLATOR_4_SR25519: &str =
 		"0x306721211d5404bd9da88e0204360a1a9ab8b87c66c1bc2fcdd37f3c2222cc20"; // Dave
 	pub const COLLATOR_5_SR25519: &str =

--- a/node/service/src/chain_spec/frequency.rs
+++ b/node/service/src/chain_spec/frequency.rs
@@ -139,41 +139,6 @@ pub fn frequency() -> ChainSpec {
 							.into(),
 						1 << 60,
 					),
-					(
-						frequency_mainnet_keys::COLLATOR_1_SR25519
-							.parse::<AccountId>()
-							.unwrap()
-							.into(),
-						1 << 60,
-					),
-					(
-						frequency_mainnet_keys::COLLATOR_2_SR25519
-							.parse::<AccountId>()
-							.unwrap()
-							.into(),
-						1 << 60,
-					),
-					(
-						frequency_mainnet_keys::COLLATOR_3_SR25519
-							.parse::<AccountId>()
-							.unwrap()
-							.into(),
-						1 << 60,
-					),
-					(
-						frequency_mainnet_keys::COLLATOR_4_SR25519
-							.parse::<AccountId>()
-							.unwrap()
-							.into(),
-						1 << 60,
-					),
-					(
-						frequency_mainnet_keys::COLLATOR_5_SR25519
-							.parse::<AccountId>()
-							.unwrap()
-							.into(),
-						1 << 60,
-					),
 				],
 				// TODO: initial council members
 				Default::default(),

--- a/node/service/src/chain_spec/frequency.rs
+++ b/node/service/src/chain_spec/frequency.rs
@@ -131,15 +131,10 @@ pub fn frequency() -> ChainSpec {
 				],
 				Some(frequency_mainnet_keys::MAINNET_FRQ_SUDO.parse::<AccountId>().unwrap().into()),
 				// TODO:: endowed accounts with initial balance.
-				vec![
-					(
-						frequency_mainnet_keys::MAINNET_FRQ_SUDO
-							.parse::<AccountId>()
-							.unwrap()
-							.into(),
-						1 << 60,
-					),
-				],
+				vec![(
+					frequency_mainnet_keys::MAINNET_FRQ_SUDO.parse::<AccountId>().unwrap().into(),
+					1 << 60,
+				)],
 				// TODO: initial council members
 				Default::default(),
 				// TODO: initial technical committee members

--- a/runtime/frequency-rococo/src/lib.rs
+++ b/runtime/frequency-rococo/src/lib.rs
@@ -665,7 +665,7 @@ parameter_types! {
 	pub const MaxCandidates: u32 = 0;
 	pub const MinCandidates: u32 = 0;
 	pub const SessionLength: BlockNumber = 6 * HOURS;
-	pub const MaxInvulnerables: u32 = 2;
+	pub const MaxInvulnerables: u32 = 5;
 	pub const ExecutiveBody: BodyId = BodyId::Executive;
 }
 

--- a/runtime/frequency/src/lib.rs
+++ b/runtime/frequency/src/lib.rs
@@ -688,7 +688,7 @@ parameter_types! {
 	pub const MaxCandidates: u32 = 0;
 	pub const MinCandidates: u32 = 0;
 	pub const SessionLength: BlockNumber = 6 * HOURS;
-	pub const MaxInvulnerables: u32 = 2;
+	pub const MaxInvulnerables: u32 = 10;
 	pub const ExecutiveBody: BodyId = BodyId::Executive;
 }
 


### PR DESCRIPTION
# Goal
Making sure that `./scripts/generate_specs.sh 999 mainnet` can run and we are setup better for mainnet specs.

Part of #263 

# Discussion
- Collators do not need an endowment
- Cannot have duplicates in the endowment

# Checklist
- [x] Chain spec updated
- [x] `./scripts/generate_specs.sh` runs for mainnet and both rococos
