### PR TITLE
Rename: add_provider_to_msa -> grant_delegation

### DIFF
--- a/pallets/msa/src/benchmarking.rs
+++ b/pallets/msa/src/benchmarking.rs
@@ -145,8 +145,7 @@ benchmarks! {
 
 	}: _(RawOrigin::Signed(caller))
 
-	add_provider_to_msa {
-
+	grant_delegation {
 		let caller: T::AccountId = whitelisted_caller();
 		let (payload, signature, key) = create_payload_and_signature::<T>();
 

--- a/pallets/msa/src/lib.rs
+++ b/pallets/msa/src/lib.rs
@@ -38,7 +38,7 @@
 //! ### Dispatchable Functions
 //!
 //! - `add_key_to_msa` - Associates a key to an MSA ID in a signed payload.
-//! - `add_provider_to_msa` - Creates a delegation relationship between a `Provider` and MSA.
+//! - `grant_delegation` - Creates a delegation relationship between a `Provider` and MSA.
 //! - `create` - Creates an MSA for the `Origin`.
 //! - `create_sponsored_account_with_delegation` - `Origin` creates an account for a given `AccountId` and sets themselves as a `Provider`.
 //! - `revoke_delegation_by_provider` - `Provider` MSA terminates a Delegation with Delegator MSA by expiring it.
@@ -453,8 +453,8 @@ pub mod pallet {
 		/// - Returns [`NoKeyExists`](Error::NoKeyExists) if there is no MSA for `origin`.
 		/// - Returns [`ProviderNotRegistered`](Error::ProviderNotRegistered) if the a non-provider MSA is used as the provider
 		/// - Returns [`UnauthorizedDelegator`](Error::UnauthorizedDelegator) if Origin attempted to add a delegate for someone else's MSA
-		#[pallet::weight(T::WeightInfo::add_provider_to_msa())]
-		pub fn add_provider_to_msa(
+		#[pallet::weight(T::WeightInfo::grant_delegation())]
+		pub fn grant_delegation(
 			origin: OriginFor<T>,
 			delegator_key: T::AccountId,
 			proof: MultiSignature,

--- a/pallets/msa/src/mock.rs
+++ b/pallets/msa/src/mock.rs
@@ -188,7 +188,7 @@ pub fn test_create_delegator_msa_with_provider() -> (u64, Public) {
 	// Register provider
 	assert_ok!(Msa::register_provider(Origin::signed(provider_account.into()), Vec::from("Foo")));
 
-	assert_ok!(Msa::add_provider_to_msa(
+	assert_ok!(Msa::grant_delegation(
 		Origin::signed(provider_account.into()),
 		delegator_account.into(),
 		delegator_signature,

--- a/pallets/msa/src/tests.rs
+++ b/pallets/msa/src/tests.rs
@@ -414,7 +414,7 @@ fn test_retire_msa_success() {
 			create_and_sign_add_provider_payload(test_account_key_pair, provider_msa_id);
 
 		assert_noop!(
-			Msa::add_provider_to_msa(
+			Msa::grant_delegation(
 				Origin::signed(provider_account.into()),
 				test_account.clone(),
 				delegator_signature,
@@ -538,7 +538,7 @@ pub fn add_provider_to_msa_is_success() {
 
 		Schemas::set_schema_count(10);
 
-		assert_ok!(Msa::add_provider_to_msa(
+		assert_ok!(Msa::grant_delegation(
 			Origin::signed(provider_account.into()),
 			delegator_account.into(),
 			delegator_signature,
@@ -561,7 +561,7 @@ pub fn add_provider_to_msa_is_success() {
 }
 
 #[test]
-pub fn add_provider_to_msa_throws_add_provider_verification_failed() {
+pub fn grant_delegation_to_msa_throws_add_provider_verification_failed() {
 	new_test_ext().execute_with(|| {
 		let (key_pair, _) = sr25519::Pair::generate();
 		let account = key_pair.public();
@@ -572,7 +572,7 @@ pub fn add_provider_to_msa_throws_add_provider_verification_failed() {
 		let signature: MultiSignature = key_pair.sign(&encode_add_provider_data).into();
 		let fake_provider_payload = AddProvider::new(3, None, expiration);
 		assert_noop!(
-			Msa::add_provider_to_msa(
+			Msa::grant_delegation(
 				Origin::signed(account.into()),
 				account.into(),
 				signature,
@@ -584,7 +584,7 @@ pub fn add_provider_to_msa_throws_add_provider_verification_failed() {
 }
 
 #[test]
-pub fn add_provider_to_msa_throws_no_key_exist_error() {
+pub fn grant_delegation_throws_no_key_exist_error() {
 	new_test_ext().execute_with(|| {
 		let (key_pair, _) = sr25519::Pair::generate();
 		let provider_account = key_pair.public();
@@ -596,7 +596,7 @@ pub fn add_provider_to_msa_throws_no_key_exist_error() {
 		let signature: MultiSignature = key_pair.sign(&encode_add_provider_data).into();
 
 		assert_noop!(
-			Msa::add_provider_to_msa(
+			Msa::grant_delegation(
 				test_origin_signed(1),
 				provider_account.into(),
 				signature,
@@ -608,7 +608,7 @@ pub fn add_provider_to_msa_throws_no_key_exist_error() {
 }
 
 #[test]
-pub fn add_provider_to_msa_throws_key_revoked_error() {
+pub fn grant_delegation_throws_key_revoked_error() {
 	new_test_ext().execute_with(|| {
 		let (key_pair, _) = sr25519::Pair::generate();
 		let provider_account = key_pair.public();
@@ -624,7 +624,7 @@ pub fn add_provider_to_msa_throws_key_revoked_error() {
 		assert_ok!(Msa::delete_key_for_msa(1, &test_public(1)));
 
 		assert_noop!(
-			Msa::add_provider_to_msa(
+			Msa::grant_delegation(
 				test_origin_signed(1),
 				provider_account.into(),
 				signature,
@@ -636,7 +636,7 @@ pub fn add_provider_to_msa_throws_key_revoked_error() {
 }
 
 #[test]
-pub fn add_provider_to_msa_throws_invalid_self_provider_error() {
+pub fn grant_delegation_throws_invalid_self_provider_error() {
 	new_test_ext().execute_with(|| {
 		let (key_pair, _) = sr25519::Pair::generate();
 		let provider_account = key_pair.public();
@@ -649,7 +649,7 @@ pub fn add_provider_to_msa_throws_invalid_self_provider_error() {
 		assert_ok!(Msa::create(Origin::signed(provider_account.into())));
 
 		assert_noop!(
-			Msa::add_provider_to_msa(
+			Msa::grant_delegation(
 				Origin::signed(provider_account.into()),
 				provider_account.into(),
 				signature,
@@ -661,7 +661,7 @@ pub fn add_provider_to_msa_throws_invalid_self_provider_error() {
 }
 
 #[test]
-pub fn add_provider_to_msa_throws_unauthorized_delegator_error() {
+pub fn grant_delegation_throws_unauthorized_delegator_error() {
 	new_test_ext().execute_with(|| {
 		// Generate a key pair for the provider
 		let (provider_key_pair, _) = sr25519::Pair::generate();
@@ -688,7 +688,7 @@ pub fn add_provider_to_msa_throws_unauthorized_delegator_error() {
 		));
 
 		assert_noop!(
-			Msa::add_provider_to_msa(
+			Msa::grant_delegation(
 				Origin::signed(provider_account.into()),
 				delegator_account.into(),
 				signature,
@@ -974,7 +974,7 @@ pub fn revoke_msa_delegation_by_delegator_is_successful() {
 		let (delegator_signature, add_provider_payload) =
 			create_and_sign_add_provider_payload(delegator_pair, provider_msa);
 
-		assert_ok!(Msa::add_provider_to_msa(
+		assert_ok!(Msa::grant_delegation(
 			Origin::signed(provider_account.into()),
 			delegator_account.into(),
 			delegator_signature,
@@ -1016,7 +1016,7 @@ pub fn revoke_provider_is_successful() {
 			Vec::from("Foo")
 		));
 
-		assert_ok!(Msa::add_provider_to_msa(
+		assert_ok!(Msa::grant_delegation(
 			Origin::signed(provider_account.into()),
 			delegator_account.into(),
 			delegator_signature,
@@ -1096,7 +1096,7 @@ fn revoke_provider_throws_error_when_delegation_already_revoked() {
 			Vec::from("Foo")
 		));
 
-		assert_ok!(Msa::add_provider_to_msa(
+		assert_ok!(Msa::grant_delegation(
 			Origin::signed(provider_account.into()),
 			delegator_account.into(),
 			delegator_signature,
@@ -1137,7 +1137,7 @@ pub fn revoke_provider_call_has_no_cost() {
 		// Register provider
 		assert_ok!(Msa::register_provider(test_origin_signed(1), Vec::from("Foo")));
 
-		assert_ok!(Msa::add_provider_to_msa(
+		assert_ok!(Msa::grant_delegation(
 			test_origin_signed(1),
 			provider_account.into(),
 			signature,
@@ -1763,7 +1763,7 @@ pub fn replaying_create_sponsored_account_with_delegation_fails() {
 
 		// expect this to fail for the same reason
 		assert_err!(
-			Msa::add_provider_to_msa(
+			Msa::grant_delegation(
 				Origin::signed(provider_key.into()),
 				delegator_key.into(),
 				signature.clone(),
@@ -1779,7 +1779,7 @@ pub fn replaying_create_sponsored_account_with_delegation_fails() {
 //   2. provider removes them as MSA (say by quickly discovering MSA is undesirable)
 //   3. MSA account replays the add, using the previous signed payload + signature.
 #[test]
-fn replaying_add_provider_to_msa_fails() {
+fn replaying_grant_delegation_fails() {
 	new_test_ext().execute_with(|| {
 		let (key_pair, _) = sr25519::Pair::generate();
 		let provider_key = key_pair.public();
@@ -1802,7 +1802,7 @@ fn replaying_add_provider_to_msa_fails() {
 		// create MSA for delegator
 		assert_ok!(Msa::create(Origin::signed(delegator_key.into())));
 
-		assert_ok!(Msa::add_provider_to_msa(
+		assert_ok!(Msa::grant_delegation(
 			Origin::signed(provider_key.into()),
 			delegator_key.into(),
 			signature.clone(),
@@ -1815,7 +1815,7 @@ fn replaying_add_provider_to_msa_fails() {
 
 		// Expected to fail because revoking the delegation just expires it at a given block number.
 		assert_err!(
-			Msa::add_provider_to_msa(
+			Msa::grant_delegation(
 				Origin::signed(provider_key.into()),
 				delegator_key.into(),
 				signature.clone(),
@@ -1961,7 +1961,7 @@ pub fn add_provider_expired() {
 		let signature: MultiSignature = user_pair.sign(&encode_add_provider_data).into();
 		// 3.5 create the user's MSA + add provider as provider
 		assert_err!(
-			Msa::add_provider_to_msa(
+			Msa::grant_delegation(
 				test_origin_signed(1),
 				delegator_key.into(),
 				signature,

--- a/pallets/msa/src/types.rs
+++ b/pallets/msa/src/types.rs
@@ -32,7 +32,7 @@ pub struct AddProvider {
 	/// Schemas for which publishing grants are authorized.
 	/// This is private intended for internal use only.
 	pub schema_ids: Vec<SchemaId>,
-	/// The block number at which the proof for add_provider_to_msa expires.
+	/// The block number at which the proof for grant_delegation expires.
 	pub expiration: BlockNumber,
 }
 

--- a/pallets/msa/src/weights.rs
+++ b/pallets/msa/src/weights.rs
@@ -60,7 +60,7 @@ pub trait WeightInfo {
 	fn add_key_to_msa() -> Weight;
 	fn delete_msa_key() -> Weight;
 	fn retire_msa() -> Weight;
-	fn add_provider_to_msa() -> Weight;
+	fn grant_delegation() -> Weight;
 	fn revoke_msa_delegation_by_delegator() -> Weight;
 	fn register_provider() -> Weight;
 	fn on_initialize(s: u32) -> Weight;
@@ -127,7 +127,7 @@ impl<T: frame_system::Config> WeightInfo for SubstrateWeight<T> {
 	// Storage: Msa PublicKeyToMsaId (r:2 w:0)
 	// Storage: Msa ProviderRegistry (r:1 w:0)
 	// Storage: Msa ProviderInfoOf (r:1 w:1)
-	fn add_provider_to_msa() -> Weight {
+	fn grant_delegation() -> Weight {
 		Weight::from_ref_time(59_000_000 as u64)
 			.saturating_add(T::DbWeight::get().reads(5 as u64))
 			.saturating_add(T::DbWeight::get().writes(2 as u64))
@@ -213,7 +213,7 @@ impl WeightInfo for () {
 	// Storage: Msa PublicKeyToMsaId (r:2 w:0)
 	// Storage: Msa ProviderRegistry (r:1 w:0)
 	// Storage: Msa ProviderInfoOf (r:1 w:1)
-	fn add_provider_to_msa() -> Weight {
+	fn grant_delegation() -> Weight {
 		Weight::from_ref_time(59_000_000 as u64)
 			.saturating_add(RocksDbWeight::get().reads(5 as u64))
 			.saturating_add(RocksDbWeight::get().writes(2 as u64))


### PR DESCRIPTION
# Goal
The goal of this PR is to rename the `add_provider_to_msa` extrinsic.

# Discussion
This PR partiall completes #508.

# Checklist
- [x] Tests added
- [x] Benchmarks added
