### PR TITLE
Rename: ProviderInfoOf -> DelegatorAndProviderToDelegation

### DIFF
--- a/common/primitives/src/msa.rs
+++ b/common/primitives/src/msa.rs
@@ -50,7 +50,7 @@ impl From<Delegator> for MessageSourceId {
 /// Struct for the information of the relationship between an MSA and a Provider
 #[derive(TypeInfo, RuntimeDebug, Clone, Decode, Encode, PartialEq, Default, MaxEncodedLen)]
 #[scale_info(skip_type_params(MaxSchemaGrantsPerDelegation))]
-pub struct ProviderInfo<BlockNumber, MaxSchemaGrantsPerDelegation>
+pub struct Delegation<BlockNumber, MaxSchemaGrantsPerDelegation>
 where
 	MaxSchemaGrantsPerDelegation: Get<u32>,
 {
@@ -145,11 +145,11 @@ pub trait ProviderLookup {
 	/// * `delegator` - The `MessageSourceId` that delegated to the provider
 	/// * `provider` - The `MessageSourceId` that has been delegated to
 	/// # Returns
-	/// * `Option<ProviderInfo<Self::BlockNumber>>`
-	fn get_provider_info_of(
+	/// * `Option<Delegation<Self::BlockNumber>>`
+	fn get_delegation_of(
 		delegator: Delegator,
 		provider: Provider,
-	) -> Option<ProviderInfo<Self::BlockNumber, Self::MaxSchemaGrantsPerDelegation>>;
+	) -> Option<Delegation<Self::BlockNumber, Self::MaxSchemaGrantsPerDelegation>>;
 }
 
 /// A behavior that allows for validating a delegator-provider relationship
@@ -169,7 +169,7 @@ pub trait DelegationValidator {
 		provider: Provider,
 		delegator: Delegator,
 		block_number: Option<Self::BlockNumber>,
-	) -> Result<ProviderInfo<Self::BlockNumber, Self::MaxSchemaGrantsPerDelegation>, DispatchError>;
+	) -> Result<Delegation<Self::BlockNumber, Self::MaxSchemaGrantsPerDelegation>, DispatchError>;
 }
 
 /// A behavior that allows for validating a schema grant

--- a/designdocs/delegation.md
+++ b/designdocs/delegation.md
@@ -129,7 +129,7 @@ pub(super) type DelegatorAndProviderToDelegation<T: Config> = StorageDoubleMap<
 		Delegator,
 		Blake2_128Concat,
 		Provider,
-		ProviderInfo<T::BlockNumber>,
+		Delegation<T::BlockNumber>,
 		OptionQuery,
 	>;
 ```

--- a/designdocs/delegation.md
+++ b/designdocs/delegation.md
@@ -123,7 +123,7 @@ Throws an Error enum indicating if either provider or delegator does not exist.
 ### Storage
 * Delegations are stored as a Double-key map of Delegator MSA id --> Provider MSA id. The data stored contains the `Permission` for that relationship:
 ```rust
-pub(super) type ProviderInfoOf<T: Config> = StorageDoubleMap<
+pub(super) type DelegatorAndProviderToDelegation<T: Config> = StorageDoubleMap<
 		_,
 		Blake2_128Concat,
 		Delegator,

--- a/pallets/messages/src/mock.rs
+++ b/pallets/messages/src/mock.rs
@@ -1,8 +1,8 @@
 use crate as pallet_messages;
 use common_primitives::{
 	msa::{
-		DelegationValidator, Delegator, MessageSourceId, MsaLookup, MsaValidator, OrderedSet,
-		Provider, ProviderInfo, ProviderLookup, SchemaGrantValidator,
+		Delegation, DelegationValidator, Delegator, MessageSourceId, MsaLookup, MsaValidator,
+		OrderedSet, Provider, ProviderLookup, SchemaGrantValidator,
 	},
 	schema::*,
 };
@@ -151,14 +151,14 @@ impl ProviderLookup for DelegationInfoHandler {
 	type BlockNumber = u64;
 	type MaxSchemaGrantsPerDelegation = MaxSchemaGrantsPerDelegation;
 
-	fn get_provider_info_of(
+	fn get_delegation_of(
 		_delegator: Delegator,
 		provider: Provider,
-	) -> Option<ProviderInfo<Self::BlockNumber, MaxSchemaGrantsPerDelegation>> {
+	) -> Option<Delegation<Self::BlockNumber, MaxSchemaGrantsPerDelegation>> {
 		if provider == Provider(2000) {
 			return None
 		};
-		Some(ProviderInfo { expired: 100, schemas: OrderedSet::new() })
+		Some(Delegation { expired: 100, schemas: OrderedSet::new() })
 	}
 }
 impl DelegationValidator for DelegationInfoHandler {
@@ -169,13 +169,12 @@ impl DelegationValidator for DelegationInfoHandler {
 		provider: Provider,
 		_delegator: Delegator,
 		_block_number: Option<Self::BlockNumber>,
-	) -> Result<ProviderInfo<Self::BlockNumber, Self::MaxSchemaGrantsPerDelegation>, DispatchError>
-	{
+	) -> Result<Delegation<Self::BlockNumber, Self::MaxSchemaGrantsPerDelegation>, DispatchError> {
 		if provider == Provider(2000) {
 			return Err(DispatchError::Other("some delegation error"))
 		};
 
-		Ok(ProviderInfo { schemas: OrderedSet::new(), expired: Default::default() })
+		Ok(Delegation { schemas: OrderedSet::new(), expired: Default::default() })
 	}
 }
 impl SchemaGrantValidator for SchemaGrantValidationHandler {
@@ -184,7 +183,7 @@ impl SchemaGrantValidator for SchemaGrantValidationHandler {
 		delegator: Delegator,
 		_schema_id: SchemaId,
 	) -> DispatchResult {
-		match DelegationInfoHandler::get_provider_info_of(delegator, provider) {
+		match DelegationInfoHandler::get_delegation_of(delegator, provider) {
 			Some(_) => Ok(()),
 			None => Err(DispatchError::Other("no schema grant or delegation")),
 		}

--- a/pallets/messages/src/weights.rs
+++ b/pallets/messages/src/weights.rs
@@ -64,7 +64,7 @@ pub struct SubstrateWeight<T>(PhantomData<T>);
 impl<T: frame_system::Config> WeightInfo for SubstrateWeight<T> {
 	// Storage: Schemas Schemas (r:1 w:0)
 	// Storage: Msa PublicKeyToMsaId (r:1 w:0)
-	// Storage: Msa ProviderInfoOf (r:1 w:0)
+	// Storage: Msa DelegatorAndProviderToDelegation (r:1 w:0)
 	// Storage: Messages BlockMessages (r:1 w:1)
 	fn add_onchain_message(n: u32, m: u32, ) -> Weight {
 		Weight::from_ref_time(3_065_000 as u64)
@@ -104,7 +104,7 @@ impl<T: frame_system::Config> WeightInfo for SubstrateWeight<T> {
 impl WeightInfo for () {
 	// Storage: Schemas Schemas (r:1 w:0)
 	// Storage: Msa PublicKeyToMsaId (r:1 w:0)
-	// Storage: Msa ProviderInfoOf (r:1 w:0)
+	// Storage: Msa DelegatorAndProviderToDelegation (r:1 w:0)
 	// Storage: Messages BlockMessages (r:1 w:1)
 	fn add_onchain_message(n: u32, m: u32, ) -> Weight {
 		Weight::from_ref_time(3_065_000 as u64)

--- a/pallets/msa/src/lib.rs
+++ b/pallets/msa/src/lib.rs
@@ -158,8 +158,8 @@ pub mod pallet {
 	/// - Keys: Delegator MSA, Provider MSA
 	/// - Value: [`ProviderInfo`](common_primitives::msa::ProviderInfo)
 	#[pallet::storage]
-	#[pallet::getter(fn get_provider_info)]
-	pub type ProviderInfoOf<T: Config> = StorageDoubleMap<
+	#[pallet::getter(fn get_delegation)]
+	pub type DelegatorAndProviderToDelegation<T: Config> = StorageDoubleMap<
 		_,
 		Twox64Concat,
 		Delegator,
@@ -805,7 +805,7 @@ impl<T: Config> Pallet<T> {
 
 		Self::ensure_all_schema_ids_are_valid(granted_schemas.clone())?;
 
-		ProviderInfoOf::<T>::try_mutate(delegator, provider, |maybe_info| -> DispatchResult {
+		DelegatorAndProviderToDelegation::<T>::try_mutate(delegator, provider, |maybe_info| -> DispatchResult {
 			ensure!(maybe_info.take() == None, Error::<T>::DuplicateProvider);
 			let info = ProviderInfo {
 				expired: Default::default(),
@@ -894,7 +894,7 @@ impl<T: Config> Pallet<T> {
 		provider_msa_id: Provider,
 		delegator_msa_id: Delegator,
 	) -> DispatchResult {
-		ProviderInfoOf::<T>::try_mutate_exists(
+		DelegatorAndProviderToDelegation::<T>::try_mutate_exists(
 			delegator_msa_id,
 			provider_msa_id,
 			|maybe_info| -> DispatchResult {
@@ -917,7 +917,7 @@ impl<T: Config> Pallet<T> {
 
 	/// Removes all delegations from the specified delegator MSA id to providers
 	pub fn remove_delegator(delegator: Delegator) -> DispatchResult {
-		_ = ProviderInfoOf::<T>::clear_prefix(delegator, u32::max_value(), None);
+		_ = DelegatorAndProviderToDelegation::<T>::clear_prefix(delegator, u32::max_value(), None);
 		Ok(())
 	}
 
@@ -1114,7 +1114,7 @@ impl<T: Config> ProviderLookup for Pallet<T> {
 		delegator: Delegator,
 		provider: Provider,
 	) -> Option<ProviderInfo<Self::BlockNumber, Self::MaxSchemaGrantsPerDelegation>> {
-		Self::get_provider_info(delegator, provider)
+		Self::get_delegation(delegator, provider)
 	}
 }
 

--- a/pallets/msa/src/tests.rs
+++ b/pallets/msa/src/tests.rs
@@ -552,7 +552,7 @@ pub fn add_provider_to_msa_is_success() {
 		let delegator = Delegator(delegator_msa);
 
 		assert_eq!(
-			Msa::get_provider_info(delegator, provider),
+			Msa::get_delegation(delegator, provider),
 			Some(ProviderInfo { expired: 0, schemas: OrderedSet::new() })
 		);
 
@@ -750,7 +750,7 @@ pub fn create_sponsored_account_with_delegation_with_valid_input_should_succeed(
 		let key_info = Msa::get_msa_by_public_key(&AccountId32::new(delegator_account.0));
 		assert_eq!(key_info.unwrap(), 2);
 
-		let provider_info = Msa::get_provider_info(Delegator(2), Provider(1));
+		let provider_info = Msa::get_delegation(Delegator(2), Provider(1));
 		assert_eq!(provider_info.is_some(), true);
 
 		let events_occured = System::events();
@@ -1035,7 +1035,7 @@ pub fn revoke_provider_is_successful() {
 		assert_ok!(Msa::revoke_provider(provider, delegator));
 
 		assert_eq!(
-			Msa::get_provider_info(delegator, provider).unwrap(),
+			Msa::get_delegation(delegator, provider).unwrap(),
 			ProviderInfo { expired: 1, schemas: OrderedSet::new() },
 		);
 	});
@@ -1217,7 +1217,7 @@ pub fn revoke_delegation_by_provider_happy_path() {
 		assert_ok!(Msa::revoke_delegation_by_provider(Origin::signed(provider_key.into()), 2u64));
 
 		// 6. verify that the provider is revoked
-		let provider_info = Msa::get_provider_info(Delegator(2), Provider(1));
+		let provider_info = Msa::get_delegation(Delegator(2), Provider(1));
 		assert_eq!(provider_info, Some(ProviderInfo { expired: 26, schemas: OrderedSet::new() }));
 
 		// 7. verify the event

--- a/pallets/msa/src/tests.rs
+++ b/pallets/msa/src/tests.rs
@@ -14,7 +14,7 @@ use crate::{
 };
 
 use common_primitives::{
-	msa::{Delegator, MessageSourceId, Provider, ProviderInfo, ProviderMetadata},
+	msa::{Delegation, Delegator, MessageSourceId, Provider, ProviderMetadata},
 	node::BlockNumber,
 	schema::SchemaId,
 	utils::wrap_binary_data,
@@ -553,7 +553,7 @@ pub fn add_provider_to_msa_is_success() {
 
 		assert_eq!(
 			Msa::get_delegation(delegator, provider),
-			Some(ProviderInfo { expired: 0, schemas: OrderedSet::new() })
+			Some(Delegation { expired: 0, schemas: OrderedSet::new() })
 		);
 
 		System::assert_last_event(
@@ -1036,7 +1036,7 @@ pub fn revoke_provider_is_successful() {
 
 		assert_eq!(
 			Msa::get_delegation(delegator, provider).unwrap(),
-			ProviderInfo { expired: 1, schemas: OrderedSet::new() },
+			Delegation { expired: 1, schemas: OrderedSet::new() },
 		);
 	});
 }
@@ -1218,7 +1218,7 @@ pub fn revoke_delegation_by_provider_happy_path() {
 
 		// 6. verify that the provider is revoked
 		let provider_info = Msa::get_delegation(Delegator(2), Provider(1));
-		assert_eq!(provider_info, Some(ProviderInfo { expired: 26, schemas: OrderedSet::new() }));
+		assert_eq!(provider_info, Some(Delegation { expired: 26, schemas: OrderedSet::new() }));
 
 		// 7. verify the event
 		System::assert_last_event(

--- a/pallets/msa/src/weights.rs
+++ b/pallets/msa/src/weights.rs
@@ -85,14 +85,14 @@ impl<T: frame_system::Config> WeightInfo for SubstrateWeight<T> {
 	// Storage: Msa ProviderToRegistryEntry (r:1 w:0)
 	// Storage: Msa MsaIdentifier (r:1 w:1)
 	// Storage: Msa PublicKeyCountForMsaId (r:1 w:1)
-	// Storage: Msa ProviderInfoOf (r:1 w:1)
+	// Storage: Msa DelegatorAndProviderToDelegation (r:1 w:1)
 	fn create_sponsored_account_with_delegation() -> Weight {
 		Weight::from_ref_time(61_000_000 as u64)
 			.saturating_add(T::DbWeight::get().reads(7 as u64))
 			.saturating_add(T::DbWeight::get().writes(5 as u64))
 	}
 	// Storage: Msa PublicKeyToMsaId (r:1 w:0)
-	// Storage: Msa ProviderInfoOf (r:1 w:1)
+	// Storage: Msa DelegatorAndProviderToDelegation (r:1 w:1)
 	fn revoke_delegation_by_provider(s: u32) -> Weight {
 		Weight::from_ref_time(20_484_000 as u64)
 			// Standard Error: 1_000
@@ -126,14 +126,14 @@ impl<T: frame_system::Config> WeightInfo for SubstrateWeight<T> {
 	// Storage: Msa PayloadSignatureRegistry (r:1 w:1)
 	// Storage: Msa PublicKeyToMsaId (r:2 w:0)
 	// Storage: Msa ProviderToRegistryEntry (r:1 w:0)
-	// Storage: Msa ProviderInfoOf (r:1 w:1)
+	// Storage: Msa DelegatorAndProviderToDelegation (r:1 w:1)
 	fn grant_delegation() -> Weight {
 		Weight::from_ref_time(59_000_000 as u64)
 			.saturating_add(T::DbWeight::get().reads(5 as u64))
 			.saturating_add(T::DbWeight::get().writes(2 as u64))
 	}
 	// Storage: Msa PublicKeyToMsaId (r:1 w:0)
-	// Storage: Msa ProviderInfoOf (r:1 w:1)
+	// Storage: Msa DelegatorAndProviderToDelegation (r:1 w:1)
 	fn revoke_delegation_by_delegator() -> Weight {
 		Weight::from_ref_time(15_000_000 as u64)
 			.saturating_add(T::DbWeight::get().reads(2 as u64))
@@ -171,14 +171,14 @@ impl WeightInfo for () {
 	// Storage: Msa ProviderToRegistryEntry (r:1 w:0)
 	// Storage: Msa MsaIdentifier (r:1 w:1)
 	// Storage: Msa PublicKeyCountForMsaId (r:1 w:1)
-	// Storage: Msa ProviderInfoOf (r:1 w:1)
+	// Storage: Msa DelegatorAndProviderToDelegation (r:1 w:1)
 	fn create_sponsored_account_with_delegation() -> Weight {
 		Weight::from_ref_time(61_000_000 as u64)
 			.saturating_add(RocksDbWeight::get().reads(7 as u64))
 			.saturating_add(RocksDbWeight::get().writes(5 as u64))
 	}
 	// Storage: Msa PublicKeyToMsaId (r:1 w:0)
-	// Storage: Msa ProviderInfoOf (r:1 w:1)
+	// Storage: Msa DelegatorAndProviderToDelegation (r:1 w:1)
 	fn revoke_delegation_by_provider(s: u32, ) -> Weight {
 		Weight::from_ref_time(18_059_000 as u64)
 			// Standard Error: 2_000
@@ -212,14 +212,14 @@ impl WeightInfo for () {
 	// Storage: Msa PayloadSignatureRegistry (r:1 w:1)
 	// Storage: Msa PublicKeyToMsaId (r:2 w:0)
 	// Storage: Msa ProviderToRegistryEntry (r:1 w:0)
-	// Storage: Msa ProviderInfoOf (r:1 w:1)
+	// Storage: Msa DelegatorAndProviderToDelegation (r:1 w:1)
 	fn grant_delegation() -> Weight {
 		Weight::from_ref_time(59_000_000 as u64)
 			.saturating_add(RocksDbWeight::get().reads(5 as u64))
 			.saturating_add(RocksDbWeight::get().writes(2 as u64))
 	}
 	// Storage: Msa PublicKeyToMsaId (r:1 w:0)
-	// Storage: Msa ProviderToRegistryEntry (r:1 w:1)
+	// Storage: Msa DelegatorAndProviderToDelegation (r:1 w:1)
 	fn revoke_delegation_by_delegator() -> Weight {
 		Weight::from_ref_time(15_000_000 as u64)
 			.saturating_add(RocksDbWeight::get().reads(2 as u64))


### PR DESCRIPTION
# Goal
The goal of this PR is to rename the `ProviderInfoOf` Storage and `ProviderInfo` struct.

# Discussion
This partially completes #508

# Checklist
- [x] Tests added
- [x] Benchmarks added
