### PR TITLE
Config Small spec and config updates

### DIFF
--- a/node/service/src/chain_spec/frequency.rs
+++ b/node/service/src/chain_spec/frequency.rs
@@ -159,7 +159,10 @@ pub fn frequency() -> ChainSpec {
 			)
 		},
 		// Bootnodes
-		Vec::new(),
+		vec![
+			"/dns/0.boot.frequency.xyz/tcp/30333/p2p/12D3KooWBd4aEArNvXECtt2JHQACBdFmeafpyfre3q81iM1xCcpP".parse().unwrap(),
+			"/dns/1.boot.frequency.xyz/tcp/30333/p2p/12D3KooWCW8d7Yz2d3Jcb49rWcNppRNEs1K2NZitCpPtrHSQb6dw".parse().unwrap(),
+		],
 		// Telemetry
 		None,
 		// Protocol ID

--- a/node/service/src/chain_spec/frequency.rs
+++ b/node/service/src/chain_spec/frequency.rs
@@ -8,6 +8,7 @@ use frequency_runtime::{
 
 use hex::FromHex;
 use sc_service::ChainType;
+use sc_telemetry::TelemetryEndpoints;
 use sp_core::ByteArray;
 use sp_runtime::traits::AccountIdConversion;
 
@@ -164,7 +165,7 @@ pub fn frequency() -> ChainSpec {
 			"/dns/1.boot.frequency.xyz/tcp/30333/p2p/12D3KooWCW8d7Yz2d3Jcb49rWcNppRNEs1K2NZitCpPtrHSQb6dw".parse().unwrap(),
 		],
 		// Telemetry
-		None,
+		TelemetryEndpoints::new(vec![("wss://telemetry.polkadot.io/submit/".into(), 0)]).ok(),
 		// Protocol ID
 		Some("frequency"),
 		// Fork ID

--- a/node/service/src/chain_spec/frequency_rococo.rs
+++ b/node/service/src/chain_spec/frequency_rococo.rs
@@ -7,6 +7,7 @@ use frequency_rococo_runtime::{
 };
 use hex::FromHex;
 use sc_service::ChainType;
+use sc_telemetry::TelemetryEndpoints;
 use sp_core::ByteArray;
 use sp_runtime::traits::AccountIdConversion;
 /// Specialized `ChainSpec` for the normal parachain runtime.
@@ -158,7 +159,7 @@ pub fn frequency_rococo_testnet() -> ChainSpec {
 		// Bootnodes
 		Vec::new(),
 		// Telemetry
-		None,
+		TelemetryEndpoints::new(vec![("wss://telemetry.frequency.xyz/submit/".into(), 0)]).ok(),
 		// Protocol ID
 		Some("frequency-rococo"),
 		// Fork ID

--- a/runtime/common/src/constants.rs
+++ b/runtime/common/src/constants.rs
@@ -71,6 +71,13 @@ pub const MICROUNIT: Balance = 1_000_000;
 /// The existential deposit. Set to 1/10 of the Connected Relay Chain.
 pub const EXISTENTIAL_DEPOSIT: Balance = MILLIUNIT;
 
+/// Generates an balance based on amount of items and bytes
+/// Items are each worth 20 Tokens
+/// Bytes each cost 1/1_000 of a Token
+pub const fn deposit(items: u32, bytes: u32) -> Balance {
+	items as Balance * 20 * UNIT + (bytes as Balance) * UNIT / 1_000
+}
+
 /// We assume that ~5% of the block weight is consumed by `on_initialize` handlers. This is
 /// used to limit the maximal weight of a single extrinsic.
 pub const AVERAGE_ON_INITIALIZE_RATIO: Perbill = Perbill::from_percent(5);
@@ -119,11 +126,13 @@ pub type BalancesMaxLocks = FIFTY;
 pub type BalancesMaxReserves = FIFTY;
 pub type SchedulerMaxScheduledPerBlock = FIFTY;
 
+/// Preimage maximum size set to 4 MB
+/// Expected to be removed in Polkadot v0.9.31
 pub type PreimageMaxSize = ConstU32<{ 4096 * 1024 }>;
 
 parameter_types! {
-	pub const PreimageBaseDeposit: Balance = 1 * MILLIUNIT;
-	pub const PreimageByteDeposit: Balance = 1 * MICROUNIT;
+	pub const PreimageBaseDeposit: Balance = deposit(10, 64);
+	pub const PreimageByteDeposit: Balance = deposit(0, 1);
 }
 pub type CouncilMaxProposals = ConstU32<25>;
 

--- a/runtime/frequency-rococo/src/lib.rs
+++ b/runtime/frequency-rococo/src/lib.rs
@@ -343,6 +343,7 @@ parameter_types! {
 	pub MaximumSchedulerWeight: Weight = Perbill::from_percent(10) * RuntimeBlockWeights::get().max_block;
 	// The maximum number of scheduled calls in the queue for a single block. Not strictly enforced, but used for weight estimation.
 	// Retry a scheduled item every 25 blocks (5 minute) until the preimage exists.
+	// Will be removed in v0.9.30
 	pub const NoPreimagePostponement: Option<u32> = Some(5 * MINUTES);
 }
 
@@ -353,11 +354,17 @@ impl pallet_scheduler::Config for Runtime {
 	type PalletsOrigin = OriginCaller;
 	type Call = Call;
 	type MaximumWeight = MaximumSchedulerWeight;
-	type ScheduleOrigin = frame_system::EnsureRoot<AccountId>;
+	/// Origin to schedule or cancel calls
+	/// Set to Root or a simple majority of the Frequency Council
+	type ScheduleOrigin = EitherOfDiverse<
+		EnsureRoot<AccountId>,
+		pallet_collective::EnsureProportionAtLeast<AccountId, CouncilCollective, 1, 2>,
+	>;
 	type MaxScheduledPerBlock = SchedulerMaxScheduledPerBlock;
 	type WeightInfo = weights::pallet_scheduler::SubstrateWeight<Runtime>;
 	type OriginPrivilegeCmp = EqualPrivilegeOnly;
 	type PreimageProvider = Preimage;
+	// Will be removed in v0.9.30
 	type NoPreimagePostponement = NoPreimagePostponement;
 }
 

--- a/runtime/frequency-rococo/src/lib.rs
+++ b/runtime/frequency-rococo/src/lib.rs
@@ -365,7 +365,12 @@ impl pallet_preimage::Config for Runtime {
 	type WeightInfo = weights::pallet_preimage::SubstrateWeight<Runtime>;
 	type Event = Event;
 	type Currency = Balances;
-	type ManagerOrigin = EnsureRoot<AccountId>;
+	/// Allow the Technical council to request preimages without deposit or fees
+	type ManagerOrigin = EitherOfDiverse<
+		EnsureRoot<AccountId>,
+		pallet_collective::EnsureMember<AccountId, TechnicalCommitteeInstance>,
+	>;
+	/// Expected to be removed in Polkadot v0.9.31
 	type MaxSize = PreimageMaxSize;
 	type BaseDeposit = PreimageBaseDeposit;
 	type ByteDeposit = PreimageByteDeposit;

--- a/runtime/frequency/src/lib.rs
+++ b/runtime/frequency/src/lib.rs
@@ -369,6 +369,7 @@ parameter_types! {
 	pub MaximumSchedulerWeight: Weight = Perbill::from_percent(10) * RuntimeBlockWeights::get().max_block;
 	// The maximum number of scheduled calls in the queue for a single block. Not strictly enforced, but used for weight estimation.
 	// Retry a scheduled item every 25 blocks (5 minute) until the preimage exists.
+	// Will be removed in v0.9.30
 	pub const NoPreimagePostponement: Option<u32> = Some(5 * MINUTES);
 }
 
@@ -379,11 +380,17 @@ impl pallet_scheduler::Config for Runtime {
 	type PalletsOrigin = OriginCaller;
 	type Call = Call;
 	type MaximumWeight = MaximumSchedulerWeight;
-	type ScheduleOrigin = EnsureRoot<AccountId>;
+	/// Origin to schedule or cancel calls
+	/// Set to Root or a simple majority of the Frequency Council
+	type ScheduleOrigin = EitherOfDiverse<
+		EnsureRoot<AccountId>,
+		pallet_collective::EnsureProportionAtLeast<AccountId, CouncilCollective, 1, 2>,
+	>;
 	type MaxScheduledPerBlock = SchedulerMaxScheduledPerBlock;
 	type WeightInfo = pallet_scheduler::weights::SubstrateWeight<Runtime>;
 	type OriginPrivilegeCmp = EqualPrivilegeOnly;
 	type PreimageProvider = Preimage;
+	// Will be removed in v0.9.30
 	type NoPreimagePostponement = NoPreimagePostponement;
 }
 

--- a/runtime/frequency/src/lib.rs
+++ b/runtime/frequency/src/lib.rs
@@ -391,7 +391,12 @@ impl pallet_preimage::Config for Runtime {
 	type WeightInfo = pallet_preimage::weights::SubstrateWeight<Runtime>;
 	type Event = Event;
 	type Currency = Balances;
-	type ManagerOrigin = EnsureRoot<AccountId>;
+	// Allow the Technical council to request preimages without deposit or fees
+	type ManagerOrigin = EitherOfDiverse<
+		EnsureRoot<AccountId>,
+		pallet_collective::EnsureMember<AccountId, TechnicalCommitteeInstance>,
+	>;
+	/// Expected to be removed in Polkadot v0.9.31
 	type MaxSize = PreimageMaxSize;
 	type BaseDeposit = PreimageBaseDeposit;
 	type ByteDeposit = PreimageByteDeposit;


### PR DESCRIPTION
# Goal
The goal of this PR is to get some config updated for bootnodes, telemetry, preimage, and scheduler

Part of #263

# Discussion
- Bootnodes for rococo are not ready (mainnet urls are set, but not running yet)
- Telemetry endpoints. Rococo is being setup, and mainnet just points at polkadot as suggested by Parity.
- Scheduler and Preimage configs are only minor updates.

# Checklist
- [x] Chain spec updated
- [x] N/A Updated the js/api-augment code if a custom RPC added/changed
- [x] N/A Design doc(s) updated
- [x] Tested TechnicalCouncil request on preimage
- [x] N/A Benchmarks added
- [x] N/A Weights updated
