### PR TITLE
Rename: register_provider -> create_provider

### DIFF
--- a/designdocs/provider_registration.md
+++ b/designdocs/provider_registration.md
@@ -65,7 +65,7 @@ Please note:
     paid and their registration was otherwise successful.
 
 ### Extrinsics
-#### register_provider(origin, provider_name)
+#### create_provider(origin, provider_name)
 Creates and posts a `ProviderRegistrationEvent`. The `MsaId`
 included in the registration must already exist.
 

--- a/pallets/messages/src/weights.rs
+++ b/pallets/messages/src/weights.rs
@@ -63,7 +63,7 @@ pub trait WeightInfo {
 pub struct SubstrateWeight<T>(PhantomData<T>);
 impl<T: frame_system::Config> WeightInfo for SubstrateWeight<T> {
 	// Storage: Schemas Schemas (r:1 w:0)
-	// Storage: Msa MessageSourceIdOf (r:1 w:0)
+	// Storage: Msa PublicKeyToMsaId (r:1 w:0)
 	// Storage: Msa ProviderInfoOf (r:1 w:0)
 	// Storage: Messages BlockMessages (r:1 w:1)
 	fn add_onchain_message(n: u32, m: u32, ) -> Weight {
@@ -76,7 +76,7 @@ impl<T: frame_system::Config> WeightInfo for SubstrateWeight<T> {
 			.saturating_add(T::DbWeight::get().writes(1 as u64))
 	}
 	// Storage: Schemas Schemas (r:1 w:0)
-	// Storage: Msa MessageSourceIdOf (r:1 w:0)
+	// Storage: Msa PublicKeyToMsaId (r:1 w:0)
 	// Storage: Messages BlockMessages (r:1 w:1)
 	fn add_ipfs_message(n: u32, m: u32, ) -> Weight {
 		Weight::from_ref_time(2_349_000 as u64)
@@ -103,7 +103,7 @@ impl<T: frame_system::Config> WeightInfo for SubstrateWeight<T> {
 // For backwards compatibility and tests
 impl WeightInfo for () {
 	// Storage: Schemas Schemas (r:1 w:0)
-	// Storage: Msa MessageSourceIdOf (r:1 w:0)
+	// Storage: Msa PublicKeyToMsaId (r:1 w:0)
 	// Storage: Msa ProviderInfoOf (r:1 w:0)
 	// Storage: Messages BlockMessages (r:1 w:1)
 	fn add_onchain_message(n: u32, m: u32, ) -> Weight {
@@ -116,7 +116,7 @@ impl WeightInfo for () {
 			.saturating_add(RocksDbWeight::get().writes(1 as u64))
 	}
 	// Storage: Schemas Schemas (r:1 w:0)
-	// Storage: Msa MessageSourceIdOf (r:1 w:0)
+	// Storage: Msa PublicKeyToMsaId (r:1 w:0)
 	// Storage: Messages BlockMessages (r:1 w:1)
 	fn add_ipfs_message(n: u32, m: u32, ) -> Weight {
 		Weight::from_ref_time(2_349_000 as u64)

--- a/pallets/msa/src/benchmarking.rs
+++ b/pallets/msa/src/benchmarking.rs
@@ -97,7 +97,7 @@ benchmarks! {
 	create_sponsored_account_with_delegation {
 		let caller: T::AccountId = whitelisted_caller();
 		assert_ok!(Msa::<T>::create(RawOrigin::Signed(caller.clone()).into()));
-		assert_ok!(Msa::<T>::register_provider(RawOrigin::Signed(caller.clone()).into(),Vec::from("Foo")));
+		assert_ok!(Msa::<T>::create_provider(RawOrigin::Signed(caller.clone()).into(),Vec::from("Foo")));
 
 		let (payload, signature, key) = create_payload_and_signature::<T>();
 
@@ -148,7 +148,7 @@ benchmarks! {
 		let (payload, signature, key) = create_payload_and_signature::<T>();
 
 		assert_ok!(Msa::<T>::create(RawOrigin::Signed(caller.clone()).into()));
-		assert_ok!(Msa::<T>::register_provider(RawOrigin::Signed(caller.clone()).into(),Vec::from("Foo")));
+		assert_ok!(Msa::<T>::create_provider(RawOrigin::Signed(caller.clone()).into(),Vec::from("Foo")));
 		assert_ok!(Msa::<T>::create(RawOrigin::Signed(key.clone()).into()));
 
 	}: _ (RawOrigin::Signed(caller), key, signature, payload)
@@ -161,7 +161,7 @@ benchmarks! {
 
 	}: _ (RawOrigin::Signed(delegator), provider_msa_id)
 
-	register_provider {
+	create_provider {
 		let (provider, _provider_msa_id) = create_account_with_msa_id::<T>(1);
 	}: _ (RawOrigin::Signed(provider), Vec::from("Foo"))
 

--- a/pallets/msa/src/lib.rs
+++ b/pallets/msa/src/lib.rs
@@ -426,8 +426,8 @@ pub mod pallet {
 		/// ## Errors
 		/// - Returns
 		///   [`DuplicateProviderMetadata`](Error::DuplicateProviderMetadata) if there is already a ProviderMetadata associated with the given MSA id.
-		#[pallet::weight(T::WeightInfo::register_provider())]
-		pub fn register_provider(origin: OriginFor<T>, provider_name: Vec<u8>) -> DispatchResult {
+		#[pallet::weight(T::WeightInfo::create_provider())]
+		pub fn create_provider(origin: OriginFor<T>, provider_name: Vec<u8>) -> DispatchResult {
 			let provider_key = ensure_signed(origin)?;
 			let bounded_name: BoundedVec<u8, T::MaxProviderNameSize> =
 				provider_name.try_into().map_err(|_| Error::<T>::ExceedsMaxProviderNameSize)?;

--- a/pallets/msa/src/lib.rs
+++ b/pallets/msa/src/lib.rs
@@ -186,8 +186,8 @@ pub mod pallet {
 	/// - Key: AccountId
 	/// - Value: [`MessageSourceId`]
 	#[pallet::storage]
-	#[pallet::getter(fn get_msa_by_account_id)]
-	pub type MessageSourceIdOf<T: Config> =
+	#[pallet::getter(fn get_msa_by_public_key)]
+	pub type PublicKeyToMsaId<T: Config> =
 		StorageMap<_, Twox64Concat, T::AccountId, MessageSourceId, OptionQuery>;
 
 	/// Storage type for a reference counter of the number of keys associated to an MSA
@@ -701,7 +701,7 @@ impl<T: Config> Pallet<T> {
 	where
 		F: FnOnce(MessageSourceId) -> DispatchResult,
 	{
-		MessageSourceIdOf::<T>::try_mutate(key, |maybe_msa_id| {
+		PublicKeyToMsaId::<T>::try_mutate(key, |maybe_msa_id| {
 			ensure!(maybe_msa_id.is_none(), Error::<T>::KeyAlreadyRegistered);
 			*maybe_msa_id = Some(msa_id);
 
@@ -851,7 +851,7 @@ impl<T: Config> Pallet<T> {
 	/// # Errors
 	/// * [`Error::<T>::NoKeyExists`] - If the key does not exist in the MSA
 	pub fn delete_key_for_msa(msa_id: MessageSourceId, key: &T::AccountId) -> DispatchResult {
-		MessageSourceIdOf::<T>::try_mutate_exists(key, |maybe_msa_id| {
+		PublicKeyToMsaId::<T>::try_mutate_exists(key, |maybe_msa_id| {
 			ensure!(maybe_msa_id.is_some(), Error::<T>::NoKeyExists);
 
 			// Delete the key if it exists
@@ -918,7 +918,7 @@ impl<T: Config> Pallet<T> {
 	pub fn try_get_msa_from_account_id(
 		key: &T::AccountId,
 	) -> Result<MessageSourceId, DispatchError> {
-		let info = Self::get_msa_by_account_id(key).ok_or(Error::<T>::NoKeyExists)?;
+		let info = Self::get_msa_by_public_key(key).ok_or(Error::<T>::NoKeyExists)?;
 		Ok(info)
 	}
 
@@ -928,7 +928,7 @@ impl<T: Config> Pallet<T> {
 	/// # Returns
 	/// * [`MessageSourceId`]
 	pub fn get_owner_of(key: &T::AccountId) -> Option<MessageSourceId> {
-		Self::get_msa_by_account_id(&key)
+		Self::get_msa_by_public_key(&key)
 	}
 
 	// *Temporarily Removed* until https://github.com/LibertyDSNP/frequency/issues/418

--- a/pallets/msa/src/mock.rs
+++ b/pallets/msa/src/mock.rs
@@ -186,7 +186,7 @@ pub fn test_create_delegator_msa_with_provider() -> (u64, Public) {
 		create_and_sign_add_provider_payload(delegator_key_pair, provider_msa_id);
 
 	// Register provider
-	assert_ok!(Msa::register_provider(Origin::signed(provider_account.into()), Vec::from("Foo")));
+	assert_ok!(Msa::create_provider(Origin::signed(provider_account.into()), Vec::from("Foo")));
 
 	assert_ok!(Msa::add_provider_to_msa(
 		Origin::signed(provider_account.into()),

--- a/pallets/msa/src/tests.rs
+++ b/pallets/msa/src/tests.rs
@@ -1500,7 +1500,7 @@ fn create_provider() {
 }
 
 #[test]
-fn register_provider_max_size_exceeded() {
+fn create_provider_max_size_exceeded() {
 	new_test_ext().execute_with(|| {
 		let (key_pair, _) = sr25519::Pair::generate();
 		let (_new_msa_id, _) =
@@ -1516,7 +1516,7 @@ fn register_provider_max_size_exceeded() {
 }
 
 #[test]
-fn register_provider_duplicate() {
+fn create_provider_duplicate() {
 	new_test_ext().execute_with(|| {
 		let (key_pair, _) = sr25519::Pair::generate();
 		let (_new_msa_id, _) =

--- a/pallets/msa/src/tests.rs
+++ b/pallets/msa/src/tests.rs
@@ -10,11 +10,11 @@ use crate::{
 	mock::*,
 	types::{AddKeyData, AddProvider, EMPTY_FUNCTION},
 	CheckFreeExtrinsicUse, Config, DispatchResult, Error, Event, MsaIdentifier,
-	PayloadSignatureRegistry, ProviderRegistry,
+	PayloadSignatureRegistry, ProviderToRegistryEntry,
 };
 
 use common_primitives::{
-	msa::{Delegator, MessageSourceId, Provider, ProviderInfo, ProviderMetadata},
+	msa::{Delegator, MessageSourceId, Provider, ProviderInfo, ProviderRegistryEntry},
 	node::BlockNumber,
 	schema::SchemaId,
 	utils::wrap_binary_data,
@@ -2007,8 +2007,8 @@ pub fn is_registered_provider_is_true() {
 		let provider = Provider(1);
 		let provider_name = Vec::from("frequency".as_bytes()).try_into().unwrap();
 
-		let provider_meta = ProviderMetadata { provider_name };
-		ProviderRegistry::<Test>::insert(provider, provider_meta);
+		let provider_meta = ProviderRegistryEntry { provider_name };
+		ProviderToRegistryEntry::<Test>::insert(provider, provider_meta);
 
 		assert!(Msa::is_registered_provider(provider.into()));
 	});

--- a/pallets/msa/src/tests.rs
+++ b/pallets/msa/src/tests.rs
@@ -382,10 +382,7 @@ fn test_retire_msa_success() {
 			Msa::try_get_msa_from_account_id(&AccountId32::new(provider_account.0)).unwrap();
 
 		// Register provider
-		assert_ok!(Msa::register_provider(
-			Origin::signed(provider_account.into()),
-			Vec::from("Foo")
-		));
+		assert_ok!(Msa::create_provider(Origin::signed(provider_account.into()), Vec::from("Foo")));
 
 		let (delegator_signature, add_provider_payload) =
 			create_and_sign_add_provider_payload(test_account_key_pair, provider_msa_id);
@@ -418,7 +415,7 @@ fn test_retire_msa_fails_if_registered_provider() {
 		assert_ok!(Msa::add_key(2, &test_public(1), EMPTY_FUNCTION));
 
 		// Register provider
-		assert_ok!(Msa::register_provider(test_origin_signed(1), Vec::from("Foo")));
+		assert_ok!(Msa::create_provider(test_origin_signed(1), Vec::from("Foo")));
 
 		// Retire MSA
 		assert_noop!(
@@ -505,10 +502,7 @@ pub fn add_provider_to_msa_is_success() {
 			Msa::try_get_msa_from_account_id(&AccountId32::new(delegator_account.0)).unwrap();
 
 		// Register provider
-		assert_ok!(Msa::register_provider(
-			Origin::signed(provider_account.into()),
-			Vec::from("Foo")
-		));
+		assert_ok!(Msa::create_provider(Origin::signed(provider_account.into()), Vec::from("Foo")));
 
 		let (delegator_signature, add_provider_payload) =
 			create_and_sign_add_provider_payload(delegator_pair, provider_msa);
@@ -659,10 +653,7 @@ pub fn add_provider_to_msa_throws_unauthorized_delegator_error() {
 		assert_ok!(Msa::create(Origin::signed(provider_account.into())));
 
 		// Register provider
-		assert_ok!(Msa::register_provider(
-			Origin::signed(provider_account.into()),
-			Vec::from("Foo")
-		));
+		assert_ok!(Msa::create_provider(Origin::signed(provider_account.into()), Vec::from("Foo")));
 
 		assert_noop!(
 			Msa::add_provider_to_msa(
@@ -707,10 +698,7 @@ pub fn create_sponsored_account_with_delegation_with_valid_input_should_succeed(
 		assert_ok!(Msa::create(Origin::signed(provider_account.into())));
 
 		// Register provider
-		assert_ok!(Msa::register_provider(
-			Origin::signed(provider_account.into()),
-			Vec::from("Foo")
-		));
+		assert_ok!(Msa::create_provider(Origin::signed(provider_account.into()), Vec::from("Foo")));
 
 		// act
 		assert_ok!(Msa::create_sponsored_account_with_delegation(
@@ -794,10 +782,7 @@ pub fn create_sponsored_account_with_delegation_with_invalid_add_provider_should
 		assert_ok!(Msa::create(Origin::signed(delegator_account.into())));
 
 		// Register provider
-		assert_ok!(Msa::register_provider(
-			Origin::signed(provider_account.into()),
-			Vec::from("Foo")
-		));
+		assert_ok!(Msa::create_provider(Origin::signed(provider_account.into()), Vec::from("Foo")));
 
 		// act
 		assert_noop!(
@@ -863,10 +848,7 @@ pub fn create_sponsored_account_with_delegation_expired() {
 		assert_ok!(Msa::create(Origin::signed(provider_account.into())));
 
 		// Register provider
-		assert_ok!(Msa::register_provider(
-			Origin::signed(provider_account.into()),
-			Vec::from("Foo")
-		));
+		assert_ok!(Msa::create_provider(Origin::signed(provider_account.into()), Vec::from("Foo")));
 
 		// act
 		assert_noop!(
@@ -940,10 +922,7 @@ pub fn revoke_msa_delegation_by_delegator_is_successful() {
 		assert_ok!(Msa::create(Origin::signed(provider_account.into())));
 
 		// Register provider
-		assert_ok!(Msa::register_provider(
-			Origin::signed(provider_account.into()),
-			Vec::from("Foo")
-		));
+		assert_ok!(Msa::create_provider(Origin::signed(provider_account.into()), Vec::from("Foo")));
 
 		let provider_msa =
 			Msa::try_get_msa_from_account_id(&AccountId32::new(provider_account.0)).unwrap();
@@ -988,10 +967,7 @@ pub fn revoke_provider_is_successful() {
 			create_and_sign_add_provider_payload(delegator_pair, provider_msa);
 
 		// Register provider
-		assert_ok!(Msa::register_provider(
-			Origin::signed(provider_account.into()),
-			Vec::from("Foo")
-		));
+		assert_ok!(Msa::create_provider(Origin::signed(provider_account.into()), Vec::from("Foo")));
 
 		assert_ok!(Msa::add_provider_to_msa(
 			Origin::signed(provider_account.into()),
@@ -1068,10 +1044,7 @@ fn revoke_provider_throws_error_when_delegation_already_revoked() {
 			create_and_sign_add_provider_payload(delegator_pair, provider_msa);
 
 		// Register provider
-		assert_ok!(Msa::register_provider(
-			Origin::signed(provider_account.into()),
-			Vec::from("Foo")
-		));
+		assert_ok!(Msa::create_provider(Origin::signed(provider_account.into()), Vec::from("Foo")));
 
 		assert_ok!(Msa::add_provider_to_msa(
 			Origin::signed(provider_account.into()),
@@ -1112,7 +1085,7 @@ pub fn revoke_provider_call_has_no_cost() {
 		assert_ok!(Msa::create(Origin::signed(provider_account.into())));
 
 		// Register provider
-		assert_ok!(Msa::register_provider(test_origin_signed(1), Vec::from("Foo")));
+		assert_ok!(Msa::create_provider(test_origin_signed(1), Vec::from("Foo")));
 
 		assert_ok!(Msa::add_provider_to_msa(
 			test_origin_signed(1),
@@ -1169,7 +1142,7 @@ pub fn revoke_delegation_by_provider_happy_path() {
 		assert_ok!(Msa::create(Origin::signed(provider_key.into()))); // MSA = 1
 
 		// Register provider
-		assert_ok!(Msa::register_provider(Origin::signed(provider_key.into()), Vec::from("Foo")));
+		assert_ok!(Msa::create_provider(Origin::signed(provider_key.into()), Vec::from("Foo")));
 
 		// 3. create delegator MSA and provider to provider
 		let expiration: BlockNumber = 10;
@@ -1514,12 +1487,12 @@ fn add_removed_key_to_msa_pass() {
 }
 
 #[test]
-fn register_provider() {
+fn create_provider() {
 	new_test_ext().execute_with(|| {
 		let (key_pair, _) = sr25519::Pair::generate();
 		let (_new_msa_id, _) =
 			Msa::create_account(key_pair.public().into(), EMPTY_FUNCTION).unwrap();
-		assert_ok!(Msa::register_provider(
+		assert_ok!(Msa::create_provider(
 			Origin::signed(key_pair.public().into()),
 			Vec::from("Foo")
 		));
@@ -1533,7 +1506,7 @@ fn register_provider_max_size_exceeded() {
 		let (_new_msa_id, _) =
 			Msa::create_account(key_pair.public().into(), EMPTY_FUNCTION).unwrap();
 		assert_err!(
-			Msa::register_provider(
+			Msa::create_provider(
 				Origin::signed(key_pair.public().into()),
 				Vec::from("12345678901234567")
 			),
@@ -1548,13 +1521,13 @@ fn register_provider_duplicate() {
 		let (key_pair, _) = sr25519::Pair::generate();
 		let (_new_msa_id, _) =
 			Msa::create_account(key_pair.public().into(), EMPTY_FUNCTION).unwrap();
-		assert_ok!(Msa::register_provider(
+		assert_ok!(Msa::create_provider(
 			Origin::signed(key_pair.public().into()),
 			Vec::from("Foo")
 		));
 
 		assert_err!(
-			Msa::register_provider(Origin::signed(key_pair.public().into()), Vec::from("Foo")),
+			Msa::create_provider(Origin::signed(key_pair.public().into()), Vec::from("Foo")),
 			Error::<Test>::DuplicateProviderMetadata
 		)
 	})
@@ -1685,7 +1658,7 @@ pub fn replaying_create_sponsored_account_with_delegation_fails() {
 
 		// create MSA for provider and register them
 		assert_ok!(Msa::create(Origin::signed(provider_key.into())));
-		assert_ok!(Msa::register_provider(Origin::signed(provider_key.into()), Vec::from("Foo")));
+		assert_ok!(Msa::create_provider(Origin::signed(provider_key.into()), Vec::from("Foo")));
 
 		// Step 1
 		assert_ok!(Msa::create_sponsored_account_with_delegation(
@@ -1766,7 +1739,7 @@ fn replaying_add_provider_to_msa_fails() {
 
 		// create MSA for provider and register them
 		assert_ok!(Msa::create(Origin::signed(provider_key.into())));
-		assert_ok!(Msa::register_provider(Origin::signed(provider_key.into()), Vec::from("Foo")));
+		assert_ok!(Msa::create_provider(Origin::signed(provider_key.into()), Vec::from("Foo")));
 
 		// create MSA for delegator
 		assert_ok!(Msa::create(Origin::signed(delegator_key.into())));
@@ -1920,7 +1893,7 @@ pub fn add_provider_expired() {
 		assert_ok!(Msa::create(Origin::signed(provider_key.into()))); // MSA = 1
 
 		// Register provider
-		assert_ok!(Msa::register_provider(Origin::signed(provider_key.into()), Vec::from("Foo")));
+		assert_ok!(Msa::create_provider(Origin::signed(provider_key.into()), Vec::from("Foo")));
 
 		// 3. create delegator MSA and provider to provider
 		let expiration: BlockNumber = 0;

--- a/pallets/msa/src/tests.rs
+++ b/pallets/msa/src/tests.rs
@@ -26,7 +26,7 @@ fn it_creates_an_msa_account() {
 	new_test_ext().execute_with(|| {
 		assert_ok!(Msa::create(test_origin_signed(1)));
 
-		assert_eq!(Msa::get_msa_by_account_id(test_public(1)), Some(1 as MessageSourceId));
+		assert_eq!(Msa::get_msa_by_public_key(test_public(1)), Some(1 as MessageSourceId));
 
 		assert_eq!(Msa::get_identifier(), 1);
 
@@ -299,7 +299,7 @@ fn it_deletes_msa_key_successfully() {
 
 		assert_ok!(Msa::delete_msa_key(test_origin_signed(1), test_public(2)));
 
-		let info = Msa::get_msa_by_account_id(&test_public(2));
+		let info = Msa::get_msa_by_public_key(&test_public(2));
 
 		assert_eq!(info, None);
 
@@ -457,7 +457,7 @@ pub fn test_delete_key() {
 	new_test_ext().execute_with(|| {
 		assert_ok!(Msa::add_key(1, &test_public(1), EMPTY_FUNCTION));
 
-		let info = Msa::get_msa_by_account_id(&test_public(1));
+		let info = Msa::get_msa_by_public_key(&test_public(1));
 
 		assert_eq!(info, Some(1 as MessageSourceId));
 
@@ -721,7 +721,7 @@ pub fn create_sponsored_account_with_delegation_with_valid_input_should_succeed(
 		));
 
 		// assert
-		let key_info = Msa::get_msa_by_account_id(&AccountId32::new(delegator_account.0));
+		let key_info = Msa::get_msa_by_public_key(&AccountId32::new(delegator_account.0));
 		assert_eq!(key_info.unwrap(), 2);
 
 		let provider_info = Msa::get_provider_info(Delegator(2), Provider(1));
@@ -898,7 +898,7 @@ pub fn add_key_with_panic_in_on_success_should_revert_everything() {
 		);
 
 		// assert
-		assert_eq!(Msa::get_msa_by_account_id(&key), None);
+		assert_eq!(Msa::get_msa_by_public_key(&key), None);
 
 		// *Temporarily Removed* until https://github.com/LibertyDSNP/frequency/issues/418 is completed
 		// assert_eq!(Msa::get_msa_keys(msa_id).into_inner(), vec![])

--- a/pallets/msa/src/weights.rs
+++ b/pallets/msa/src/weights.rs
@@ -70,7 +70,7 @@ pub trait WeightInfo {
 pub struct SubstrateWeight<T>(PhantomData<T>);
 impl<T: frame_system::Config> WeightInfo for SubstrateWeight<T> {
 	// Storage: Msa MsaIdentifier (r:1 w:1)
-	// Storage: Msa MessageSourceIdOf (r:1 w:1)
+	// Storage: Msa PublicKeyToMsaId (r:1 w:1)
 	// Storage: Msa MsaInfoOf (r:1 w:1)
 	fn create(s: u32, ) -> Weight {
 		Weight::from_ref_time(17_462_000 as u64)
@@ -80,7 +80,7 @@ impl<T: frame_system::Config> WeightInfo for SubstrateWeight<T> {
 			.saturating_add(T::DbWeight::get().writes(3 as u64))
 	}
 	// Storage: Msa PayloadSignatureRegistry (r:1 w:1)
-	// Storage: Msa MessageSourceIdOf (r:2 w:1)
+	// Storage: Msa PublicKeyToMsaId (r:2 w:1)
 	// Storage: Msa ProviderRegistry (r:1 w:0)
 	// Storage: Msa MsaIdentifier (r:1 w:1)
 	// Storage: Msa MsaInfoOf (r:1 w:1)
@@ -90,7 +90,7 @@ impl<T: frame_system::Config> WeightInfo for SubstrateWeight<T> {
 			.saturating_add(T::DbWeight::get().reads(7 as u64))
 			.saturating_add(T::DbWeight::get().writes(5 as u64))
 	}
-	// Storage: Msa MessageSourceIdOf (r:1 w:0)
+	// Storage: Msa PublicKeyToMsaId (r:1 w:0)
 	// Storage: Msa ProviderInfoOf (r:1 w:1)
 	fn revoke_delegation_by_provider(s: u32, ) -> Weight {
 		Weight::from_ref_time(18_059_000 as u64)
@@ -100,21 +100,21 @@ impl<T: frame_system::Config> WeightInfo for SubstrateWeight<T> {
 			.saturating_add(T::DbWeight::get().writes(1 as u64))
 	}
 	// Storage: Msa PayloadSignatureRegistry (r:1 w:1)
-	// Storage: Msa MessageSourceIdOf (r:2 w:1)
+	// Storage: Msa PublicKeyToMsaId (r:2 w:1)
 	// Storage: Msa MsaInfoOf (r:1 w:1)
 	fn add_key_to_msa() -> Weight {
 		Weight::from_ref_time(55_000_000 as u64)
 			.saturating_add(T::DbWeight::get().reads(4 as u64))
 			.saturating_add(T::DbWeight::get().writes(3 as u64))
 	}
-	// Storage: Msa MessageSourceIdOf (r:2 w:1)
+	// Storage: Msa PublicKeyToMsaId (r:2 w:1)
 	// Storage: Msa MsaInfoOf (r:1 w:1)
 	fn delete_msa_key() -> Weight {
 		Weight::from_ref_time(18_000_000 as u64)
 			.saturating_add(T::DbWeight::get().reads(3 as u64))
 			.saturating_add(T::DbWeight::get().writes(2 as u64))
 	}
-	// Storage: Msa MessageSourceIdOf (r:1 w:1)
+	// Storage: Msa PublicKeyToMsaId (r:1 w:1)
 	// Storage: Msa ProviderRegistry (r:1 w:0)
 	// Storage: Msa MsaInfoOf (r:1 w:1)
 	fn retire_msa() -> Weight {
@@ -123,7 +123,7 @@ impl<T: frame_system::Config> WeightInfo for SubstrateWeight<T> {
 			.saturating_add(T::DbWeight::get().writes(2 as u64))
 	}
 	// Storage: Msa PayloadSignatureRegistry (r:1 w:1)
-	// Storage: Msa MessageSourceIdOf (r:2 w:0)
+	// Storage: Msa PublicKeyToMsaId (r:2 w:0)
 	// Storage: Msa ProviderRegistry (r:1 w:0)
 	// Storage: Msa ProviderInfoOf (r:1 w:1)
 	fn add_provider_to_msa() -> Weight {
@@ -131,14 +131,14 @@ impl<T: frame_system::Config> WeightInfo for SubstrateWeight<T> {
 			.saturating_add(T::DbWeight::get().reads(5 as u64))
 			.saturating_add(T::DbWeight::get().writes(2 as u64))
 	}
-	// Storage: Msa MessageSourceIdOf (r:1 w:0)
+	// Storage: Msa PublicKeyToMsaId (r:1 w:0)
 	// Storage: Msa ProviderInfoOf (r:1 w:1)
 	fn revoke_msa_delegation_by_delegator() -> Weight {
 		Weight::from_ref_time(15_000_000 as u64)
 			.saturating_add(T::DbWeight::get().reads(2 as u64))
 			.saturating_add(T::DbWeight::get().writes(1 as u64))
 	}
-	// Storage: Msa MessageSourceIdOf (r:1 w:0)
+	// Storage: Msa PublicKeyToMsaId (r:1 w:0)
 	// Storage: Msa ProviderRegistry (r:1 w:1)
 	fn register_provider() -> Weight {
 		Weight::from_ref_time(13_000_000 as u64)
@@ -155,7 +155,7 @@ impl<T: frame_system::Config> WeightInfo for SubstrateWeight<T> {
 // For backwards compatibility and tests
 impl WeightInfo for () {
 	// Storage: Msa MsaIdentifier (r:1 w:1)
-	// Storage: Msa MessageSourceIdOf (r:1 w:1)
+	// Storage: Msa PublicKeyToMsaId (r:1 w:1)
 	// Storage: Msa MsaInfoOf (r:1 w:1)
 	fn create(s: u32, ) -> Weight {
 		Weight::from_ref_time(17_462_000 as u64)
@@ -165,7 +165,7 @@ impl WeightInfo for () {
 			.saturating_add(RocksDbWeight::get().writes(3 as u64))
 	}
 	// Storage: Msa PayloadSignatureRegistry (r:1 w:1)
-	// Storage: Msa MessageSourceIdOf (r:2 w:1)
+	// Storage: Msa PublicKeyToMsaId (r:2 w:1)
 	// Storage: Msa ProviderRegistry (r:1 w:0)
 	// Storage: Msa MsaIdentifier (r:1 w:1)
 	// Storage: Msa MsaInfoOf (r:1 w:1)
@@ -175,7 +175,7 @@ impl WeightInfo for () {
 			.saturating_add(RocksDbWeight::get().reads(7 as u64))
 			.saturating_add(RocksDbWeight::get().writes(5 as u64))
 	}
-	// Storage: Msa MessageSourceIdOf (r:1 w:0)
+	// Storage: Msa PublicKeyToMsaId (r:1 w:0)
 	// Storage: Msa ProviderInfoOf (r:1 w:1)
 	fn revoke_delegation_by_provider(s: u32, ) -> Weight {
 		Weight::from_ref_time(18_059_000 as u64)
@@ -185,21 +185,21 @@ impl WeightInfo for () {
 			.saturating_add(RocksDbWeight::get().writes(1 as u64))
 	}
 	// Storage: Msa PayloadSignatureRegistry (r:1 w:1)
-	// Storage: Msa MessageSourceIdOf (r:2 w:1)
+	// Storage: Msa PublicKeyToMsaId (r:2 w:1)
 	// Storage: Msa MsaInfoOf (r:1 w:1)
 	fn add_key_to_msa() -> Weight {
 		Weight::from_ref_time(55_000_000 as u64)
 			.saturating_add(RocksDbWeight::get().reads(4 as u64))
 			.saturating_add(RocksDbWeight::get().writes(3 as u64))
 	}
-	// Storage: Msa MessageSourceIdOf (r:2 w:1)
+	// Storage: Msa PublicKeyToMsaId (r:2 w:1)
 	// Storage: Msa MsaInfoOf (r:1 w:1)
 	fn delete_msa_key() -> Weight {
 		Weight::from_ref_time(18_000_000 as u64)
 			.saturating_add(RocksDbWeight::get().reads(3 as u64))
 			.saturating_add(RocksDbWeight::get().writes(2 as u64))
 	}
-	// Storage: Msa MessageSourceIdOf (r:1 w:1)
+	// Storage: Msa PublicKeyToMsaId (r:1 w:1)
 	// Storage: Msa ProviderRegistry (r:1 w:0)
 	// Storage: Msa MsaInfoOf (r:1 w:1)
 	fn retire_msa() -> Weight {
@@ -208,7 +208,7 @@ impl WeightInfo for () {
 			.saturating_add(RocksDbWeight::get().writes(2 as u64))
 	}
 	// Storage: Msa PayloadSignatureRegistry (r:1 w:1)
-	// Storage: Msa MessageSourceIdOf (r:2 w:0)
+	// Storage: Msa PublicKeyToMsaId (r:2 w:0)
 	// Storage: Msa ProviderRegistry (r:1 w:0)
 	// Storage: Msa ProviderInfoOf (r:1 w:1)
 	fn add_provider_to_msa() -> Weight {
@@ -216,14 +216,14 @@ impl WeightInfo for () {
 			.saturating_add(RocksDbWeight::get().reads(5 as u64))
 			.saturating_add(RocksDbWeight::get().writes(2 as u64))
 	}
-	// Storage: Msa MessageSourceIdOf (r:1 w:0)
+	// Storage: Msa PublicKeyToMsaId (r:1 w:0)
 	// Storage: Msa ProviderInfoOf (r:1 w:1)
 	fn revoke_msa_delegation_by_delegator() -> Weight {
 		Weight::from_ref_time(15_000_000 as u64)
 			.saturating_add(RocksDbWeight::get().reads(2 as u64))
 			.saturating_add(RocksDbWeight::get().writes(1 as u64))
 	}
-	// Storage: Msa MessageSourceIdOf (r:1 w:0)
+	// Storage: Msa PublicKeyToMsaId (r:1 w:0)
 	// Storage: Msa ProviderRegistry (r:1 w:1)
 	fn register_provider() -> Weight {
 		Weight::from_ref_time(13_000_000 as u64)

--- a/pallets/msa/src/weights.rs
+++ b/pallets/msa/src/weights.rs
@@ -62,7 +62,7 @@ pub trait WeightInfo {
 	fn retire_msa() -> Weight;
 	fn add_provider_to_msa() -> Weight;
 	fn revoke_msa_delegation_by_delegator() -> Weight;
-	fn register_provider() -> Weight;
+	fn create_provider() -> Weight;
 	fn on_initialize(m: u32, ) -> Weight;
 }
 
@@ -140,7 +140,7 @@ impl<T: frame_system::Config> WeightInfo for SubstrateWeight<T> {
 	}
 	// Storage: Msa PublicKeyToMsaId (r:1 w:0)
 	// Storage: Msa ProviderRegistry (r:1 w:1)
-	fn register_provider() -> Weight {
+	fn create_provider() -> Weight {
 		Weight::from_ref_time(13_000_000 as u64)
 			.saturating_add(T::DbWeight::get().reads(2 as u64))
 			.saturating_add(T::DbWeight::get().writes(1 as u64))
@@ -225,7 +225,7 @@ impl WeightInfo for () {
 	}
 	// Storage: Msa PublicKeyToMsaId (r:1 w:0)
 	// Storage: Msa ProviderRegistry (r:1 w:1)
-	fn register_provider() -> Weight {
+	fn create_provider() -> Weight {
 		Weight::from_ref_time(13_000_000 as u64)
 			.saturating_add(RocksDbWeight::get().reads(2 as u64))
 			.saturating_add(RocksDbWeight::get().writes(1 as u64))


### PR DESCRIPTION
# Goal
The goal of this PR is to rename the `register_provider` extrinsic.

# Discussion
This PR partially completes #508 

# Checklist
- [x] Design doc(s) updated
- [x] Tests added
- [x] Benchmarks added
