### PR TITLE
Fix docs build and warnings

### DIFF
--- a/.github/workflows/mrc_gh_pages.yml
+++ b/.github/workflows/mrc_gh_pages.yml
@@ -11,7 +11,7 @@ jobs:
       matrix:
         os: [ubuntu-latest]
         target: [docs]
-        rust_toolchain: [nightly-2022-07-23]
+        rust_toolchain: [nightly-2022-09-21]
     runs-on: ${{ matrix.os }}
     env:
       RUST_TOOLCHAIN: ${{ matrix.rust_toolchain }}
@@ -34,8 +34,10 @@ jobs:
           default: true
       - name: Setup Cache 📦
         uses: Swatinem/rust-cache@v1
+      - name: Install toolchain for frequency
+        run: make install-toolchain
       - name: Build Frequency related documentation 📝
-        run: ./scripts/frequency_docs.sh
+        run: make docs
       - name: Deploy Frequency docs to gh-pages 🚀
         uses: JamesIves/github-pages-deploy-action@v4.4.0
         with:

--- a/.github/workflows/mrc_gh_pages.yml
+++ b/.github/workflows/mrc_gh_pages.yml
@@ -11,7 +11,7 @@ jobs:
       matrix:
         os: [ubuntu-latest]
         target: [docs]
-        rust_toolchain: [nightly-2022-09-21]
+        rust_toolchain: [nightly-2022-07-23]  # Needs nightly for docs
     runs-on: ${{ matrix.os }}
     env:
       RUST_TOOLCHAIN: ${{ matrix.rust_toolchain }}

--- a/.github/workflows/tests-pr.yml
+++ b/.github/workflows/tests-pr.yml
@@ -11,7 +11,7 @@ jobs:
       matrix:
         os: [ubuntu-latest]
         target: [tests, lint]
-        rust_toolchain: [nightly-2022-07-23]
+        rust_toolchain: [nightly-2022-07-23] # Needs nightly for clippy and docs check
     runs-on: ${{ matrix.os }}
     env:
       RUST_TOOLCHAIN: ${{ matrix.rust_toolchain }}

--- a/Makefile
+++ b/Makefile
@@ -54,8 +54,8 @@ format:
 .PHONY: lint
 lint:
 	cargo fmt --check
-	SKIP_WASM_BUILD=1 env -u RUSTFLAGS cargo +nightly clippy --features all-frequency-features -- -D warnings
-	RUSTDOCFLAGS="--enable-index-page --check -Zunstable-options" cargo +nightly doc --no-deps
+	SKIP_WASM_BUILD=1 env -u RUSTFLAGS cargo clippy --features all-frequency-features -- -D warnings
+	RUSTDOCFLAGS="--enable-index-page --check -Zunstable-options" cargo doc --no-deps
 
 .PHONY: format-lint
 format-lint: format lint

--- a/Makefile
+++ b/Makefile
@@ -53,7 +53,9 @@ format:
 
 .PHONY: lint
 lint:
-	cargo fmt --check && SKIP_WASM_BUILD=1 env -u RUSTFLAGS cargo clippy --features all-frequency-features -- -D warnings
+	cargo fmt --check
+	SKIP_WASM_BUILD=1 env -u RUSTFLAGS cargo +nightly clippy --features all-frequency-features -- -D warnings
+	RUSTDOCFLAGS="--enable-index-page --check -Zunstable-options" cargo +nightly doc --no-deps
 
 .PHONY: format-lint
 format-lint: format lint
@@ -78,7 +80,7 @@ benchmarks-schemas:
 
 .PHONY: docs
 docs:
-	./scripts/frequency_docs.sh
+	RUSTDOCFLAGS="--enable-index-page -Zunstable-options" cargo doc --no-deps
 
 # Cleans unused docker resources and artifacts
 .PHONY: docs

--- a/ci/build.sh
+++ b/ci/build.sh
@@ -17,7 +17,7 @@ cargo --version
 
 case $TARGET in
   build-node)
-    cargo build --release --features all-frequency-features "$@" 
+    cargo build --release --features all-frequency-features "$@"
     ;;
 
   build-runtime)
@@ -32,6 +32,7 @@ case $TARGET in
 
   lint)
     cargo fmt -- --check
-    SKIP_WASM_BUILD=1 env -u RUSTFLAGS cargo clippy --features all-frequency-features -- -D warnings
+    SKIP_WASM_BUILD=1 env -u RUSTFLAGS cargo +nightly clippy --features all-frequency-features -- -D warnings
+    RUSTDOCFLAGS="--enable-index-page --check -Zunstable-options" cargo +nightly doc --no-deps
     ;;
 esac

--- a/ci/build.sh
+++ b/ci/build.sh
@@ -32,7 +32,7 @@ case $TARGET in
 
   lint)
     cargo fmt -- --check
-    SKIP_WASM_BUILD=1 env -u RUSTFLAGS cargo +nightly clippy --features all-frequency-features -- -D warnings
-    RUSTDOCFLAGS="--enable-index-page --check -Zunstable-options" cargo +nightly doc --no-deps
+    SKIP_WASM_BUILD=1 env -u RUSTFLAGS cargo clippy --features all-frequency-features -- -D warnings
+    RUSTDOCFLAGS="--enable-index-page --check -Zunstable-options" cargo doc --no-deps
     ;;
 esac

--- a/common/primitives/src/parquet/column_compression_codec.rs
+++ b/common/primitives/src/parquet/column_compression_codec.rs
@@ -3,7 +3,7 @@ use scale_info::TypeInfo;
 use serde::{Deserialize, Serialize};
 use sp_std::prelude::*;
 
-/// Compression codecs: https://github.com/apache/parquet-format/blob/master/LogicalTypes.md
+/// Compression codecs: <https://github.com/apache/parquet-format/blob/master/LogicalTypes.md>
 #[derive(
 	Clone, Encode, Decode, PartialEq, Debug, TypeInfo, Eq, MaxEncodedLen, Serialize, Deserialize,
 )]
@@ -15,11 +15,11 @@ pub enum ColumnCompressionCodec {
 	Snappy,
 	/// Gzip compression
 	Gzip,
-	/// Lempel-Zip-Obenhumer compression: https://en.wikipedia.org/wiki/Lempel%E2%80%93Ziv%E2%80%93Oberhumer
+	/// Lempel-Zip-Obenhumer compression: <https://en.wikipedia.org/wiki/Lempel%E2%80%93Ziv%E2%80%93Oberhumer>
 	Lzo,
 	/// Brotli compression
 	Brotli,
-	/// Zstandard compression: https://en.wikipedia.org/wiki/Zstd
+	/// Zstandard compression: <https://en.wikipedia.org/wiki/Zstd>
 	ZSTD,
 	/// Lz4 compression without block headers
 	Lz4Raw,

--- a/common/primitives/src/parquet/numeric.rs
+++ b/common/primitives/src/parquet/numeric.rs
@@ -1,7 +1,7 @@
 use serde::{Deserialize, Serialize};
 use sp_std::prelude::*;
 
-/// Parquet numeric types: https://github.com/apache/parquet-format/blob/master/LogicalTypes.md
+/// Parquet numeric types: <https://github.com/apache/parquet-format/blob/master/LogicalTypes.md>
 #[derive(Clone, PartialEq, Debug, Eq, Serialize, Deserialize)]
 #[serde(rename_all = "UPPERCASE")]
 pub enum ParquetNumericType {

--- a/common/primitives/src/parquet/string.rs
+++ b/common/primitives/src/parquet/string.rs
@@ -1,7 +1,7 @@
 use serde::{Deserialize, Serialize};
 use sp_std::prelude::*;
 
-/// Parquet String types: https://github.com/apache/parquet-format/blob/master/LogicalTypes.md
+/// Parquet String types: <https://github.com/apache/parquet-format/blob/master/LogicalTypes.md>
 /// NOTE: We are not supporting ENUMs yet.
 
 #[derive(Clone, PartialEq, Debug, Eq, Serialize, Deserialize)]

--- a/common/primitives/src/parquet/temporal.rs
+++ b/common/primitives/src/parquet/temporal.rs
@@ -1,13 +1,13 @@
 use serde::{Deserialize, Serialize};
 use sp_std::prelude::*;
 
-/// Parquet temporal types: https://github.com/apache/parquet-format/blob/master/LogicalTypes.md
+/// Parquet temporal types: <https://github.com/apache/parquet-format/blob/master/LogicalTypes.md>
 #[derive(Clone, PartialEq, Debug, Eq, Serialize, Deserialize)]
 #[serde(rename_all = "UPPERCASE")]
 pub enum ParquetTemporalType {
 	/// Parquet dates
 	Date,
-	/// Parquet intervals: https://github.com/apache/parquet-format/blob/master/LogicalTypes.md#interval
+	/// Parquet intervals: <https://github.com/apache/parquet-format/blob/master/LogicalTypes.md#interval>
 	Interval,
 	/// Time
 	Time(ParquetTime),
@@ -15,14 +15,14 @@ pub enum ParquetTemporalType {
 	Timestamp(ParquetTimestamp),
 }
 
-/// Parquet time: https://github.com/apache/parquet-format/blob/master/LogicalTypes.md
+/// Parquet time: <https://github.com/apache/parquet-format/blob/master/LogicalTypes.md>
 #[derive(Clone, PartialEq, Debug, Eq, Serialize, Deserialize)]
 pub struct ParquetTime {
 	is_adjusted_to_utc: bool,
 	unit: ParquetTimeUnit,
 }
 
-/// Parquet timestamps: https://github.com/apache/parquet-format/blob/master/LogicalTypes.md
+/// Parquet timestamps: <https://github.com/apache/parquet-format/blob/master/LogicalTypes.md>
 #[derive(Clone, PartialEq, Debug, Eq, Serialize, Deserialize)]
 pub struct ParquetTimestamp {
 	is_adjusted_to_utc: bool,
@@ -33,10 +33,10 @@ pub struct ParquetTimestamp {
 #[derive(Clone, PartialEq, Debug, Eq, Serialize, Deserialize)]
 #[serde(rename_all = "UPPERCASE")]
 enum ParquetTimeUnit {
-	/// Millisecond precision for time: https://github.com/apache/parquet-format/blob/master/LogicalTypes.md#time
+	/// Millisecond precision for time: <https://github.com/apache/parquet-format/blob/master/LogicalTypes.md#time>
 	Millis,
-	/// Microsecond precision for time: https://github.com/apache/parquet-format/blob/master/LogicalTypes.md#time
+	/// Microsecond precision for time: <https://github.com/apache/parquet-format/blob/master/LogicalTypes.md#time>
 	Micros,
-	/// Manosecond precision for time: https://github.com/apache/parquet-format/blob/master/LogicalTypes.md#time
+	/// Manosecond precision for time: <https://github.com/apache/parquet-format/blob/master/LogicalTypes.md#time>
 	Nanos,
 }

--- a/common/primitives/src/schema.rs
+++ b/common/primitives/src/schema.rs
@@ -15,9 +15,9 @@ pub type SchemaId = u16;
 #[cfg_attr(feature = "std", derive(Serialize, Deserialize))]
 #[derive(Clone, Encode, Decode, PartialEq, Debug, TypeInfo, Eq, MaxEncodedLen)]
 pub enum ModelType {
-	/// Message payload modeled with Apache Avro: https://avro.apache.org/docs/current/spec.html
+	/// Message payload modeled with Apache Avro: <https://avro.apache.org/docs/current/spec.html>
 	AvroBinary,
-	/// Message payload modeled with Apache Parquet: https://parquet.apache.org/
+	/// Message payload modeled with Apache Parquet: <https://parquet.apache.org/>
 	Parquet,
 }
 

--- a/node/service/src/chain_spec.rs
+++ b/node/service/src/chain_spec.rs
@@ -43,7 +43,7 @@ where
 	AccountPublic::from(get_public_from_seed::<TPublic>(seed)).into_account()
 }
 
-/// The extensions for the [`ChainSpec`].
+/// The extensions for the [`sc_service::ChainSpec`].
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize, ChainSpecGroup, ChainSpecExtension)]
 #[serde(deny_unknown_fields)]
 pub struct Extensions {

--- a/pallets/msa/src/lib.rs
+++ b/pallets/msa/src/lib.rs
@@ -837,7 +837,7 @@ impl<T: Config> Pallet<T> {
 	/// # Returns
 	/// * [`DispatchResult`]
 	/// # Errors
-	/// * [`ensure_valid_delegation`] Errors
+	/// * [`Self::ensure_valid_delegation`] Errors
 	/// * [`Error::SchemaNotGranted`]
 	pub fn ensure_valid_schema_grant(
 		provider: Provider,

--- a/scripts/frequency_docs.sh
+++ b/scripts/frequency_docs.sh
@@ -1,7 +1,0 @@
-#! /bin/sh
-
-set -e
-set -x
-
-./scripts/init.sh install-toolchain
-RUSTDOCFLAGS="--enable-index-page -Zunstable-options" cargo doc --no-deps


### PR DESCRIPTION
# Goal
The goal of this PR is to fix the broken docs build and then make it much harder to happen again by including doc checks in the lint runs

Part of #453 

# Discussion
- Fixed doc lint issue
- Fixed doc link warnings
- Removed layer of redirection of the frequency docs script
- Setup ci to also check docs on PRs
- Updated the nightly that generates the docs as we use some nightly features

# Checklist
- [x] `make lint`
- [x] `TARGET=lint ./ci/build.sh`
