### PR TITLE
Rename Event: KeyRemoved -> PublicKeyDeleted

### DIFF
--- a/pallets/msa/src/lib.rs
+++ b/pallets/msa/src/lib.rs
@@ -231,7 +231,7 @@ pub mod pallet {
 			key: T::AccountId,
 		},
 		/// An AccountId had all permissions revoked from its MessageSourceId
-		KeyRemoved {
+		PublicKeyDeleted {
 			/// The key no longer approved for the associated MSA
 			key: T::AccountId,
 		},
@@ -568,7 +568,7 @@ pub mod pallet {
 		}
 
 		/// Remove a key associated with an MSA by expiring it at the current block.
-		/// Returns `Ok(())` on success, otherwise returns an error. Deposits event [`KeyRemoved`](Event::KeyRemoved).
+		/// Returns `Ok(())` on success, otherwise returns an error. Deposits event [`PublicKeyDeleted`](Event::PublicKeyDeleted).
 		///
 		/// ### Errors
 		/// - Returns [`InvalidSelfRemoval`](Error::InvalidSelfRemoval) if `origin` and `key` are the same.
@@ -596,7 +596,7 @@ pub mod pallet {
 			Self::delete_key_for_msa(who_msa_id, &key)?;
 
 			// Deposit the event
-			Self::deposit_event(Event::KeyRemoved { key });
+			Self::deposit_event(Event::PublicKeyDeleted { key });
 
 			Ok(())
 		}
@@ -666,9 +666,9 @@ pub mod pallet {
 			// Remove delegator from all delegator<->provider delegations
 			Self::remove_delegator(delegator)?;
 
-			// Delete the last and only account key and deposit the "KeyRemoved" event
+			// Delete the last and only account key and deposit the "PublicKeyDeleted" event
 			Self::delete_key_for_msa(msa_id, &who)?;
-			Self::deposit_event(Event::KeyRemoved { key: who });
+			Self::deposit_event(Event::PublicKeyDeleted { key: who });
 
 			// Deposit the "MsaRetired" event
 			Self::deposit_event(Event::MsaRetired { msa_id });

--- a/pallets/msa/src/tests.rs
+++ b/pallets/msa/src/tests.rs
@@ -324,7 +324,7 @@ fn it_deletes_msa_key_successfully() {
 
 		assert_eq!(info, None);
 
-		System::assert_last_event(Event::KeyRemoved { key: test_public(2) }.into());
+		System::assert_last_event(Event::PublicKeyDeleted { key: test_public(2) }.into());
 	})
 }
 
@@ -361,8 +361,8 @@ fn test_retire_msa_success() {
 		// Retire the MSA
 		assert_ok!(Msa::retire_msa(origin));
 
-		// Check if KeyRemoved event was dispatched.
-		System::assert_has_event(Event::KeyRemoved { key: test_account.clone() }.into());
+		// Check if PublicKeyDeleted event was dispatched.
+		System::assert_has_event(Event::PublicKeyDeleted { key: test_account.clone() }.into());
 
 		// Check if MsaRetired event was dispatched.
 		System::assert_last_event(Event::MsaRetired { msa_id }.into());


### PR DESCRIPTION
# Goal
The goal of this PR is to rename the `KeyRemoved` event.

# Discussion
This PR partially completes #508

# Checklist
- [x] Tests added
