### PR TITLE
update parachain-node docker image for onFinality

### DIFF
--- a/docker/collator-node-local.dockerfile
+++ b/docker/collator-node-local.dockerfile
@@ -36,13 +36,14 @@ ENV Frequency_BINARY_PATH=./target/release/frequency
 HEALTHCHECK --interval=300s --timeout=75s --start-period=30s --retries=3 \
 	CMD ["./scripts/healthcheck.sh"]
 
-VOLUME ["/data"]
-
-ENTRYPOINT ["/usr/bin/tini", "--"]
-
-CMD ["/bin/bash", "./scripts/init.sh", "start-frequency-container"]
+VOLUME ["/chain-data"]
 
 # 9933 p2p port
 # 9944 rpc port
 # 30333 ws port
 EXPOSE 9933 9944 30333
+
+ENTRYPOINT ["/usr/bin/tini", "--"]
+CMD ["/bin/bash", "./scripts/init.sh", "start-frequency-container"]
+
+

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -20,7 +20,7 @@ services:
       --node-key=e5be9a5092b81bca64be81d212e7f2f9eba183bb7a90954f7b76361f6edb5c0a
       --wasm-execution=compiled
       --execution=wasm
-      --base-path=/data
+      --base-path=/chain-data
       --port 30335
       --rpc-port 9933
       --ws-port 9944
@@ -47,7 +47,7 @@ services:
     command: >
       --chain=/chainspec.json
       --node-key=398f0c28f98885e046333d4a41c19cee4c37368a9832c6502f6cfd182e2aef89
-      --base-path=/data
+      --base-path=/chain-data
       --wasm-execution=compiled
       --execution=wasm
       --port 30336

--- a/docker/instant-seal-node.dockerfile
+++ b/docker/instant-seal-node.dockerfile
@@ -1,16 +1,21 @@
 # Docker image for running Frequency parachain node container (with collating)
 # locally in instant seal mode. Requires to run from repository root and to copy
 # the binary in the build folder.
+# This is the build stage for Polkadot. Here we create the binary in a temporary image.
 FROM --platform=linux/amd64 ubuntu:focal AS base
+
 LABEL maintainer="Frequency Team"
 LABEL description="Frequency collator node in instant seal mode"
 
 RUN apt-get update && apt-get install -y ca-certificates && update-ca-certificates
 
+# This is the 2nd stage: a very small image where we copy the Frequency binary
 FROM --platform=linux/amd64 ubuntu:focal
+
 RUN useradd -m -u 1000 -U -s /bin/sh -d /frequency frequency && \
-	mkdir /data && \
-	chown -R frequency:frequency /data
+	mkdir -p /chain-data /frequency/.local/share && \
+	chown -R frequency:frequency /chain-data && \
+	ln -s /chain-data /frequency/.local/share/frequency
 
 USER frequency
 
@@ -18,14 +23,13 @@ COPY --from=base /etc/ssl/certs/ca-certificates.crt /etc/ssl/certs/ca-certificat
 # For local testing only
 # COPY --chown=frequency target/release/frequency.amd64 ./frequency/frequency
 COPY --chown=frequency target/release/frequency ./frequency/
-RUN chmod uog+x ./frequency/frequency
 
 # 9933 P2P port
 # 9944 for RPC call
 # 30333 for Websocket
 EXPOSE 9933 9944 30333
 
-VOLUME ["/data"]
+VOLUME ["/chain-data"]
 
 ENTRYPOINT ["/frequency/frequency", \
 	# Required params for starting the chain

--- a/docker/parachain-node.dockerfile
+++ b/docker/parachain-node.dockerfile
@@ -13,9 +13,9 @@ RUN apt-get update && apt-get install -y ca-certificates && update-ca-certificat
 FROM --platform=linux/amd64 ubuntu:focal
 
 RUN useradd -m -u 1000 -U -s /bin/sh -d /frequency frequency && \
-	mkdir -p /data /frequency/.local/share && \
-	chown -R frequency:frequency /data && \
-	ln -s /data /frequency/.local/share/frequency && \
+	mkdir -p /chain-data /frequency/.local/share && \
+	chown -R frequency:frequency /chain-data && \
+	ln -s /chain-data /frequency/.local/share/frequency && \
 	rm -rf /usr/bin /usr/sbin
 
 USER frequency
@@ -25,27 +25,17 @@ COPY --from=base /etc/ssl/certs/ca-certificates.crt /etc/ssl/certs/ca-certificat
 # COPY --chown=frequency target/release/frequency.amd64 ./frequency/frequency
 COPY --chown=frequency target/release/frequency ./frequency/
 
-# 9933 P2P port
-# 9944 for RPC call
-# 30333 for Websocket
+# 9933 for RPC call
+# 9944 for Websocket
+# 30333 for P2P
 # 9615 for Telemetry (prometheus)
 EXPOSE 9933 9944 30333 9615
 
-VOLUME ["/data"]
+VOLUME ["/chain-data"]
 
-ARG FREQUENCY_CHAIN_SPEC
-ENV FREQUENCY_CHAIN_SPEC=frequency-rococo
-ENTRYPOINT ["/frequency/frequency", \
-	# Required params for starting the chain
-	"--base-path=/data", \
-	"--port=30333", \
-	"--rpc-port=9933", \
-	"--ws-port=9944", \
-	"--rpc-external", \
-	"--rpc-cors=all", \
-	"--ws-external", \
-	"--rpc-methods=safe" \
-	]
+ENTRYPOINT ["/frequency/frequency"]
 
 # Params which can be overriden from CLI
-CMD ["--chain=frequency"]
+# CMD ["", "", ...]
+
+

--- a/docker/parachain-node.overview.md
+++ b/docker/parachain-node.overview.md
@@ -6,10 +6,21 @@ Has no collating abilities.
 ## Run
 
 ```sh
-# Connect to Mainnet (default)
-docker run --rm -p 9944:9944 -p 9933:9944 -p 30333:30333 frequencychain/parachain-node
+# Connect to Mainnet
+docker run --rm -p 9944:9944 -p 9933:9944 -p 30333:30333 frequencychain/parachain-node \
+    --chain=frequency \
+    --base-path=/chain-data \
+    --rpc-external \
+    --rpc-cors=all \
+    --ws-external \
+    --rpc-methods=safe
 
 # Connect to Rococo Testnet
 docker run --rm -p 9944:9944 -p 9933:9944 -p 30333:30333 frequencychain/parachain-node \
-    --chain=frequency-rococo
+    --chain=frequency-rococo \
+    --base-path=/chain-data \
+    --rpc-external \
+    --rpc-cors=all \
+    --ws-external \
+    --rpc-methods=safe
 ```

--- a/scripts/init.sh
+++ b/scripts/init.sh
@@ -56,7 +56,7 @@ start-frequency)
 
   ./scripts/run_collator.sh \
     --chain="${chain_spec}" --alice \
-    --base-path=$parachain_dir/data \
+    --base-path=$parachain_dir/chain-data \
     --wasm-execution=compiled \
     --execution=wasm \
     --force-authoring \
@@ -113,7 +113,7 @@ start-frequency-container)
 
   ./scripts/run_collator.sh \
     --chain="${chain_spec}" --alice \
-    --base-path=$parachain_dir/data \
+    --base-path=$parachain_dir/chain-data \
     --wasm-execution=compiled \
     --execution=wasm \
     --force-authoring \


### PR DESCRIPTION
# Goal
The goal of this PR is to update `parachain-docker` image to make flexible, so it can be used on onFinality.io and directly from CLI

Closes #372
