### PR TITLE
Rename: MessageSourceIdOf -> PublicKeyToMsaId

### DIFF
--- a/pallets/messages/src/weights.rs
+++ b/pallets/messages/src/weights.rs
@@ -63,7 +63,7 @@ pub trait WeightInfo {
 pub struct SubstrateWeight<T>(PhantomData<T>);
 impl<T: frame_system::Config> WeightInfo for SubstrateWeight<T> {
 	// Storage: Schemas Schemas (r:1 w:0)
-	// Storage: Msa MessageSourceIdOf (r:1 w:0)
+	// Storage: Msa PublicKeyToMsaId (r:1 w:0)
 	// Storage: Msa ProviderInfoOf (r:1 w:0)
 	// Storage: Messages BlockMessages (r:1 w:1)
 	fn add_onchain_message(n: u32, m: u32, ) -> Weight {
@@ -76,7 +76,7 @@ impl<T: frame_system::Config> WeightInfo for SubstrateWeight<T> {
 			.saturating_add(T::DbWeight::get().writes(1 as u64))
 	}
 	// Storage: Schemas Schemas (r:1 w:0)
-	// Storage: Msa MessageSourceIdOf (r:1 w:0)
+	// Storage: Msa PublicKeyToMsaId (r:1 w:0)
 	// Storage: Messages BlockMessages (r:1 w:1)
 	fn add_ipfs_message(n: u32, m: u32, ) -> Weight {
 		Weight::from_ref_time(2_349_000 as u64)
@@ -103,7 +103,7 @@ impl<T: frame_system::Config> WeightInfo for SubstrateWeight<T> {
 // For backwards compatibility and tests
 impl WeightInfo for () {
 	// Storage: Schemas Schemas (r:1 w:0)
-	// Storage: Msa MessageSourceIdOf (r:1 w:0)
+	// Storage: Msa PublicKeyToMsaId (r:1 w:0)
 	// Storage: Msa ProviderInfoOf (r:1 w:0)
 	// Storage: Messages BlockMessages (r:1 w:1)
 	fn add_onchain_message(n: u32, m: u32, ) -> Weight {
@@ -116,7 +116,7 @@ impl WeightInfo for () {
 			.saturating_add(RocksDbWeight::get().writes(1 as u64))
 	}
 	// Storage: Schemas Schemas (r:1 w:0)
-	// Storage: Msa MessageSourceIdOf (r:1 w:0)
+	// Storage: Msa PublicKeyToMsaId (r:1 w:0)
 	// Storage: Messages BlockMessages (r:1 w:1)
 	fn add_ipfs_message(n: u32, m: u32, ) -> Weight {
 		Weight::from_ref_time(2_349_000 as u64)

--- a/pallets/msa/src/lib.rs
+++ b/pallets/msa/src/lib.rs
@@ -186,8 +186,8 @@ pub mod pallet {
 	/// - Key: AccountId
 	/// - Value: [`MessageSourceId`]
 	#[pallet::storage]
-	#[pallet::getter(fn get_msa_by_account_id)]
-	pub type MessageSourceIdOf<T: Config> =
+	#[pallet::getter(fn get_msa_by_public_key)]
+	pub type PublicKeyToMsaId<T: Config> =
 		StorageMap<_, Twox64Concat, T::AccountId, MessageSourceId, OptionQuery>;
 
 	/// Storage type for a reference counter of the number of keys associated to an MSA
@@ -701,7 +701,7 @@ impl<T: Config> Pallet<T> {
 	where
 		F: FnOnce(MessageSourceId) -> DispatchResult,
 	{
-		MessageSourceIdOf::<T>::try_mutate(key, |maybe_msa_id| {
+		PublicKeyToMsaId::<T>::try_mutate(key, |maybe_msa_id| {
 			ensure!(maybe_msa_id.is_none(), Error::<T>::KeyAlreadyRegistered);
 			*maybe_msa_id = Some(msa_id);
 
@@ -851,7 +851,7 @@ impl<T: Config> Pallet<T> {
 	/// # Errors
 	/// * [`Error::<T>::NoKeyExists`] - If the key does not exist in the MSA
 	pub fn delete_key_for_msa(msa_id: MessageSourceId, key: &T::AccountId) -> DispatchResult {
-		MessageSourceIdOf::<T>::try_mutate_exists(key, |maybe_msa_id| {
+		PublicKeyToMsaId::<T>::try_mutate_exists(key, |maybe_msa_id| {
 			ensure!(maybe_msa_id.is_some(), Error::<T>::NoKeyExists);
 
 			// Delete the key if it exists
@@ -918,7 +918,7 @@ impl<T: Config> Pallet<T> {
 	pub fn try_get_msa_from_account_id(
 		key: &T::AccountId,
 	) -> Result<MessageSourceId, DispatchError> {
-		let info = Self::get_msa_by_account_id(key).ok_or(Error::<T>::NoKeyExists)?;
+		let info = Self::get_msa_by_public_key(key).ok_or(Error::<T>::NoKeyExists)?;
 		Ok(info)
 	}
 
@@ -928,7 +928,7 @@ impl<T: Config> Pallet<T> {
 	/// # Returns
 	/// * [`MessageSourceId`]
 	pub fn get_owner_of(key: &T::AccountId) -> Option<MessageSourceId> {
-		Self::get_msa_by_account_id(&key)
+		Self::get_msa_by_public_key(&key)
 	}
 
 	// *Temporarily Removed* until https://github.com/LibertyDSNP/frequency/issues/418

--- a/pallets/msa/src/tests.rs
+++ b/pallets/msa/src/tests.rs
@@ -26,7 +26,7 @@ fn it_creates_an_msa_account() {
 	new_test_ext().execute_with(|| {
 		assert_ok!(Msa::create(test_origin_signed(1)));
 
-		assert_eq!(Msa::get_msa_by_account_id(test_public(1)), Some(1 as MessageSourceId));
+		assert_eq!(Msa::get_msa_by_public_key(test_public(1)), Some(1 as MessageSourceId));
 
 		assert_eq!(Msa::get_identifier(), 1);
 
@@ -299,7 +299,7 @@ fn it_deletes_msa_key_successfully() {
 
 		assert_ok!(Msa::delete_msa_key(test_origin_signed(1), test_public(2)));
 
-		let info = Msa::get_msa_by_account_id(&test_public(2));
+		let info = Msa::get_msa_by_public_key(&test_public(2));
 
 		assert_eq!(info, None);
 
@@ -457,7 +457,7 @@ pub fn test_delete_key() {
 	new_test_ext().execute_with(|| {
 		assert_ok!(Msa::add_key(1, &test_public(1), EMPTY_FUNCTION));
 
-		let info = Msa::get_msa_by_account_id(&test_public(1));
+		let info = Msa::get_msa_by_public_key(&test_public(1));
 
 		assert_eq!(info, Some(1 as MessageSourceId));
 
@@ -721,7 +721,7 @@ pub fn create_sponsored_account_with_delegation_with_valid_input_should_succeed(
 		));
 
 		// assert
-		let key_info = Msa::get_msa_by_account_id(&AccountId32::new(delegator_account.0));
+		let key_info = Msa::get_msa_by_public_key(&AccountId32::new(delegator_account.0));
 		assert_eq!(key_info.unwrap(), 2);
 
 		let provider_info = Msa::get_provider_info(Delegator(2), Provider(1));
@@ -898,7 +898,7 @@ pub fn add_key_with_panic_in_on_success_should_revert_everything() {
 		);
 
 		// assert
-		assert_eq!(Msa::get_msa_by_account_id(&key), None);
+		assert_eq!(Msa::get_msa_by_public_key(&key), None);
 
 		// *Temporarily Removed* until https://github.com/LibertyDSNP/frequency/issues/418 is completed
 		// assert_eq!(Msa::get_msa_keys(msa_id).into_inner(), vec![])

--- a/pallets/msa/src/weights.rs
+++ b/pallets/msa/src/weights.rs
@@ -70,7 +70,7 @@ pub trait WeightInfo {
 pub struct SubstrateWeight<T>(PhantomData<T>);
 impl<T: frame_system::Config> WeightInfo for SubstrateWeight<T> {
 	// Storage: Msa MsaIdentifier (r:1 w:1)
-	// Storage: Msa MessageSourceIdOf (r:1 w:1)
+	// Storage: Msa PublicKeyToMsaId (r:1 w:1)
 	// Storage: Msa MsaInfoOf (r:1 w:1)
 	fn create(s: u32, ) -> Weight {
 		Weight::from_ref_time(17_462_000 as u64)
@@ -80,7 +80,7 @@ impl<T: frame_system::Config> WeightInfo for SubstrateWeight<T> {
 			.saturating_add(T::DbWeight::get().writes(3 as u64))
 	}
 	// Storage: Msa PayloadSignatureRegistry (r:1 w:1)
-	// Storage: Msa MessageSourceIdOf (r:2 w:1)
+	// Storage: Msa PublicKeyToMsaId (r:2 w:1)
 	// Storage: Msa ProviderRegistry (r:1 w:0)
 	// Storage: Msa MsaIdentifier (r:1 w:1)
 	// Storage: Msa MsaInfoOf (r:1 w:1)
@@ -90,7 +90,7 @@ impl<T: frame_system::Config> WeightInfo for SubstrateWeight<T> {
 			.saturating_add(T::DbWeight::get().reads(7 as u64))
 			.saturating_add(T::DbWeight::get().writes(5 as u64))
 	}
-	// Storage: Msa MessageSourceIdOf (r:1 w:0)
+	// Storage: Msa PublicKeyToMsaId (r:1 w:0)
 	// Storage: Msa ProviderInfoOf (r:1 w:1)
 	fn revoke_delegation_by_provider(s: u32, ) -> Weight {
 		Weight::from_ref_time(18_059_000 as u64)
@@ -100,21 +100,21 @@ impl<T: frame_system::Config> WeightInfo for SubstrateWeight<T> {
 			.saturating_add(T::DbWeight::get().writes(1 as u64))
 	}
 	// Storage: Msa PayloadSignatureRegistry (r:1 w:1)
-	// Storage: Msa MessageSourceIdOf (r:2 w:1)
+	// Storage: Msa PublicKeyToMsaId (r:2 w:1)
 	// Storage: Msa MsaInfoOf (r:1 w:1)
 	fn add_key_to_msa() -> Weight {
 		Weight::from_ref_time(55_000_000 as u64)
 			.saturating_add(T::DbWeight::get().reads(4 as u64))
 			.saturating_add(T::DbWeight::get().writes(3 as u64))
 	}
-	// Storage: Msa MessageSourceIdOf (r:2 w:1)
+	// Storage: Msa PublicKeyToMsaId (r:2 w:1)
 	// Storage: Msa MsaInfoOf (r:1 w:1)
 	fn delete_msa_key() -> Weight {
 		Weight::from_ref_time(18_000_000 as u64)
 			.saturating_add(T::DbWeight::get().reads(3 as u64))
 			.saturating_add(T::DbWeight::get().writes(2 as u64))
 	}
-	// Storage: Msa MessageSourceIdOf (r:1 w:1)
+	// Storage: Msa PublicKeyToMsaId (r:1 w:1)
 	// Storage: Msa ProviderRegistry (r:1 w:0)
 	// Storage: Msa MsaInfoOf (r:1 w:1)
 	fn retire_msa() -> Weight {
@@ -123,7 +123,7 @@ impl<T: frame_system::Config> WeightInfo for SubstrateWeight<T> {
 			.saturating_add(T::DbWeight::get().writes(2 as u64))
 	}
 	// Storage: Msa PayloadSignatureRegistry (r:1 w:1)
-	// Storage: Msa MessageSourceIdOf (r:2 w:0)
+	// Storage: Msa PublicKeyToMsaId (r:2 w:0)
 	// Storage: Msa ProviderRegistry (r:1 w:0)
 	// Storage: Msa ProviderInfoOf (r:1 w:1)
 	fn add_provider_to_msa() -> Weight {
@@ -131,14 +131,14 @@ impl<T: frame_system::Config> WeightInfo for SubstrateWeight<T> {
 			.saturating_add(T::DbWeight::get().reads(5 as u64))
 			.saturating_add(T::DbWeight::get().writes(2 as u64))
 	}
-	// Storage: Msa MessageSourceIdOf (r:1 w:0)
+	// Storage: Msa PublicKeyToMsaId (r:1 w:0)
 	// Storage: Msa ProviderInfoOf (r:1 w:1)
 	fn revoke_msa_delegation_by_delegator() -> Weight {
 		Weight::from_ref_time(15_000_000 as u64)
 			.saturating_add(T::DbWeight::get().reads(2 as u64))
 			.saturating_add(T::DbWeight::get().writes(1 as u64))
 	}
-	// Storage: Msa MessageSourceIdOf (r:1 w:0)
+	// Storage: Msa PublicKeyToMsaId (r:1 w:0)
 	// Storage: Msa ProviderRegistry (r:1 w:1)
 	fn register_provider() -> Weight {
 		Weight::from_ref_time(13_000_000 as u64)
@@ -155,7 +155,7 @@ impl<T: frame_system::Config> WeightInfo for SubstrateWeight<T> {
 // For backwards compatibility and tests
 impl WeightInfo for () {
 	// Storage: Msa MsaIdentifier (r:1 w:1)
-	// Storage: Msa MessageSourceIdOf (r:1 w:1)
+	// Storage: Msa PublicKeyToMsaId (r:1 w:1)
 	// Storage: Msa MsaInfoOf (r:1 w:1)
 	fn create(s: u32, ) -> Weight {
 		Weight::from_ref_time(17_462_000 as u64)
@@ -165,7 +165,7 @@ impl WeightInfo for () {
 			.saturating_add(RocksDbWeight::get().writes(3 as u64))
 	}
 	// Storage: Msa PayloadSignatureRegistry (r:1 w:1)
-	// Storage: Msa MessageSourceIdOf (r:2 w:1)
+	// Storage: Msa PublicKeyToMsaId (r:2 w:1)
 	// Storage: Msa ProviderRegistry (r:1 w:0)
 	// Storage: Msa MsaIdentifier (r:1 w:1)
 	// Storage: Msa MsaInfoOf (r:1 w:1)
@@ -175,7 +175,7 @@ impl WeightInfo for () {
 			.saturating_add(RocksDbWeight::get().reads(7 as u64))
 			.saturating_add(RocksDbWeight::get().writes(5 as u64))
 	}
-	// Storage: Msa MessageSourceIdOf (r:1 w:0)
+	// Storage: Msa PublicKeyToMsaId (r:1 w:0)
 	// Storage: Msa ProviderInfoOf (r:1 w:1)
 	fn revoke_delegation_by_provider(s: u32, ) -> Weight {
 		Weight::from_ref_time(18_059_000 as u64)
@@ -185,21 +185,21 @@ impl WeightInfo for () {
 			.saturating_add(RocksDbWeight::get().writes(1 as u64))
 	}
 	// Storage: Msa PayloadSignatureRegistry (r:1 w:1)
-	// Storage: Msa MessageSourceIdOf (r:2 w:1)
+	// Storage: Msa PublicKeyToMsaId (r:2 w:1)
 	// Storage: Msa MsaInfoOf (r:1 w:1)
 	fn add_key_to_msa() -> Weight {
 		Weight::from_ref_time(55_000_000 as u64)
 			.saturating_add(RocksDbWeight::get().reads(4 as u64))
 			.saturating_add(RocksDbWeight::get().writes(3 as u64))
 	}
-	// Storage: Msa MessageSourceIdOf (r:2 w:1)
+	// Storage: Msa PublicKeyToMsaId (r:2 w:1)
 	// Storage: Msa MsaInfoOf (r:1 w:1)
 	fn delete_msa_key() -> Weight {
 		Weight::from_ref_time(18_000_000 as u64)
 			.saturating_add(RocksDbWeight::get().reads(3 as u64))
 			.saturating_add(RocksDbWeight::get().writes(2 as u64))
 	}
-	// Storage: Msa MessageSourceIdOf (r:1 w:1)
+	// Storage: Msa PublicKeyToMsaId (r:1 w:1)
 	// Storage: Msa ProviderRegistry (r:1 w:0)
 	// Storage: Msa MsaInfoOf (r:1 w:1)
 	fn retire_msa() -> Weight {
@@ -208,7 +208,7 @@ impl WeightInfo for () {
 			.saturating_add(RocksDbWeight::get().writes(2 as u64))
 	}
 	// Storage: Msa PayloadSignatureRegistry (r:1 w:1)
-	// Storage: Msa MessageSourceIdOf (r:2 w:0)
+	// Storage: Msa PublicKeyToMsaId (r:2 w:0)
 	// Storage: Msa ProviderRegistry (r:1 w:0)
 	// Storage: Msa ProviderInfoOf (r:1 w:1)
 	fn add_provider_to_msa() -> Weight {
@@ -216,14 +216,14 @@ impl WeightInfo for () {
 			.saturating_add(RocksDbWeight::get().reads(5 as u64))
 			.saturating_add(RocksDbWeight::get().writes(2 as u64))
 	}
-	// Storage: Msa MessageSourceIdOf (r:1 w:0)
+	// Storage: Msa PublicKeyToMsaId (r:1 w:0)
 	// Storage: Msa ProviderInfoOf (r:1 w:1)
 	fn revoke_msa_delegation_by_delegator() -> Weight {
 		Weight::from_ref_time(15_000_000 as u64)
 			.saturating_add(RocksDbWeight::get().reads(2 as u64))
 			.saturating_add(RocksDbWeight::get().writes(1 as u64))
 	}
-	// Storage: Msa MessageSourceIdOf (r:1 w:0)
+	// Storage: Msa PublicKeyToMsaId (r:1 w:0)
 	// Storage: Msa ProviderRegistry (r:1 w:1)
 	fn register_provider() -> Weight {
 		Weight::from_ref_time(13_000_000 as u64)


### PR DESCRIPTION
# Goal
The goal of this PR is to rename the `MessageSourceIdOf` Storage.

# Discussion
This partially completes #508

# Checklist
- [x] Tests added
- [x] Benchmarks added
