### PR TITLE
Rename: add_key_to_msa -> add_public_key_to_msa

### DIFF
--- a/pallets/msa/src/benchmarking.rs
+++ b/pallets/msa/src/benchmarking.rs
@@ -116,7 +116,7 @@ benchmarks! {
 		}
 	}: _ (RawOrigin::Signed(provider), delegator_msa_id)
 
-	add_key_to_msa {
+	add_public_key_to_msa {
 		let caller: T::AccountId = whitelisted_caller();
 		assert_ok!(Msa::<T>::create(RawOrigin::Signed(caller.clone()).into()));
 		let (add_provider_payload, signature, key) = add_key_payload_and_signature::<T>();
@@ -128,7 +128,7 @@ benchmarks! {
 		assert_ok!(Msa::<T>::create(RawOrigin::Signed(caller.clone()).into()));
 
 		let (add_provider_payload, signature, key) = add_key_payload_and_signature::<T>();
-		assert_ok!(Msa::<T>::add_key_to_msa(RawOrigin::Signed(caller.clone()).into(), key.clone(), signature, add_provider_payload));
+		assert_ok!(Msa::<T>::add_public_key_to_msa(RawOrigin::Signed(caller.clone()).into(), key.clone(), signature, add_provider_payload));
 
 	}: _(RawOrigin::Signed(caller), key)
 

--- a/pallets/msa/src/lib.rs
+++ b/pallets/msa/src/lib.rs
@@ -37,7 +37,7 @@
 //!
 //! ### Dispatchable Functions
 //!
-//! - `add_key_to_msa` - Associates a key to an MSA ID in a signed payload.
+//! - `add_public_key_to_msa` - Associates a key to an MSA ID in a signed payload.
 //! - `add_provider_to_msa` - Creates a delegation relationship between a `Provider` and MSA.
 //! - `create` - Creates an MSA for the `Origin`.
 //! - `create_sponsored_account_with_delegation` - `Origin` creates an account for a given `AccountId` and sets themselves as a `Provider`.
@@ -530,8 +530,8 @@ pub mod pallet {
 		/// - Returns ['NotMsaOwner'](Error::NotMsaOwner) if Origin's MSA is not the same as 'add_key_payload` MSA. Essentially you can only add a key to your own MSA.
 		/// - Returns ['ProofHasExpired'](Error::ProofHasExpired) if the current block is less than the `expired` bock number set in `AddKeyData`.
 		/// - Returns ['ProofNotYetValid'](Error::ProofNotYetValid) if the `expired` block number set in `AddKeyData` is greater than the current block number plus mortality_block_limit().
-		#[pallet::weight(T::WeightInfo::add_key_to_msa())]
-		pub fn add_key_to_msa(
+		#[pallet::weight(T::WeightInfo::add_public_key_to_msa())]
+		pub fn add_public_key_to_msa(
 			origin: OriginFor<T>,
 			key: T::AccountId,
 			proof: MultiSignature,

--- a/pallets/msa/src/tests.rs
+++ b/pallets/msa/src/tests.rs
@@ -82,7 +82,7 @@ fn it_throws_error_when_key_verification_fails() {
 		let signature: MultiSignature = key_pair.sign(&encode_data_new_key_data).into();
 
 		assert_noop!(
-			Msa::add_key_to_msa(
+			Msa::add_public_key_to_msa(
 				test_origin_signed(1),
 				fake_account.into(),
 				signature,
@@ -112,7 +112,7 @@ fn it_throws_error_when_not_msa_owner() {
 		let signature: MultiSignature = key_pair_2.sign(&encode_data_new_key_data).into();
 
 		assert_noop!(
-			Msa::add_key_to_msa(
+			Msa::add_public_key_to_msa(
 				test_origin_signed(1),
 				new_account.into(),
 				signature,
@@ -138,7 +138,7 @@ fn it_throws_error_when_for_duplicate_key() {
 		let signature: MultiSignature = key_pair.sign(&encode_data_new_key_data).into();
 
 		assert_noop!(
-			Msa::add_key_to_msa(
+			Msa::add_public_key_to_msa(
 				Origin::signed(new_account.into()),
 				new_account.into(),
 				signature,
@@ -163,7 +163,7 @@ fn add_key_with_more_than_allowed_should_panic() {
 			let (new_key_pair, _) = sr25519::Pair::generate();
 			let new_account = new_key_pair.public();
 			let signature: MultiSignature = new_key_pair.sign(&encode_data_new_key_data).into();
-			assert_ok!(Msa::add_key_to_msa(
+			assert_ok!(Msa::add_public_key_to_msa(
 				Origin::signed(account.into()),
 				new_account.into(),
 				signature,
@@ -176,7 +176,7 @@ fn add_key_with_more_than_allowed_should_panic() {
 		let final_account = final_key_pair.public();
 		let signature: MultiSignature = final_key_pair.sign(&encode_data_new_key_data).into();
 		assert_noop!(
-			Msa::add_key_to_msa(
+			Msa::add_public_key_to_msa(
 				Origin::signed(account.into()),
 				final_account.into(),
 				signature,
@@ -205,7 +205,7 @@ fn add_key_with_valid_request_should_store_value_and_event() {
 		let signature: MultiSignature = key_pair_2.sign(&encode_data_new_key_data).into();
 
 		// act
-		assert_ok!(Msa::add_key_to_msa(
+		assert_ok!(Msa::add_public_key_to_msa(
 			Origin::signed(account.into()),
 			new_key.into(),
 			signature,
@@ -247,7 +247,7 @@ fn add_key_with_expired_proof_fails() {
 		let signature: MultiSignature = key_pair_2.sign(&encode_data_new_key_data).into();
 
 		assert_noop!(
-			Msa::add_key_to_msa(
+			Msa::add_public_key_to_msa(
 				Origin::signed(account.into()),
 				new_key.into(),
 				signature,
@@ -280,7 +280,7 @@ fn add_key_with_proof_too_far_into_future_fails() {
 		let signature: MultiSignature = key_pair_2.sign(&encode_data_new_key_data).into();
 
 		assert_noop!(
-			Msa::add_key_to_msa(
+			Msa::add_public_key_to_msa(
 				Origin::signed(account.into()),
 				new_key.into(),
 				signature,
@@ -363,7 +363,7 @@ fn test_retire_msa_success() {
 		let encode_data_new_key_data = wrap_binary_data(add_new_key_data.encode());
 		let signature: MultiSignature = key_pair1.sign(&encode_data_new_key_data).into();
 		assert_noop!(
-			Msa::add_key_to_msa(
+			Msa::add_public_key_to_msa(
 				Origin::signed(test_account.clone()),
 				new_account1.into(),
 				signature,
@@ -1477,7 +1477,7 @@ fn double_add_key_two_msa_fails() {
 		let encode_data_new_key_data = wrap_binary_data(add_new_key_data.encode());
 		let signature: MultiSignature = key_pair1.sign(&encode_data_new_key_data).into();
 		assert_noop!(
-			Msa::add_key_to_msa(
+			Msa::add_public_key_to_msa(
 				Origin::signed(new_account2.into()),
 				new_account1.into(),
 				signature,
@@ -1504,7 +1504,7 @@ fn add_removed_key_to_msa_pass() {
 		let add_new_key_data = AddKeyData { nonce: 1, msa_id: msa_id2, expiration: 10 };
 		let encode_data_new_key_data = wrap_binary_data(add_new_key_data.encode());
 		let signature: MultiSignature = key_pair1.sign(&encode_data_new_key_data).into();
-		assert_ok!(Msa::add_key_to_msa(
+		assert_ok!(Msa::add_public_key_to_msa(
 			Origin::signed(new_account2.into()),
 			new_account1.into(),
 			signature,
@@ -1708,7 +1708,7 @@ pub fn replaying_create_sponsored_account_with_delegation_fails() {
 		let encode_add_key_data = wrap_binary_data(add_key_payload.encode());
 		let add_key_signature = key_pair_delegator2.sign(&encode_add_key_data);
 
-		assert_ok!(Msa::add_key_to_msa(
+		assert_ok!(Msa::add_public_key_to_msa(
 			Origin::signed(delegator_key.into()),
 			delegator_account2.into(),
 			add_key_signature.into(),

--- a/pallets/msa/src/types.rs
+++ b/pallets/msa/src/types.rs
@@ -13,14 +13,14 @@ use scale_info::TypeInfo;
 /// Dispatch Empty
 pub const EMPTY_FUNCTION: fn(MessageSourceId) -> DispatchResult = |_| Ok(());
 
-/// A type definition for the payload of adding an MSA key - `pallet_msa::add_key_to_msa`
+/// A type definition for the payload of adding an MSA key - `pallet_msa::add_public_key_to_msa`
 #[derive(TypeInfo, Debug, Clone, Decode, Encode, PartialEq, Eq)]
 pub struct AddKeyData {
 	/// Message Source Account identifier
 	pub msa_id: MessageSourceId,
 	/// A cryptographic nonce.
 	pub nonce: u32,
-	/// The block number at which the signed proof for add_key_to_msa expires.
+	/// The block number at which the signed proof for add_public_key_to_msa expires.
 	pub expiration: BlockNumber,
 }
 

--- a/pallets/msa/src/weights.rs
+++ b/pallets/msa/src/weights.rs
@@ -57,7 +57,7 @@ pub trait WeightInfo {
 	fn create(s: u32, ) -> Weight;
 	fn create_sponsored_account_with_delegation() -> Weight;
 	fn revoke_delegation_by_provider(s: u32, ) -> Weight;
-	fn add_key_to_msa() -> Weight;
+	fn add_public_key_to_msa() -> Weight;
 	fn delete_msa_key() -> Weight;
 	fn retire_msa() -> Weight;
 	fn add_provider_to_msa() -> Weight;
@@ -102,7 +102,7 @@ impl<T: frame_system::Config> WeightInfo for SubstrateWeight<T> {
 	// Storage: Msa PayloadSignatureRegistry (r:1 w:1)
 	// Storage: Msa PublicKeyToMsaId (r:2 w:1)
 	// Storage: Msa MsaInfoOf (r:1 w:1)
-	fn add_key_to_msa() -> Weight {
+	fn add_public_key_to_msa() -> Weight {
 		Weight::from_ref_time(55_000_000 as u64)
 			.saturating_add(T::DbWeight::get().reads(4 as u64))
 			.saturating_add(T::DbWeight::get().writes(3 as u64))
@@ -187,7 +187,7 @@ impl WeightInfo for () {
 	// Storage: Msa PayloadSignatureRegistry (r:1 w:1)
 	// Storage: Msa PublicKeyToMsaId (r:2 w:1)
 	// Storage: Msa MsaInfoOf (r:1 w:1)
-	fn add_key_to_msa() -> Weight {
+	fn add_public_key_to_msa() -> Weight {
 		Weight::from_ref_time(55_000_000 as u64)
 			.saturating_add(RocksDbWeight::get().reads(4 as u64))
 			.saturating_add(RocksDbWeight::get().writes(3 as u64))


### PR DESCRIPTION
# Goal
The goal of this PR is to rename the `add_key_to_msa` extrinsic.

# Discussion
This PR partially completes #508.

# Checklist
- [ ] Design doc(s) updated
- [x] Tests added
- [x] Benchmarks added
