### PR TITLE
Rename: revoke_msa_delegation_by_delegator -> revoke_delegation_by_delegator

### DIFF
--- a/designdocs/delegation.md
+++ b/designdocs/delegation.md
@@ -86,7 +86,7 @@ This is a signed call directly from the caller, so the owner of the new MSA pays
   * Events:
     1. `DelegatorRevokedDelegation`
         * `msa_id` - id of the newly created MSA
-#### revoke_msa_delegation_by_delegator
+#### revoke_delegation_by_delegator
 A delegator removes its relationship from a provider.
 This is a signed call directly from the delegator's MSA.
 This call incurs no fees.

--- a/pallets/msa/src/benchmarking.rs
+++ b/pallets/msa/src/benchmarking.rs
@@ -155,8 +155,7 @@ benchmarks! {
 
 	}: _ (RawOrigin::Signed(caller), key, signature, payload)
 
-	revoke_msa_delegation_by_delegator {
-
+	revoke_delegation_by_delegator {
 		let (provider, provider_msa_id) = create_account_with_msa_id::<T>(0);
 		let (delegator, delegator_msa_id) = create_account_with_msa_id::<T>(1);
 		add_delegation::<T>(Delegator(delegator_msa_id), Provider(provider_msa_id.clone()));

--- a/pallets/msa/src/lib.rs
+++ b/pallets/msa/src/lib.rs
@@ -42,7 +42,7 @@
 //! - `create` - Creates an MSA for the `Origin`.
 //! - `create_sponsored_account_with_delegation` - `Origin` creates an account for a given `AccountId` and sets themselves as a `Provider`.
 //! - `revoke_delegation_by_provider` - `Provider` MSA terminates a Delegation with Delegator MSA by expiring it.
-//! - `revoke_msa_delegation_by_delegator` - Delegator MSA terminates a Delegation with the `Provider` MSA by expiring it.
+//! - `revoke_delegation_by_delegator` - Delegator MSA terminates a Delegation with the `Provider` MSA by expiring it.
 //! - `delete_msa_public_key` - Removes the given key by from storage against respective MSA.
 //!
 //! ### Assumptions
@@ -492,8 +492,8 @@ pub mod pallet {
 		/// - Returns [`DelegationNotFound`](Error::DelegationNotFound) if there is not delegation relationship between Origin and Delegator or Origin and Delegator are the same.
 		/// - May also return []
 		///
-		#[pallet::weight((T::WeightInfo::revoke_msa_delegation_by_delegator(), DispatchClass::Normal, Pays::No))]
-		pub fn revoke_msa_delegation_by_delegator(
+		#[pallet::weight((T::WeightInfo::revoke_delegation_by_delegator(), DispatchClass::Normal, Pays::No))]
+		pub fn revoke_delegation_by_delegator(
 			origin: OriginFor<T>,
 			provider_msa_id: MessageSourceId,
 		) -> DispatchResult {
@@ -1209,7 +1209,7 @@ impl<T: Config> SchemaGrantValidator for Pallet<T> {
 
 /// The SignedExtension trait is implemented on CheckFreeExtrinsicUse to validate that a provider
 /// has not already been revoked if the calling extrinsic is revoking a provider to an MSA. The
-/// purpose of this is to ensure that the revoke_msa_delegation_by_delegator extrinsic cannot be
+/// purpose of this is to ensure that the revoke_delegation_by_delegator extrinsic cannot be
 /// repeatedly called and flood the network.
 #[derive(Encode, Decode, Clone, Eq, PartialEq, TypeInfo)]
 #[scale_info(skip_type_params(T))]
@@ -1296,7 +1296,7 @@ where
 	}
 
 	/// Frequently called by the transaction queue to ensure that the transaction is valid such that:
-	/// * The calling extrinsic is 'revoke_msa_delegation_by_delegator'.
+	/// * The calling extrinsic is 'revoke_delegation_by_delegator'.
 	/// * The sender key is associated to an MSA and not revoked.
 	/// * The provider MSA is a valid provider to the delegator MSA.
 	fn validate(
@@ -1307,7 +1307,7 @@ where
 		_len: usize,
 	) -> TransactionValidity {
 		match call.is_sub_type() {
-			Some(Call::revoke_msa_delegation_by_delegator { provider_msa_id, .. }) =>
+			Some(Call::revoke_delegation_by_delegator { provider_msa_id, .. }) =>
 				CheckFreeExtrinsicUse::<T>::validate_delegation_by_delegator(who, provider_msa_id),
 			Some(Call::delete_msa_public_key { key, .. }) =>
 				CheckFreeExtrinsicUse::<T>::validate_key_revocation(who, key),

--- a/pallets/msa/src/tests.rs
+++ b/pallets/msa/src/tests.rs
@@ -428,7 +428,7 @@ fn test_retire_msa_success() {
 
 		// [TEST] Revoking a provider (modifying permissions) should fail
 		assert_noop!(
-			Msa::revoke_msa_delegation_by_delegator(
+			Msa::revoke_delegation_by_delegator(
 				Origin::signed(test_account.clone()),
 				provider_msa_id
 			),
@@ -954,7 +954,7 @@ pub fn create_account_with_panic_in_on_success_should_revert_everything() {
 }
 
 #[test]
-pub fn revoke_msa_delegation_by_delegator_is_successful() {
+pub fn revoke_delegation_by_delegatoris_successful() {
 	new_test_ext().execute_with(|| {
 		let (key_pair, _) = sr25519::Pair::generate();
 		let provider_account = key_pair.public();
@@ -984,7 +984,7 @@ pub fn revoke_msa_delegation_by_delegator_is_successful() {
 			add_provider_payload
 		));
 
-		assert_ok!(Msa::revoke_msa_delegation_by_delegator(
+		assert_ok!(Msa::revoke_delegation_by_delegator(
 			Origin::signed(delegator_account.into()),
 			2
 		));
@@ -1042,34 +1042,34 @@ pub fn revoke_provider_is_successful() {
 }
 
 #[test]
-fn revoke_msa_delegation_by_delegator_fails_when_no_msa() {
+fn revoke_delegation_by_delegator_fails_when_no_msa() {
 	new_test_ext().execute_with(|| {
 		assert_noop!(
-			Msa::revoke_msa_delegation_by_delegator(test_origin_signed(1), 1),
+			Msa::revoke_delegation_by_delegator(test_origin_signed(1), 1),
 			Error::<Test>::NoKeyExists
 		);
 	});
 }
 
 #[test]
-pub fn revoke_msa_delegation_fails_if_only_key_is_revoked() {
+pub fn revoke_delegation_fails_if_only_key_is_revoked() {
 	new_test_ext().execute_with(|| {
 		assert_ok!(Msa::create(test_origin_signed(2)));
 		assert_ok!(Msa::delete_key_for_msa(1, &test_public(2)));
 		assert_noop!(
-			Msa::revoke_msa_delegation_by_delegator(test_origin_signed(2), 1),
+			Msa::revoke_delegation_by_delegator(test_origin_signed(2), 1),
 			Error::<Test>::NoKeyExists
 		);
 	})
 }
 
 #[test]
-pub fn revoke_msa_delegation_by_delegator_fails_if_has_msa_but_no_delegation() {
+pub fn revoke_delegation_by_delegator_fails_if_has_msa_but_no_delegation() {
 	new_test_ext().execute_with(|| {
 		assert_ok!(Msa::create(test_origin_signed(1)));
 		assert_ok!(Msa::create(test_origin_signed(2)));
 		assert_noop!(
-			Msa::revoke_msa_delegation_by_delegator(test_origin_signed(1), 2),
+			Msa::revoke_delegation_by_delegator(test_origin_signed(1), 2),
 			Error::<Test>::DelegationNotFound
 		);
 	})
@@ -1106,13 +1106,13 @@ fn revoke_provider_throws_error_when_delegation_already_revoked() {
 			add_provider_payload
 		));
 
-		assert_ok!(Msa::revoke_msa_delegation_by_delegator(
+		assert_ok!(Msa::revoke_delegation_by_delegator(
 			Origin::signed(delegator_account.into()),
 			provider_msa
 		));
 
 		assert_noop!(
-			Msa::revoke_msa_delegation_by_delegator(
+			Msa::revoke_delegation_by_delegator(
 				Origin::signed(delegator_account.into()),
 				provider_msa
 			),
@@ -1147,7 +1147,7 @@ pub fn revoke_provider_call_has_no_cost() {
 			add_provider_payload
 		));
 
-		let call = MsaCall::<Test>::revoke_msa_delegation_by_delegator { provider_msa_id: 2 };
+		let call = MsaCall::<Test>::revoke_delegation_by_delegator { provider_msa_id: 2 };
 		let dispatch_info = call.get_dispatch_info();
 
 		assert_eq!(dispatch_info.pays_fee, Pays::No);
@@ -1332,11 +1332,11 @@ pub fn delegation_expired() {
 /// Assert that revoking an MSA delegation passes the signed extension CheckFreeExtrinsicUse
 /// validation when a valid delegation exists.
 #[test]
-fn signed_extension_revoke_msa_delegation_by_delegator() {
+fn signed_extension_revoke_delegation_by_delegator() {
 	new_test_ext().execute_with(|| {
 		let (provider_msa_id, delegator_account) = test_create_delegator_msa_with_provider();
 		let call_revoke_delegation: &<Test as frame_system::Config>::Call =
-			&Call::Msa(MsaCall::revoke_msa_delegation_by_delegator { provider_msa_id });
+			&Call::Msa(MsaCall::revoke_delegation_by_delegator { provider_msa_id });
 		let info = DispatchInfo::default();
 		let len = 0_usize;
 		let result = CheckFreeExtrinsicUse::<Test>::new().validate(
@@ -1356,7 +1356,7 @@ fn signed_extension_validation_failure_on_revoked() {
 	new_test_ext().execute_with(|| {
 		let (provider_msa_id, delegator_account) = test_create_delegator_msa_with_provider();
 		let call_revoke_delegation: &<Test as frame_system::Config>::Call =
-			&Call::Msa(MsaCall::revoke_msa_delegation_by_delegator { provider_msa_id });
+			&Call::Msa(MsaCall::revoke_delegation_by_delegator { provider_msa_id });
 		let info = DispatchInfo::default();
 		let len = 0_usize;
 		let result = CheckFreeExtrinsicUse::<Test>::new().validate(
@@ -1366,14 +1366,14 @@ fn signed_extension_validation_failure_on_revoked() {
 			len,
 		);
 		assert_ok!(result);
-		assert_ok!(Msa::revoke_msa_delegation_by_delegator(
+		assert_ok!(Msa::revoke_delegation_by_delegator(
 			Origin::signed(delegator_account.into()),
 			provider_msa_id
 		));
 
 		System::set_block_number(System::block_number() + 1);
 		let call_revoke_delegation: &<Test as frame_system::Config>::Call =
-			&Call::Msa(MsaCall::revoke_msa_delegation_by_delegator { provider_msa_id });
+			&Call::Msa(MsaCall::revoke_delegation_by_delegator { provider_msa_id });
 		let info = DispatchInfo::default();
 		let len = 0_usize;
 		let result_revoked = CheckFreeExtrinsicUse::<Test>::new().validate(
@@ -1386,7 +1386,7 @@ fn signed_extension_validation_failure_on_revoked() {
 	});
 }
 
-/// Assert that a call that is not revoke_msa_delegation_by_delegator passes the signed extension
+/// Assert that a call that is not revoke_delegation_by_delegator passes the signed extension
 /// CheckFreeExtrinsicUse validaton.
 #[test]
 fn signed_extension_validation_valid_for_others() {
@@ -1730,10 +1730,7 @@ pub fn replaying_create_sponsored_account_with_delegation_fails() {
 		));
 
 		// Step 2
-		assert_ok!(Msa::revoke_msa_delegation_by_delegator(
-			Origin::signed(delegator_key.into()),
-			1
-		));
+		assert_ok!(Msa::revoke_delegation_by_delegator(Origin::signed(delegator_key.into()), 1));
 		// Step 3
 		let (key_pair_delegator2, _) = sr25519::Pair::generate();
 		let delegator_account2 = key_pair_delegator2.public();
@@ -1872,26 +1869,26 @@ fn signed_ext_check_nonce_delete_msa_public_key() {
 	})
 }
 
-// Assert that check nonce validation does not create a token account for revoke_msa_delegation_by_delegator call.
+// Assert that check nonce validation does not create a token account for revoke_delegation_by_delegator call.
 #[test]
-fn signed_ext_check_nonce_revoke_msa_delegation_by_delegator() {
+fn signed_ext_check_nonce_revoke_delegation_by_delegator() {
 	new_test_ext().execute_with(|| {
 		let (provider_msa_id, _) = test_create_delegator_msa_with_provider();
 
-		// We are testing the revoke_msa_delegation_by_delegator() call.
-		let call_revoke_msa_delegation_by_delegator: &<Test as frame_system::Config>::Call =
-			&Call::Msa(MsaCall::revoke_msa_delegation_by_delegator { provider_msa_id });
+		// We are testing the revoke_delegation_by_delegator() call.
+		let call_revoke_delegation_by_delegator: &<Test as frame_system::Config>::Call =
+			&Call::Msa(MsaCall::revoke_delegation_by_delegator { provider_msa_id });
 
 		let len = 0_usize;
 
 		// Get the dispatch info for the call.
-		let info = call_revoke_msa_delegation_by_delegator.get_dispatch_info();
+		let info = call_revoke_delegation_by_delegator.get_dispatch_info();
 
-		// Call revoke_msa_delegation_by_delegator() using the Alice account
+		// Call revoke_delegation_by_delegator() using the Alice account
 		let who = test_public(1);
 		assert_ok!(CheckNonce::<Test>(0).pre_dispatch(
 			&who,
-			call_revoke_msa_delegation_by_delegator,
+			call_revoke_delegation_by_delegator,
 			&info,
 			len
 		));

--- a/pallets/msa/src/weights.rs
+++ b/pallets/msa/src/weights.rs
@@ -61,7 +61,7 @@ pub trait WeightInfo {
 	fn delete_msa_public_key() -> Weight;
 	fn retire_msa() -> Weight;
 	fn grant_delegation() -> Weight;
-	fn revoke_msa_delegation_by_delegator() -> Weight;
+	fn revoke_delegation_by_delegator() -> Weight;
 	fn register_provider() -> Weight;
 	fn on_initialize(s: u32) -> Weight;
 }
@@ -134,7 +134,7 @@ impl<T: frame_system::Config> WeightInfo for SubstrateWeight<T> {
 	}
 	// Storage: Msa PublicKeyToMsaId (r:1 w:0)
 	// Storage: Msa ProviderInfoOf (r:1 w:1)
-	fn revoke_msa_delegation_by_delegator() -> Weight {
+	fn revoke_delegation_by_delegator() -> Weight {
 		Weight::from_ref_time(15_000_000 as u64)
 			.saturating_add(T::DbWeight::get().reads(2 as u64))
 			.saturating_add(T::DbWeight::get().writes(1 as u64))
@@ -220,7 +220,7 @@ impl WeightInfo for () {
 	}
 	// Storage: Msa PublicKeyToMsaId (r:1 w:0)
 	// Storage: Msa ProviderToRegistryEntry (r:1 w:1)
-	fn revoke_msa_delegation_by_delegator() -> Weight {
+	fn revoke_delegation_by_delegator() -> Weight {
 		Weight::from_ref_time(15_000_000 as u64)
 			.saturating_add(RocksDbWeight::get().reads(2 as u64))
 			.saturating_add(RocksDbWeight::get().writes(1 as u64))


### PR DESCRIPTION
# Goal
The goal of this PR is to rename the `revoke_msa_delegation_by_delegator` extrinsic.

# Discussion
This PR partially completes #508.

# Checklist
- [x] Design doc(s) updated
- [x] Tests added
- [x] Benchmarks added
