### PR TITLE
make releases atomic

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -13,8 +13,8 @@ env:
   RELEASE_VERSION: ${{github.ref_name}}
 
 jobs:
-  compile-project:
-    name: Compile ${{matrix.arch}} Binary for ${{matrix.network}}
+  build-binaries:
+    name: Build ${{matrix.arch}} Binary for ${{matrix.network}}
     strategy:
       matrix:
         os: [ubuntu-latest, macos-latest]
@@ -44,13 +44,20 @@ jobs:
           target: wasm32-unknown-unknown
       - name: Check Out Repo
         uses: actions/checkout@v3
-      - name: Cache Target Dir
-        id: cache-target-dir
-        uses: actions/cache@v3
+      # Test only. Let's you skip full binary build during development
+      # - name: Cache Binary
+      #   id: cache-binary
+      #   uses: actions/cache@v3
+      #   with:
+      #     path: target/${{matrix.build-profile}}/frequency
+      #     key: ${{runner.os}}-${{matrix.network}}-${{matrix.arch}}-${{env.RELEASE_VERSION}}
+      - name: Cache Dependencies
+        if: steps.cache-binary.outputs.cache-hit != 'true'
+        uses: Swatinem/rust-cache@v2
         with:
-          path: target/${{matrix.build-profile}}
-          key: ${{runner.os}}-${{matrix.network}}-${{matrix.arch}}-${{env.RELEASE_VERSION}}
+          shared-key: ${{env.RUST_TOOLCHAIN}}
       - name: Compile for ${{matrix.network}}
+        if: steps.cache-binary.outputs.cache-hit != 'true'
         run: |
           CARGO_INCREMENTAL=0 RUSTFLAGS="-D warnings" cargo build \
             --locked \
@@ -60,151 +67,19 @@ jobs:
         run: |
           file ./target/${{matrix.build-profile}}/frequency && \
             ./target/${{matrix.build-profile}}/frequency --version
-
-  release-binaries:
-    needs: compile-project
-    name: Release ${{matrix.arch}} Binary for ${{matrix.network}}
-    strategy:
-      matrix:
-        os: [ubuntu-latest, macos-latest]
-        network: [rococo, mainnet]
-        include:
-          - network: rococo
-            spec: frequency-rococo-testnet
-            build-profile: production
-          - network: mainnet
-            spec: frequency
-            build-profile: production
-          - os: ubuntu-latest
-            arch: amd64
-          - os: macos-latest
-            arch: arm64
-    runs-on: ${{matrix.os}}
-    steps:
-      - name: Cache target dir
-        id: cache-target-dir
-        uses: actions/cache@v3
-        with:
-          path: target/${{matrix.build-profile}}
-          key: ${{runner.os}}-${{matrix.network}}-${{matrix.arch}}-${{env.RELEASE_VERSION}}
-      - name: Create tarball of frequency rococo binary
+      - name: Archive Artifact
         run: |
           tar -cvf frequency-binary-${{matrix.network}}-${{env.RELEASE_VERSION}}.${{matrix.arch}}.tar \
             ./target/${{matrix.build-profile}}/frequency
-      - name: Upload frequency binary artifacts
-        uses: softprops/action-gh-release@v1
+      - name: Upload Artifact
+        uses: actions/upload-artifact@v3
         with:
-          files: frequency-binary-${{matrix.network}}-${{env.RELEASE_VERSION}}.${{matrix.arch}}.tar
+          name: artifacts-${{github.run_id}}
+          path: frequency-binary-${{matrix.network}}-${{env.RELEASE_VERSION}}.${{matrix.arch}}.tar
+          if-no-files-found: error
 
-  release-node-images:
-    needs: compile-project
-    name: Release ${{matrix.arch}} Node Image for ${{matrix.network}}
-    strategy:
-      matrix:
-        arch: [amd64]
-        network: [rococo, mainnet]
-        include:
-          - network: rococo
-            build-profile: production
-          - network: mainnet
-            build-profile: production
-    env:
-      DOCKER_HUB_PROFILE: frequencychain
-      IMAGE_NAME: parachain-node
-    runs-on: ubuntu-latest
-    steps:
-      # BUILD NODE DOCKER IMAGES
-      - name: Check Out Repo
-        uses: actions/checkout@v3
-      - name: Cache target dir
-        id: cache-target-dir
-        uses: actions/cache@v3
-        with:
-          path: target/${{matrix.build-profile}}
-          key: ${{runner.os}}-${{matrix.network}}-${{matrix.arch}}-${{env.RELEASE_VERSION}}
-      - name: Set up QEMU
-        uses: docker/setup-qemu-action@v2
-        with:
-          platforms: "amd64"
-      - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v2
-      - name: Login to DockerHub
-        uses: docker/login-action@v2
-        with:
-          username: ${{secrets.DOCKERHUB_USERNAME_FC}}
-          password: ${{secrets.DOCKERHUB_TOKEN_FC}}
-      - name: Build and Push Parachain Image
-        uses: docker/build-push-action@v3
-        with:
-          context: .
-          platforms: linux/amd64
-          push: true
-          file: ./docker/${{env.IMAGE_NAME}}.dockerfile
-          tags: |
-            ${{env.DOCKER_HUB_PROFILE}}/${{env.IMAGE_NAME}}-${{matrix.network}}:${{env.RELEASE_VERSION}}
-            ${{env.DOCKER_HUB_PROFILE}}/${{env.IMAGE_NAME}}-${{matrix.network}}:latest
-      - name: Update DockerHub Description
-        uses: peter-evans/dockerhub-description@v3
-        with:
-          username: ${{secrets.DOCKERHUB_USERNAME_FC}}
-          password: ${{secrets.DOCKERHUB_TOKEN_FC}}
-          repository: ${{env.DOCKER_HUB_PROFILE}}/${{env.IMAGE_NAME}}-${{matrix.network}}
-          readme-filepath: docker/${{env.IMAGE_NAME}}-${{matrix.network}}.overview.md
-
-  release-dev-images:
-    needs: compile-project
-    name: Release Dev Image for ${{matrix.node}}
-    strategy:
-      matrix:
-        network: [local]
-        arch: [amd64]
-        node: [collator-node-local, instant-seal-node]
-        include:
-          - network: local
-            build-profile: release
-    env:
-      DOCKER_HUB_PROFILE: frequencychain
-    runs-on: ubuntu-latest
-    steps:
-      - name: Check Out Repo
-        uses: actions/checkout@v3
-      - name: Cache target dir
-        id: cache-target-dir
-        uses: actions/cache@v3
-        with:
-          path: target/${{matrix.build-profile}}
-          key: ${{runner.os}}-${{matrix.network}}-${{matrix.arch}}-${{env.RELEASE_VERSION}}
-      - name: Set up QEMU
-        uses: docker/setup-qemu-action@v2
-        with:
-          platforms: "amd64"
-      - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v2
-      - name: Login to DockerHub
-        uses: docker/login-action@v2
-        with:
-          username: ${{secrets.DOCKERHUB_USERNAME_FC}}
-          password: ${{secrets.DOCKERHUB_TOKEN_FC}}
-      - name: Build and Push Dev Image
-        uses: docker/build-push-action@v3
-        with:
-          context: .
-          platforms: linux/amd64
-          push: true
-          file: ./docker/${{matrix.node}}.dockerfile
-          tags: |
-            ${{env.DOCKER_HUB_PROFILE}}/${{matrix.node}}:${{env.RELEASE_VERSION}}
-            ${{env.DOCKER_HUB_PROFILE}}/${{matrix.node}}:latest
-      - name: Update DockerHub Description
-        uses: peter-evans/dockerhub-description@v3
-        with:
-          username: ${{secrets.DOCKERHUB_USERNAME_FC}}
-          password: ${{secrets.DOCKERHUB_TOKEN_FC}}
-          repository: ${{env.DOCKER_HUB_PROFILE}}/${{matrix.node}}
-          readme-filepath: docker/${{matrix.node}}.overview.md
-
-  release-wasm:
-    name: Release Deterministic WASM for ${{matrix.network}}
+  build-wasm:
+    name: Build Deterministic WASM for ${{matrix.network}}
     strategy:
       matrix:
         network: [rococo, mainnet]
@@ -219,7 +94,6 @@ jobs:
             package: frequency-runtime
             runtime-dir: runtime/frequency
             wasm-file-name-prefix: frequency_runtime
-
     env:
       SRT_TOOL_VERSION: "1.62.0"
     runs-on: ubuntu-latest
@@ -240,13 +114,15 @@ jobs:
             ./${{matrix.runtime-dir}}/target/srtool/${{matrix.build-profile}}/wbuild/${{matrix.package}}/${{matrix.wasm-file-name-prefix}}.compact.compressed.wasm \
             ./${{matrix.runtime-dir}}/target/srtool/${{matrix.build-profile}}/wbuild/${{matrix.package}}/${{matrix.wasm-file-name-prefix}}.compact.wasm \
             ./${{matrix.runtime-dir}}/target/srtool/${{matrix.build-profile}}/wbuild/${{matrix.package}}/${{matrix.wasm-file-name-prefix}}.wasm
-      - name: Upload WASM
-        uses: softprops/action-gh-release@v1
+      - name: Upload Artifact
+        uses: actions/upload-artifact@v3
         with:
-          files: frequency-wasm-${{matrix.network}}-${{env.RELEASE_VERSION}}.tar
+          name: artifacts-${{github.run_id}}
+          path: frequency-wasm-${{matrix.network}}-${{env.RELEASE_VERSION}}.tar
+          if-no-files-found: error
 
-  release-rust-developer-docs:
-    name: Release Rust Developer Docs
+  build-rust-developer-docs:
+    name: Build Rust Developer Docs
     runs-on: ubuntu-latest
     steps:
       - name: Install Rust Toolchain
@@ -261,14 +137,15 @@ jobs:
       - name: Build Docs
         run: |
           RUSTDOCFLAGS="--enable-index-page -Zunstable-options" cargo doc --no-deps
-      - name: Deploy Frequency docs to gh-pages
-        uses: JamesIves/github-pages-deploy-action@v4.4.1
+      - name: Upload Docs
+        uses: actions/upload-artifact@v3
         with:
-          branch: gh-pages
-          folder: ./target/doc
+          name: rust-developer-docs-${{github.run_id}}
+          path: ./target/doc
+          if-no-files-found: error
 
-  release-js-api-augment:
-    name: Release JS API Augment
+  build-js-api-augment:
+    name: Build JS API Augment
     runs-on: ubuntu-latest
     steps:
       - name: Check Out Repo
@@ -286,11 +163,197 @@ jobs:
       - name: Build
         run: npm run build
         working-directory: js/api-augment
+      - name: Upload Dist Dir
+        uses: actions/upload-artifact@v3
+        with:
+          name: js-api-augment-${{github.run_id}}
+          path: js/api-augment/dist
+          if-no-files-found: error
+
+  wait-for-all-builds:
+    needs: [build-binaries, build-wasm, build-rust-developer-docs, build-js-api-augment]
+    name: Wait for All Builds to Finish
+    runs-on: ubuntu-latest
+    steps:
+      - name: Proceed Forward
+        run: echo "All build jobs have finished, proceeding with release"
+
+  release-artifacts:
+    needs: wait-for-all-builds
+    name: Release Built Artifacts
+    runs-on: ubuntu-latest
+    steps:
+      - name: Download Binary Artifacts
+        id: download
+        uses: actions/download-artifact@v3
+        with:
+          name: artifacts-${{github.run_id}}
+          path: .
+      - name: Upload Binary Artifact to Release Page
+        uses: softprops/action-gh-release@v1
+        with:
+          files: "*.tar"
+
+  release-node-images:
+    needs: wait-for-all-builds
+    name: Release ${{matrix.arch}} Node Docker Image for ${{matrix.network}}
+    strategy:
+      matrix:
+        arch: [amd64]
+        network: [rococo, mainnet]
+        include:
+          - network: rococo
+            build-profile: production
+          - network: mainnet
+            build-profile: production
+          - arch: amd64
+            docker-platform: linux/amd64
+    env:
+      DOCKER_HUB_PROFILE: frequencychain
+      IMAGE_NAME: parachain-node
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check Out Repo
+        uses: actions/checkout@v3
+      - name: Download Binary Artifacts
+        id: download
+        uses: actions/download-artifact@v3
+        with:
+          name: artifacts-${{github.run_id}}
+          path: .
+      - name: Extract Binary
+        run: |
+          tar -xvf frequency-binary-${{matrix.network}}-${{env.RELEASE_VERSION}}.${{matrix.arch}}.tar
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v2
+        with:
+          platforms: ${{matrix.arch}}
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v2
+      - name: Login to DockerHub
+        uses: docker/login-action@v2
+        with:
+          username: ${{secrets.DOCKERHUB_USERNAME_FC}}
+          password: ${{secrets.DOCKERHUB_TOKEN_FC}}
+      - name: Build and Push Parachain Image
+        uses: docker/build-push-action@v3
+        with:
+          context: .
+          platforms: ${{matrix.docker-platform}}
+          push: true
+          file: ./docker/${{env.IMAGE_NAME}}.dockerfile
+          tags: |
+            ${{env.DOCKER_HUB_PROFILE}}/${{env.IMAGE_NAME}}-${{matrix.network}}:${{env.RELEASE_VERSION}}
+            ${{env.DOCKER_HUB_PROFILE}}/${{env.IMAGE_NAME}}-${{matrix.network}}:latest
+      - name: Update DockerHub Description
+        uses: peter-evans/dockerhub-description@v3
+        with:
+          username: ${{secrets.DOCKERHUB_USERNAME_FC}}
+          password: ${{secrets.DOCKERHUB_TOKEN_FC}}
+          repository: ${{env.DOCKER_HUB_PROFILE}}/${{env.IMAGE_NAME}}-${{matrix.network}}
+          readme-filepath: docker/${{env.IMAGE_NAME}}-${{matrix.network}}.overview.md
+
+  release-dev-images:
+    needs: wait-for-all-builds
+    name: Release Dev Docker Image for ${{matrix.node}}
+    strategy:
+      matrix:
+        network: [local]
+        arch: [amd64]
+        node: [collator-node-local, instant-seal-node]
+        include:
+          - network: local
+            build-profile: release
+          - arch: amd64
+            docker-platform: linux/amd64
+    env:
+      DOCKER_HUB_PROFILE: frequencychain
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check Out Repo
+        uses: actions/checkout@v3
+      - name: Download Binary Artifacts
+        id: download
+        uses: actions/download-artifact@v3
+        with:
+          name: artifacts-${{github.run_id}}
+          path: .
+      - name: Extract Binary
+        run: |
+          tar -xvf frequency-binary-${{matrix.network}}-${{env.RELEASE_VERSION}}.${{matrix.arch}}.tar
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v2
+        with:
+          platforms: ${{matrix.arch}}
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v2
+      - name: Login to DockerHub
+        uses: docker/login-action@v2
+        with:
+          username: ${{secrets.DOCKERHUB_USERNAME_FC}}
+          password: ${{secrets.DOCKERHUB_TOKEN_FC}}
+      - name: Build and Push Dev Image
+        uses: docker/build-push-action@v3
+        with:
+          context: .
+          platforms: ${{matrix.docker-platform}}
+          push: true
+          file: ./docker/${{matrix.node}}.dockerfile
+          tags: |
+            ${{env.DOCKER_HUB_PROFILE}}/${{matrix.node}}:${{env.RELEASE_VERSION}}
+            ${{env.DOCKER_HUB_PROFILE}}/${{matrix.node}}:latest
+      - name: Update DockerHub Description
+        uses: peter-evans/dockerhub-description@v3
+        with:
+          username: ${{secrets.DOCKERHUB_USERNAME_FC}}
+          password: ${{secrets.DOCKERHUB_TOKEN_FC}}
+          repository: ${{env.DOCKER_HUB_PROFILE}}/${{matrix.node}}
+          readme-filepath: docker/${{matrix.node}}.overview.md
+
+  release-rust-developer-docs:
+    needs: wait-for-all-builds
+    name: Release Rust Developer Docs
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check Out Repo
+        uses: actions/checkout@v3
+      - name: Download Docs
+        id: download
+        uses: actions/download-artifact@v3
+        with:
+          name: rust-developer-docs-${{github.run_id}}
+          path: ./target/doc
+      - name: Deploy Frequency docs to gh-pages
+        uses: JamesIves/github-pages-deploy-action@v4
+        with:
+          branch: gh-pages
+          folder: ./target/doc
+
+  release-js-api-augment:
+    needs: wait-for-all-builds
+    name: Release JS API Augment
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check Out Repo
+        uses: actions/checkout@v3
+      - name: Set up NodeJs
+        uses: actions/setup-node@v3
+        with:
+          node-version: 16
+          cache: "npm"
+          registry-url: "https://registry.npmjs.org"
+          cache-dependency-path: js/api-augment/package-lock.json
+      - name: Download Dist Dir
+        id: download
+        uses: actions/download-artifact@v3
+        with:
+          name: js-api-augment-${{github.run_id}}
+          path: js/api-augment/dist
       - name: Version Package
         run: npm version --new-version "${{env.RELEASE_VERSION}}" --no-git-tag-version
         working-directory: js/api-augment/dist
       - name: Release on NPM @latest
         run: npm publish --tag latest --access public
-        working-directory: js/api-augment/dist
+        working-directory: ./js/api-augment/dist
         env:
           NODE_AUTH_TOKEN: ${{secrets.NODE_AUTH_TOKEN}}

--- a/.github/workflows/verify-pr-commit.yml
+++ b/.github/workflows/verify-pr-commit.yml
@@ -57,7 +57,7 @@ jobs:
         with:
           path: target/${{env.BUILD_PROFILE}}/frequency
           key: ${{runner.os}}-${{env.RUST_TOOLCHAIN}}-${{github.sha}}
-      - name: Compile
+      - name: Compile for ${{matrix.network}}
         run: |
           CARGO_INCREMENTAL=0 RUSTFLAGS="-D warnings" cargo build --locked --release \
             --features  frequency


### PR DESCRIPTION
# Goal
The goal of this PR is to make Frequency releases atomic (or really close to it). In other words, a release should be published only when all build steps have succeed. In order to achieve this, the `release.yml` workflow has been split into 2 parts:

1. **The build** - this is where all builds happen. All built artifacts are uploaded under `artifacts-${{github.run_id}}` name.
2. **The release** - this part of the release workflows kicks in only after all builds have finished and all artifacts have been uploaded successfully. It uses GitHub upload/download artifacts actions to pass built artifacts between them two. More reliable and appropriate than using cache action. 

![Screen Shot 2022-10-13 at 1 25 41 PM](https://user-images.githubusercontent.com/4452412/195703632-c615984f-51f6-4c51-9ad8-70a77b171fca.png)


❗ Blocked by:
- https://github.com/LibertyDSNP/frequency/pull/507