### PR TITLE
Renamed RPC: msa_grantedSchemaIds -> msa_grantedSchemaIdsByMsaId

### DIFF
--- a/pallets/msa/src/lib.rs
+++ b/pallets/msa/src/lib.rs
@@ -994,7 +994,7 @@ impl<T: Config> Pallet<T> {
 	/// # Errors
 	/// * [`Error::DelegationNotFound`]
 	/// * [`Error::SchemaNotGranted`]
-	pub fn get_granted_schemas(
+	pub fn get_granted_schemas_by_msa_id(
 		delegator: Delegator,
 		provider: Provider,
 	) -> Result<Option<Vec<SchemaId>>, DispatchError> {

--- a/pallets/msa/src/rpc/src/lib.rs
+++ b/pallets/msa/src/rpc/src/lib.rs
@@ -26,8 +26,8 @@ pub trait MsaApi<BlockHash, AccountId> {
 		block_number: Option<BlockNumber>,
 	) -> RpcResult<Vec<(MessageSourceId, bool)>>;
 
-	#[method(name = "msa_grantedSchemaIds")]
-	fn get_granted_schemas(
+	#[method(name = "msa_grantedSchemaIdsByMsaId")]
+	fn get_granted_schemas_by_msa_id(
 		&self,
 		delegator_msa_id: MessageSourceId,
 		provider_msa_id: MessageSourceId,
@@ -87,7 +87,7 @@ where
 			.collect())
 	}
 
-	fn get_granted_schemas(
+	fn get_granted_schemas_by_msa_id(
 		&self,
 		delegator_msa_id: MessageSourceId,
 		provider_msa_id: MessageSourceId,
@@ -96,7 +96,7 @@ where
 		let at = BlockId::hash(self.client.info().best_hash);
 		let delegator = Delegator(delegator_msa_id);
 		let provider = Provider(provider_msa_id);
-		let runtime_api_result = api.get_granted_schemas(&at, delegator, provider);
+		let runtime_api_result = api.get_granted_schemas_by_msa_id(&at, delegator, provider);
 		map_rpc_result(runtime_api_result)
 	}
 }

--- a/pallets/msa/src/runtime-api/src/lib.rs
+++ b/pallets/msa/src/runtime-api/src/lib.rs
@@ -18,6 +18,6 @@ sp_api::decl_runtime_apis! {
 
 		fn has_delegation(delegator: Delegator, provider: Provider, block_number: Option<BlockNumber>) -> bool;
 
-		fn get_granted_schemas(delegator: Delegator, provider: Provider) -> Result<Option<Vec<SchemaId>>, DispatchError>;
+		fn get_granted_schemas_by_msa_id(delegator: Delegator, provider: Provider) -> Result<Option<Vec<SchemaId>>, DispatchError>;
 	}
 }

--- a/pallets/msa/src/tests.rs
+++ b/pallets/msa/src/tests.rs
@@ -1659,7 +1659,7 @@ pub fn error_not_delegated_rpc() {
 		let provider = Provider(1);
 		let delegator = Delegator(2);
 		assert_err!(
-			Msa::get_granted_schemas(delegator, provider),
+			Msa::get_granted_schemas_by_msa_id(delegator, provider),
 			Error::<Test>::DelegationNotFound
 		);
 	})
@@ -1671,7 +1671,10 @@ pub fn error_schema_not_granted_rpc() {
 		let provider = Provider(1);
 		let delegator = Delegator(2);
 		assert_ok!(Msa::add_provider(provider, delegator, Vec::default()));
-		assert_err!(Msa::get_granted_schemas(delegator, provider), Error::<Test>::SchemaNotGranted);
+		assert_err!(
+			Msa::get_granted_schemas_by_msa_id(delegator, provider),
+			Error::<Test>::SchemaNotGranted
+		);
 	})
 }
 
@@ -1684,7 +1687,7 @@ pub fn schema_granted_success_rpc() {
 		let delegator = Delegator(2);
 		let schema_grants = vec![1, 2];
 		assert_ok!(Msa::add_provider(provider, delegator, schema_grants));
-		let schemas_granted = Msa::get_granted_schemas(delegator, provider);
+		let schemas_granted = Msa::get_granted_schemas_by_msa_id(delegator, provider);
 		let expected_schemas_granted = vec![1, 2];
 		let output_schemas: Vec<SchemaId> = schemas_granted.unwrap().unwrap();
 		assert_eq!(output_schemas, expected_schemas_granted);

--- a/runtime/frequency-rococo/src/lib.rs
+++ b/runtime/frequency-rococo/src/lib.rs
@@ -820,8 +820,8 @@ impl_runtime_apis! {
 			}
 		}
 
-		fn get_granted_schemas(delegator: Delegator, provider: Provider) -> Result<Option<Vec<SchemaId>>, DispatchError> {
-			Msa::get_granted_schemas(delegator, provider)
+		fn get_granted_schemas_by_msa_id(delegator: Delegator, provider: Provider) -> Result<Option<Vec<SchemaId>>, DispatchError> {
+			Msa::get_granted_schemas_by_msa_id(delegator, provider)
 		}
 	}
 

--- a/runtime/frequency/src/lib.rs
+++ b/runtime/frequency/src/lib.rs
@@ -869,8 +869,8 @@ impl_runtime_apis! {
 			}
 		}
 
-		fn get_granted_schemas(delegator: Delegator, provider: Provider) -> Result<Option<Vec<SchemaId>>, DispatchError> {
-			Msa::get_granted_schemas(delegator, provider)
+		fn get_granted_schemas_by_msa_id(delegator: Delegator, provider: Provider) -> Result<Option<Vec<SchemaId>>, DispatchError> {
+			Msa::get_granted_schemas_by_msa_id(delegator, provider)
 		}
 	}
 


### PR DESCRIPTION
# Goal
The goal of this PR is to rename the `get_granted_schemas` RPC.

# Discussion
This PR partially completes #508

# Checklist
- [x] Tests added
- [x] Benchmarks added
