### PR TITLE
Rename: delete_msa_key -> delete_msa_public_key

### DIFF
--- a/pallets/msa/src/benchmarking.rs
+++ b/pallets/msa/src/benchmarking.rs
@@ -124,7 +124,7 @@ benchmarks! {
 
 	}: _ (RawOrigin::Signed(key.clone()), key.clone(), signature, key_new, signature_new, add_provider_payload)
 
-	delete_msa_key {
+	delete_msa_public_key {
 
 		let (add_provider_payload, signature, caller) = add_key_payload_and_signature::<T>();
 		assert_ok!(Msa::<T>::create(RawOrigin::Signed(caller.clone()).into()));

--- a/pallets/msa/src/lib.rs
+++ b/pallets/msa/src/lib.rs
@@ -43,7 +43,7 @@
 //! - `create_sponsored_account_with_delegation` - `Origin` creates an account for a given `AccountId` and sets themselves as a `Provider`.
 //! - `revoke_delegation_by_provider` - `Provider` MSA terminates a Delegation with Delegator MSA by expiring it.
 //! - `revoke_msa_delegation_by_delegator` - Delegator MSA terminates a Delegation with the `Provider` MSA by expiring it.
-//! - `delete_msa_key` - Removes the given key by from storage against respective MSA.
+//! - `delete_msa_public_key` - Removes the given key by from storage against respective MSA.
 //!
 //! ### Assumptions
 //!
@@ -578,8 +578,8 @@ pub mod pallet {
 		/// ### Remarks
 		/// - Removal of key deletes the association of the key with the MSA.
 		/// - The key can be re-added to same or another MSA if needed.
-		#[pallet::weight((T::WeightInfo::delete_msa_key(), DispatchClass::Normal, Pays::No))]
-		pub fn delete_msa_key(origin: OriginFor<T>, key: T::AccountId) -> DispatchResult {
+		#[pallet::weight((T::WeightInfo::delete_msa_public_key(), DispatchClass::Normal, Pays::No))]
+		pub fn delete_msa_public_key(origin: OriginFor<T>, key: T::AccountId) -> DispatchResult {
 			let who = ensure_signed(origin)?;
 
 			// The calling account can't remove itself
@@ -1309,7 +1309,7 @@ where
 		match call.is_sub_type() {
 			Some(Call::revoke_msa_delegation_by_delegator { provider_msa_id, .. }) =>
 				CheckFreeExtrinsicUse::<T>::validate_delegation_by_delegator(who, provider_msa_id),
-			Some(Call::delete_msa_key { key, .. }) =>
+			Some(Call::delete_msa_public_key { key, .. }) =>
 				CheckFreeExtrinsicUse::<T>::validate_key_revocation(who, key),
 			_ => return Ok(Default::default()),
 		}

--- a/pallets/msa/src/tests.rs
+++ b/pallets/msa/src/tests.rs
@@ -318,7 +318,7 @@ fn it_deletes_msa_key_successfully() {
 		assert_ok!(Msa::add_key(2, &test_public(1), EMPTY_FUNCTION));
 		assert_ok!(Msa::add_key(2, &test_public(2), EMPTY_FUNCTION));
 
-		assert_ok!(Msa::delete_msa_key(test_origin_signed(1), test_public(2)));
+		assert_ok!(Msa::delete_msa_public_key(test_origin_signed(1), test_public(2)));
 
 		let info = Msa::get_msa_by_public_key(&test_public(2));
 
@@ -341,7 +341,10 @@ fn it_deletes_msa_last_key_self_removal() {
 		assert_ok!(Msa::add_key(msa_id, &test_account, EMPTY_FUNCTION));
 
 		// Attempt to delete/remove the account from the MSA
-		assert_noop!(Msa::delete_msa_key(origin, test_account), Error::<Test>::InvalidSelfRemoval);
+		assert_noop!(
+			Msa::delete_msa_public_key(origin, test_account),
+			Error::<Test>::InvalidSelfRemoval
+		);
 	})
 }
 
@@ -1401,12 +1404,12 @@ fn signed_extension_validation_valid_for_others() {
 }
 
 #[test]
-pub fn delete_msa_key_call_has_correct_costs() {
+pub fn delete_msa_public_key_call_has_correct_costs() {
 	new_test_ext().execute_with(|| {
 		let (key_pair, _) = sr25519::Pair::generate();
 		let new_key = key_pair.public();
 
-		let call = MsaCall::<Test>::delete_msa_key { key: AccountId32::from(new_key) };
+		let call = MsaCall::<Test>::delete_msa_public_key { key: AccountId32::from(new_key) };
 		let dispatch_info = call.get_dispatch_info();
 		assert_eq!(dispatch_info.pays_fee, Pays::No);
 	})
@@ -1422,19 +1425,19 @@ fn signed_extension_validation_on_msa_key_deleted() {
 		let user_account_id = AccountId32::from(user_public_key);
 		assert_ok!(Msa::add_key(owner_msa_id, &user_account_id, EMPTY_FUNCTION));
 
-		let call_delete_msa_key: &<Test as frame_system::Config>::Call =
-			&Call::Msa(MsaCall::delete_msa_key { key: owner_key.clone() });
+		let call_delete_msa_public_key: &<Test as frame_system::Config>::Call =
+			&Call::Msa(MsaCall::delete_msa_public_key { key: owner_key.clone() });
 
 		let info = DispatchInfo::default();
 		let len = 0_usize;
 		let result = CheckFreeExtrinsicUse::<Test>::new().validate(
 			&owner_key,
-			call_delete_msa_key,
+			call_delete_msa_public_key,
 			&info,
 			len,
 		);
 		assert_ok!(result);
-		assert_ok!(Msa::delete_msa_key(
+		assert_ok!(Msa::delete_msa_public_key(
 			Origin::signed(AccountId32::from(owner_key.clone())),
 			user_account_id
 		));
@@ -1451,32 +1454,32 @@ fn signed_extension_validation_failure_on_msa_key_deleted() {
 		let user_account_id = AccountId32::from(user_public_key);
 		assert_ok!(Msa::add_key(owner_msa_id, &user_account_id, EMPTY_FUNCTION));
 
-		let call_delete_msa_key: &<Test as frame_system::Config>::Call =
-			&Call::Msa(MsaCall::delete_msa_key { key: owner_key.clone() });
+		let call_delete_msa_public_key: &<Test as frame_system::Config>::Call =
+			&Call::Msa(MsaCall::delete_msa_public_key { key: owner_key.clone() });
 
 		let info = DispatchInfo::default();
 		let len = 0_usize;
 		let result = CheckFreeExtrinsicUse::<Test>::new().validate(
 			&owner_key,
-			call_delete_msa_key,
+			call_delete_msa_public_key,
 			&info,
 			len,
 		);
 
 		System::set_block_number(2);
 		assert_ok!(result);
-		assert_ok!(Msa::delete_msa_key(
+		assert_ok!(Msa::delete_msa_public_key(
 			Origin::signed(AccountId32::from(owner_key.clone())),
 			user_account_id.clone()
 		));
 
-		let call_delete_msa_key: &<Test as frame_system::Config>::Call =
-			&Call::Msa(MsaCall::delete_msa_key { key: user_account_id.clone() });
+		let call_delete_msa_public_key: &<Test as frame_system::Config>::Call =
+			&Call::Msa(MsaCall::delete_msa_public_key { key: user_account_id.clone() });
 		let info = DispatchInfo::default();
 		let len = 0_usize;
 		let result_deleted = CheckFreeExtrinsicUse::<Test>::new().validate(
 			&user_account_id.clone(),
-			call_delete_msa_key,
+			call_delete_msa_public_key,
 			&info,
 			len,
 		);
@@ -1748,7 +1751,7 @@ pub fn replaying_create_sponsored_account_with_delegation_fails() {
 			add_key_signature_new_key.into(),
 			add_key_payload
 		));
-		assert_ok!(Msa::delete_msa_key(
+		assert_ok!(Msa::delete_msa_public_key(
 			Origin::signed(delegator_account2.into()),
 			delegator_key.into(),
 		));
@@ -1829,9 +1832,9 @@ fn replaying_grant_delegation_fails() {
 	})
 }
 
-// Assert that check nonce validation does not create a token account for delete_msa_key call.
+// Assert that check nonce validation does not create a token account for delete_msa_public_key call.
 #[test]
-fn signed_ext_check_nonce_delete_msa_key() {
+fn signed_ext_check_nonce_delete_msa_public_key() {
 	new_test_ext().execute_with(|| {
 		// Generate a key pair for MSA account
 		let (msa_key_pair, _) = sr25519::Pair::generate();
@@ -1839,14 +1842,19 @@ fn signed_ext_check_nonce_delete_msa_key() {
 
 		let len = 0_usize;
 
-		// Test the delete_msa_key() call
-		let call_delete_msa_key: &<Test as frame_system::Config>::Call =
-			&Call::Msa(MsaCall::delete_msa_key { key: AccountId32::from(msa_new_key) });
-		let info = call_delete_msa_key.get_dispatch_info();
+		// Test the delete_msa_public_key() call
+		let call_delete_msa_public_key: &<Test as frame_system::Config>::Call =
+			&Call::Msa(MsaCall::delete_msa_public_key { key: AccountId32::from(msa_new_key) });
+		let info = call_delete_msa_public_key.get_dispatch_info();
 
-		// Call delete_msa_key() using the Alice account
+		// Call delete_msa_public_key() using the Alice account
 		let who = test_public(1);
-		assert_ok!(CheckNonce::<Test>(0).pre_dispatch(&who, call_delete_msa_key, &info, len));
+		assert_ok!(CheckNonce::<Test>(0).pre_dispatch(
+			&who,
+			call_delete_msa_public_key,
+			&info,
+			len
+		));
 
 		// Did the call create a token account?
 		let created_token_account: bool;

--- a/pallets/msa/src/weights.rs
+++ b/pallets/msa/src/weights.rs
@@ -58,7 +58,7 @@ pub trait WeightInfo {
 	fn create_sponsored_account_with_delegation() -> Weight;
 	fn revoke_delegation_by_provider(s: u32) -> Weight;
 	fn add_key_to_msa() -> Weight;
-	fn delete_msa_key() -> Weight;
+	fn delete_msa_public_key() -> Weight;
 	fn retire_msa() -> Weight;
 	fn grant_delegation() -> Weight;
 	fn revoke_msa_delegation_by_delegator() -> Weight;
@@ -110,7 +110,7 @@ impl<T: frame_system::Config> WeightInfo for SubstrateWeight<T> {
 	}
 	// Storage: Msa PublicKeyToMsaId (r:2 w:1)
 	// Storage: Msa PublicKeyCountForMsaId (r:1 w:1)
-	fn delete_msa_key() -> Weight {
+	fn delete_msa_public_key() -> Weight {
 		Weight::from_ref_time(18_000_000 as u64)
 			.saturating_add(T::DbWeight::get().reads(3 as u64))
 			.saturating_add(T::DbWeight::get().writes(2 as u64))
@@ -196,7 +196,7 @@ impl WeightInfo for () {
 	}
 	// Storage: Msa PublicKeyToMsaId (r:2 w:1)
 	// Storage: Msa PublicKeyCountForMsaId (r:1 w:1)
-	fn delete_msa_key() -> Weight {
+	fn delete_msa_public_key() -> Weight {
 		Weight::from_ref_time(18_000_000 as u64)
 			.saturating_add(RocksDbWeight::get().reads(3 as u64))
 			.saturating_add(RocksDbWeight::get().writes(2 as u64))


### PR DESCRIPTION
# Goal
The goal of this PR is to rename the `delete_msa_key` extrinsic.

# Discussion
This PR partially completes #508.

# Checklist
- [x] Tests added
- [x] Benchmarks added
