### PR TITLE
Rename Event: ProviderAdded -> DelegationGranted

### DIFF
--- a/designdocs/delegation.md
+++ b/designdocs/delegation.md
@@ -65,7 +65,7 @@ Creates a new MSA on behalf of a delegator and adds the origin held MSA as its p
       1. `MsaCreated`
           * `new_msa_id` - id of the newly created MSA
           * `key` - the `delegator_key`
-      2. `ProviderAdded`
+      2. `DelegationGranted`
           * `delegator` - id of the newly created MSA
           * `provider` - id of the MSA help by the provider
 

--- a/pallets/msa/src/lib.rs
+++ b/pallets/msa/src/lib.rs
@@ -236,7 +236,7 @@ pub mod pallet {
 			key: T::AccountId,
 		},
 		/// A delegation relationship was added with the given provider and delegator
-		ProviderAdded {
+		DelegationGranted {
 			/// The Provider MSA Id
 			provider: Provider,
 			/// The Delegator MSA Id
@@ -357,7 +357,7 @@ pub mod pallet {
 			Ok(())
 		}
 
-		/// `Origin` MSA creates an MSA on behalf of `delegator_key`, creates a Delegation with the `delegator_key`'s MSA as the Delegator and `origin` as `Provider`. Deposits events [`MsaCreated`](Event::MsaCreated) and [`ProviderAdded`](Event::ProviderAdded).
+		/// `Origin` MSA creates an MSA on behalf of `delegator_key`, creates a Delegation with the `delegator_key`'s MSA as the Delegator and `origin` as `Provider`. Deposits events [`MsaCreated`](Event::MsaCreated) and [`DelegationGranted`](Event::DelegationGranted).
 		/// Returns `Ok(())` on success, otherwise returns an error.
 		///
 		/// ## Errors
@@ -410,7 +410,7 @@ pub mod pallet {
 						key: delegator_key.clone(),
 					});
 
-					Self::deposit_event(Event::ProviderAdded {
+					Self::deposit_event(Event::DelegationGranted {
 						delegator: new_msa_id.into(),
 						provider: provider_msa_id.into(),
 					});
@@ -447,7 +447,7 @@ pub mod pallet {
 
 		/// Creates a new Delegation for an existing MSA, with `origin` as the Provider and `delegator_key` is the delegator.
 		/// Since it is being sent on the Delegator's behalf, it requires the Delegator to authorize the new Delegation.
-		/// Returns `Ok(())` on success, otherwise returns an error. Deposits event [`ProviderAdded`](Event::ProviderAdded).
+		/// Returns `Ok(())` on success, otherwise returns an error. Deposits event [`DelegationGranted`](Event::DelegationGranted).
 		///
 		/// ## Errors
 		/// - Returns [`AddProviderSignatureVerificationFailed`](Error::AddProviderSignatureVerificationFailed) if `origin`'s MSA ID does not equal `add_provider_payload.authorized_msa_id`.
@@ -486,7 +486,7 @@ pub mod pallet {
 
 			Self::add_provider(provider, delegator, add_provider_payload.schema_ids)?;
 
-			Self::deposit_event(Event::ProviderAdded { delegator, provider });
+			Self::deposit_event(Event::DelegationGranted { delegator, provider });
 
 			Ok(())
 		}

--- a/pallets/msa/src/tests.rs
+++ b/pallets/msa/src/tests.rs
@@ -531,8 +531,11 @@ pub fn add_provider_to_msa_is_success() {
 		);
 
 		System::assert_last_event(
-			Event::ProviderAdded { delegator: delegator_msa.into(), provider: provider_msa.into() }
-				.into(),
+			Event::DelegationGranted {
+				delegator: delegator_msa.into(),
+				provider: provider_msa.into(),
+			}
+			.into(),
 		);
 	});
 }
@@ -737,7 +740,7 @@ pub fn create_sponsored_account_with_delegation_with_valid_input_should_succeed(
 		);
 		assert_eq!(
 			provider_event.event,
-			Event::ProviderAdded { provider: 1u64.into(), delegator: 2u64.into() }.into()
+			Event::DelegationGranted { provider: 1u64.into(), delegator: 2u64.into() }.into()
 		);
 	});
 }


### PR DESCRIPTION
# Goal
The goal of this PR is to rename the `ProviderAdded` event.

# Discussion
This PR partially completes #508.

# Checklist
- [x] Design doc(s) updated
- [x] Tests added
