### PR TITLE
Test example storage migration

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5798,6 +5798,7 @@ dependencies = [
  "frame-benchmarking",
  "frame-support",
  "frame-system",
+ "log",
  "orml-utilities",
  "parity-scale-codec",
  "scale-info",

--- a/pallets/msa/Cargo.toml
+++ b/pallets/msa/Cargo.toml
@@ -19,6 +19,7 @@ codec = {package = "parity-scale-codec", version = "3.1.5", default-features = f
 frame-benchmarking = {default-features = false, git = "https://github.com/paritytech/substrate.git", optional = true, branch = "polkadot-v0.9.27" }
 frame-support = {default-features = false, git = "https://github.com/paritytech/substrate.git", branch = "polkadot-v0.9.27" }
 frame-system = {default-features = false, git = "https://github.com/paritytech/substrate.git", branch = "polkadot-v0.9.27" }
+log = { version = "0.4.17", default-features = false }
 scale-info = {version = "2.1.2", default-features = false, features = ["derive"]}
 sp-core = {default-features = false, git = "https://github.com/paritytech/substrate.git", branch = "polkadot-v0.9.27" }
 sp-runtime = {default-features = false, git = "https://github.com/paritytech/substrate.git", branch = "polkadot-v0.9.27" }

--- a/pallets/msa/src/lib.rs
+++ b/pallets/msa/src/lib.rs
@@ -84,7 +84,9 @@ mod mock;
 #[cfg(test)]
 mod tests;
 
+/// Import migrations module which executes migrations when the runtime is upgraded.
 pub mod migrations;
+
 pub mod weights;
 
 pub use weights::*;

--- a/pallets/msa/src/lib.rs
+++ b/pallets/msa/src/lib.rs
@@ -84,6 +84,7 @@ mod mock;
 #[cfg(test)]
 mod tests;
 
+pub mod migrations;
 pub mod weights;
 
 pub use weights::*;
@@ -97,6 +98,10 @@ use sp_std::prelude::*;
 #[frame_support::pallet]
 pub mod pallet {
 	use super::*;
+	use frame_support::traits::StorageVersion;
+
+	// Upgrade storage version from 0 to 1
+	const STORAGE_VERSION: StorageVersion = StorageVersion::new(1);
 
 	#[pallet::config]
 	pub trait Config: frame_system::Config {
@@ -123,6 +128,7 @@ pub mod pallet {
 
 	#[pallet::pallet]
 	#[pallet::generate_store(pub(super) trait Store)]
+	#[pallet::storage_version(STORAGE_VERSION)]
 	pub struct Pallet<T>(_);
 
 	/// Storage type for MSA identifier
@@ -163,8 +169,15 @@ pub mod pallet {
 	/// - Key: AccountId
 	/// - Value: [`MessageSourceId`]
 	#[pallet::storage]
-	#[pallet::getter(fn get_msa_by_account_id)]
 	pub type MessageSourceIdOf<T: Config> =
+		StorageMap<_, Twox64Concat, T::AccountId, MessageSourceId, OptionQuery>;
+
+	/// Migrated Storage type for key to MSA information
+	/// - Key: AccountId
+	/// - Value: [`MessageSourceId`]
+	#[pallet::storage]
+	#[pallet::getter(fn get_msa_by_account_id)]
+	pub type MessageSourceMigratedIdOf<T: Config> =
 		StorageMap<_, Twox64Concat, T::AccountId, MessageSourceId, OptionQuery>;
 
 	/// Storage for MSA keys

--- a/pallets/msa/src/migrations/mod.rs
+++ b/pallets/msa/src/migrations/mod.rs
@@ -1,0 +1,2 @@
+/// Version 1.
+pub mod v1;

--- a/pallets/msa/src/migrations/v1.rs
+++ b/pallets/msa/src/migrations/v1.rs
@@ -1,13 +1,9 @@
 /// Trivial migration which moves MessageSourceIdOf -> MessageSourceMigratedIdOf
 ///
 /// Note: The depositor is not optional since he can never change.
-use crate::{Config, Pallet};
+use crate::*;
 
-use frame_support::{
-	migration::StorageKeyIterator,
-	traits::{OnRuntimeUpgrade, StorageVersion},
-	weights::Weight,
-};
+use frame_support::{migration::StorageKeyIterator, traits::OnRuntimeUpgrade, weights::Weight};
 use log;
 
 pub struct MigrateToV1<T>(sp_std::marker::PhantomData<T>);

--- a/pallets/msa/src/migrations/v1.rs
+++ b/pallets/msa/src/migrations/v1.rs
@@ -5,66 +5,60 @@ use crate::*;
 
 use frame_support::{migration::StorageKeyIterator, traits::OnRuntimeUpgrade, weights::Weight};
 use log;
-
 /// Struct on which to implement OnRuntimeUpgrade trait
 pub struct MigrateToV1<T>(sp_std::marker::PhantomData<T>);
+impl<T: Config> OnRuntimeUpgrade for MigrateToV1<T> {
+	/// Perform a module upgrade.
+	///
+	/// # Warning
+	///
+	/// This function will be called before we initialized any runtime state, aka `on_initialize`
+	/// wasn't called yet. So, information like the block number and any other
+	/// block local data are not accessible.
+	///
+	/// Return the non-negotiable weight consumed for runtime upgrade.
+	fn on_runtime_upgrade() -> Weight {
+		let current = Pallet::<T>::current_storage_version();
+		let onchain = Pallet::<T>::on_chain_storage_version();
+		log::info!(
+			"Running MSA migration with current storage version {:?} / onchain {:?}",
+			current,
+			onchain
+		);
 
-/// Version 1
-pub mod v1 {
-	use super::*;
-	impl<T: Config> OnRuntimeUpgrade for MigrateToV1<T> {
-		/// Perform a module upgrade.
-		///
-		/// # Warning
-		///
-		/// This function will be called before we initialized any runtime state, aka `on_initialize`
-		/// wasn't called yet. So, information like the block number and any other
-		/// block local data are not accessible.
-		///
-		/// Return the non-negotiable weight consumed for runtime upgrade.
-		fn on_runtime_upgrade() -> Weight {
-			let current = Pallet::<T>::current_storage_version();
-			let onchain = Pallet::<T>::on_chain_storage_version();
-			log::info!(
-				"Running MSA migration with current storage version {:?} / onchain {:?}",
-				current,
-				onchain
-			);
+		// Execute the migration when upgrading MSA storage version from version 0 to version 1
+		if current == 1 && onchain == 0 {
+			// TODO: Iterate through AccountId in MessageSourceIdOf and
+			// copy the key/value pair to MessageSourceMigratedIdOf
 
-			// Execute the migration when upgrading MSA storage version from version 0 to version 1
-			if current == 1 && onchain == 0 {
-				// TODO: Iterate through AccountId in MessageSourceIdOf and
-				// copy the key/value pair to MessageSourceMigratedIdOf
+			// put the current storage version into storage
+			current.put::<Pallet<T>>();
+			log::info!("Migrated MessageSourceIdOf storage to MessageSourceMigratedIdOf");
 
-				// put the current storage version into storage
-				current.put::<Pallet<T>>();
-				log::info!("Migrated MessageSourceIdOf storage to MessageSourceMigratedIdOf");
+			// TODO: Update the returned weight to reflect the cost of iterating through MessageSourceIdOf
+			// writing to MessageSourceMigratedIdOf, read the on chain storage version, and update the on chain storage version
+			T::DbWeight::get().reads(1)
+		} else {
+			log::info!("MigrateToV1 has already been completed and can be removed.");
 
-				// TODO: Update the returned weight to reflect the cost of iterating through MessageSourceIdOf
-				// writing to MessageSourceMigratedIdOf, read the on chain storage version, and update the on chain storage version
-				T::DbWeight::get().reads(1)
-			} else {
-				log::info!("MigrateToV1 has already been completed and can be removed.");
-
-				// The weight cost to read the on chain storage version
-				T::DbWeight::get().reads(1)
-			}
+			// The weight cost to read the on chain storage version
+			T::DbWeight::get().reads(1)
 		}
+	}
 
-		/// Execute some pre-checks prior to a runtime upgrade.
-		///
-		/// This hook is never meant to be executed on-chain but is meant to be used by testing tools.
-		#[cfg(feature = "try-runtime")]
-		fn pre_upgrade() -> Result<(), &'static str> {
-			Ok(())
-		}
+	/// Execute some pre-checks prior to a runtime upgrade.
+	///
+	/// This hook is never meant to be executed on-chain but is meant to be used by testing tools.
+	#[cfg(feature = "try-runtime")]
+	fn pre_upgrade() -> Result<(), &'static str> {
+		Ok(())
+	}
 
-		/// Execute some post-checks after a runtime upgrade.
-		///
-		/// This hook is never meant to be executed on-chain but is meant to be used by testing tools.
-		#[cfg(feature = "try-runtime")]
-		fn post_upgrade() -> Result<(), &'static str> {
-			Ok(())
-		}
+	/// Execute some post-checks after a runtime upgrade.
+	///
+	/// This hook is never meant to be executed on-chain but is meant to be used by testing tools.
+	#[cfg(feature = "try-runtime")]
+	fn post_upgrade() -> Result<(), &'static str> {
+		Ok(())
 	}
 }

--- a/pallets/msa/src/migrations/v1.rs
+++ b/pallets/msa/src/migrations/v1.rs
@@ -39,9 +39,14 @@ pub mod v1 {
 				// put the current storage version into storage
 				current.put::<Pallet<T>>();
 				log::info!("Migrated MessageSourceIdOf storage to MessageSourceMigratedIdOf");
+
+				// TODO: Update the returned weight to reflect the cost of iterating through MessageSourceIdOf
+				// writing to MessageSourceMigratedIdOf, read the on chain storage version, and update the on chain storage version
 				T::DbWeight::get().reads(1)
 			} else {
 				log::info!("MigrateToV1 has already been completed and can be removed.");
+
+				// The weight cost to read the on chain storage version
 				T::DbWeight::get().reads(1)
 			}
 		}

--- a/pallets/msa/src/migrations/v1.rs
+++ b/pallets/msa/src/migrations/v1.rs
@@ -3,7 +3,7 @@
 /// Note: The depositor is not optional since he can never change.
 use crate::*;
 
-use frame_support::{migration::StorageKeyIterator, traits::OnRuntimeUpgrade, weights::Weight};
+use frame_support::{traits::OnRuntimeUpgrade, weights::Weight};
 use log;
 /// Struct on which to implement OnRuntimeUpgrade trait
 pub struct MigrateToV1<T>(sp_std::marker::PhantomData<T>);
@@ -28,11 +28,11 @@ impl<T: Config> OnRuntimeUpgrade for MigrateToV1<T> {
 
 		// Execute the migration when upgrading MSA storage version from version 0 to version 1
 		if current == 1 && onchain == 0 {
-			// TODO: Iterate through AccountId in MessageSourceIdOf and
+			// Iterate through AccountId in MessageSourceIdOf and
 			// copy the key/value pair to MessageSourceMigratedIdOf
 			let mut count = 0;
-			for (AccountId, MessageSourceId) in MessageSourceIdOf::<T>::iter() {
-				MessageSourceMigratedIdOf::<T>::insert(AccountId, MessageSourceId);
+			for (account_id, msa_id) in MessageSourceIdOf::<T>::iter() {
+				MessageSourceMigratedIdOf::<T>::insert(account_id, msa_id);
 				count += 1;
 			}
 

--- a/pallets/msa/src/migrations/v1.rs
+++ b/pallets/msa/src/migrations/v1.rs
@@ -30,14 +30,19 @@ impl<T: Config> OnRuntimeUpgrade for MigrateToV1<T> {
 		if current == 1 && onchain == 0 {
 			// TODO: Iterate through AccountId in MessageSourceIdOf and
 			// copy the key/value pair to MessageSourceMigratedIdOf
+			let mut count = 0;
+			for (AccountId, MessageSourceId) in MessageSourceIdOf::<T>::iter() {
+				MessageSourceMigratedIdOf::<T>::insert(AccountId, MessageSourceId);
+				count += 1;
+			}
 
 			// put the current storage version into storage
 			current.put::<Pallet<T>>();
 			log::info!("Migrated MessageSourceIdOf storage to MessageSourceMigratedIdOf");
 
-			// TODO: Update the returned weight to reflect the cost of iterating through MessageSourceIdOf
+			// Return the weight to reflect the cost of iterating through MessageSourceIdOf
 			// writing to MessageSourceMigratedIdOf, read the on chain storage version, and update the on chain storage version
-			T::DbWeight::get().reads(1)
+			T::DbWeight::get().reads_writes(count + 1, count + 1)
 		} else {
 			log::info!("MigrateToV1 has already been completed and can be removed.");
 

--- a/pallets/msa/src/migrations/v1.rs
+++ b/pallets/msa/src/migrations/v1.rs
@@ -6,7 +6,10 @@ use crate::*;
 use frame_support::{migration::StorageKeyIterator, traits::OnRuntimeUpgrade, weights::Weight};
 use log;
 
+/// Struct on which to implement OnRuntimeUpgrade trait
 pub struct MigrateToV1<T>(sp_std::marker::PhantomData<T>);
+
+/// Version 1
 pub mod v1 {
 	use super::*;
 	impl<T: Config> OnRuntimeUpgrade for MigrateToV1<T> {
@@ -30,15 +33,17 @@ pub mod v1 {
 
 			// Execute the migration when upgrading MSA storage version from version 0 to version 1
 			if current == 1 && onchain == 0 {
+				// TODO: Iterate through AccountId in MessageSourceIdOf and
+				// copy the key/value pair to MessageSourceMigratedIdOf
+
 				// put the current storage version into storage
 				current.put::<Pallet<T>>();
 				log::info!("Migrated MessageSourceIdOf storage to MessageSourceMigratedIdOf");
-				T::DbWeight::get().reads(1 as Weight)
-			} else if onchain > 0 {
+				T::DbWeight::get().reads(1)
+			} else {
 				log::info!("MigrateToV1 has already been completed and can be removed.");
-				T::DbWeight::get().reads(1 as Weight)
+				T::DbWeight::get().reads(1)
 			}
-			0
 		}
 
 		/// Execute some pre-checks prior to a runtime upgrade.

--- a/pallets/msa/src/migrations/v1.rs
+++ b/pallets/msa/src/migrations/v1.rs
@@ -1,0 +1,64 @@
+/// Trivial migration which moves MessageSourceIdOf -> MessageSourceMigratedIdOf
+///
+/// Note: The depositor is not optional since he can never change.
+use crate::{Config, Pallet};
+
+use frame_support::{
+	migration::StorageKeyIterator,
+	traits::{OnRuntimeUpgrade, StorageVersion},
+	weights::Weight,
+};
+use log;
+
+pub struct MigrateToV1<T>(sp_std::marker::PhantomData<T>);
+pub mod v1 {
+	use super::*;
+	impl<T: Config> OnRuntimeUpgrade for MigrateToV1<T> {
+		/// Perform a module upgrade.
+		///
+		/// # Warning
+		///
+		/// This function will be called before we initialized any runtime state, aka `on_initialize`
+		/// wasn't called yet. So, information like the block number and any other
+		/// block local data are not accessible.
+		///
+		/// Return the non-negotiable weight consumed for runtime upgrade.
+		fn on_runtime_upgrade() -> Weight {
+			let current = Pallet::<T>::current_storage_version();
+			let onchain = Pallet::<T>::on_chain_storage_version();
+			log::info!(
+				"Running MSA migration with current storage version {:?} / onchain {:?}",
+				current,
+				onchain
+			);
+
+			// Execute the migration when upgrading MSA storage version from version 0 to version 1
+			if current == 1 && onchain == 0 {
+				// put the current storage version into storage
+				current.put::<Pallet<T>>();
+				log::info!("Migrated MessageSourceIdOf storage to MessageSourceMigratedIdOf");
+				T::DbWeight::get().reads(1 as Weight)
+			} else if onchain > 0 {
+				log::info!("MigrateToV1 has already been completed and can be removed.");
+				T::DbWeight::get().reads(1 as Weight)
+			}
+			0
+		}
+
+		/// Execute some pre-checks prior to a runtime upgrade.
+		///
+		/// This hook is never meant to be executed on-chain but is meant to be used by testing tools.
+		#[cfg(feature = "try-runtime")]
+		fn pre_upgrade() -> Result<(), &'static str> {
+			Ok(())
+		}
+
+		/// Execute some post-checks after a runtime upgrade.
+		///
+		/// This hook is never meant to be executed on-chain but is meant to be used by testing tools.
+		#[cfg(feature = "try-runtime")]
+		fn post_upgrade() -> Result<(), &'static str> {
+			Ok(())
+		}
+	}
+}

--- a/runtime/frequency-rococo/src/lib.rs
+++ b/runtime/frequency-rococo/src/lib.rs
@@ -195,7 +195,7 @@ pub const VERSION: RuntimeVersion = RuntimeVersion {
 	spec_name: create_runtime_str!("frequency-rococo"),
 	impl_name: create_runtime_str!("frequency-rococo"),
 	authoring_version: 1,
-	spec_version: 1,
+	spec_version: 2,
 	impl_version: 0,
 	apis: RUNTIME_API_VERSIONS,
 	transaction_version: 1,

--- a/runtime/frequency-rococo/src/lib.rs
+++ b/runtime/frequency-rococo/src/lib.rs
@@ -133,7 +133,12 @@ pub type Executive = frame_executive::Executive<
 	frame_system::ChainContext<Runtime>,
 	Runtime,
 	AllPalletsWithSystem,
+	Migrations,
 >;
+
+// All migrations executed on runtime upgrade as a nested tuple of types implementing
+// `OnRuntimeUpgrade`.
+type Migrations = (pallet_msa::migrations::v1::MigrateToV1<Runtime>,);
 
 /// Handles converting a weight scalar to a fee value, based on the scale and granularity of the
 /// node's balance type.

--- a/runtime/frequency/src/lib.rs
+++ b/runtime/frequency/src/lib.rs
@@ -208,7 +208,7 @@ pub const VERSION: RuntimeVersion = RuntimeVersion {
 	spec_name: create_runtime_str!("frequency"),
 	impl_name: create_runtime_str!("frequency"),
 	authoring_version: 1,
-	spec_version: 1,
+	spec_version: 2,
 	impl_version: 0,
 	apis: RUNTIME_API_VERSIONS,
 	transaction_version: 1,


### PR DESCRIPTION
# Goal
The goal of this PR is to provide visibility to an example storage migration

References #268

# Discussion
The PR aims to elucidate an example of a storage migration which creates a duplicate of `MessageSourceIdOf`. 

# TODO list
- [x] Iterate through `MessageSourceIdOf` and copy each key/value to `MessageSourceMigratedIdOf`
- [ ] Determine and write tests for `pre_upgrade` / `post_upgrade` testing hooks
- [x] Test the upgrade on Rococo Local
- [ ] Test the upgrade on Rococo

