### PR TITLE
Rename RPC: messages_getBySchema -> messages_getBySchemaId

### DIFF
--- a/designdocs/batched_messages.md
+++ b/designdocs/batched_messages.md
@@ -181,8 +181,8 @@ parameter also serves as an on-chain declaration that not only allows consumers
 of batches to quickly discover if a batch announcer was honest, but the file
 requestor can know in advance when to stop requesting data.
 
-#### Changes to `get_messages_by_schema`
-The `MessagesPallet::get_messages_by_schema` RPC returns a paginated
+#### Changes to `get_messages_by_schema_id`
+The `MessagesPallet::get_messages_by_schema_id` RPC returns a paginated
 `MessageResponse`. It is possible that this document will change the structure
 of the `MessageResponse` to be more like the following:
 

--- a/pallets/messages/src/rpc/src/lib.rs
+++ b/pallets/messages/src/rpc/src/lib.rs
@@ -21,8 +21,8 @@ mod tests;
 
 #[rpc(client, server)]
 pub trait MessagesApi<BlockNumber> {
-	#[method(name = "messages_getBySchema")]
-	fn get_messages_by_schema(
+	#[method(name = "messages_getBySchemaId")]
+	fn get_messages_by_schema_id(
 		&self,
 		schema_id: SchemaId,
 		pagination: BlockPaginationRequest<BlockNumber>,
@@ -66,7 +66,7 @@ where
 	C::Api: MessagesRuntimeApi<Block, BlockNumber>,
 	BlockNumber: Codec + Copy + AtLeast32BitUnsigned,
 {
-	fn get_messages_by_schema(
+	fn get_messages_by_schema_id(
 		&self,
 		schema_id: SchemaId,
 		pagination: BlockPaginationRequest<BlockNumber>,

--- a/pallets/messages/src/rpc/src/tests/mod.rs
+++ b/pallets/messages/src/rpc/src/tests/mod.rs
@@ -71,7 +71,7 @@ async fn get_messages_by_schema_with_invalid_request_should_panic() {
 	let client = Arc::new(TestApi {});
 	let api = MessagesHandler::new(client);
 
-	let result: GetMessagesBySchemaResult = api.get_messages_by_schema(
+	let result: GetMessagesBySchemaResult = api.get_messages_by_schema_id(
 		SCHEMA_ID_EMPTY, // Schema Id
 		BlockPaginationRequest { from_block: 1, to_block: 2, from_index: 0, page_size: 0 },
 	);
@@ -85,7 +85,7 @@ async fn get_messages_by_schema_with_bad_schema_id_should_err() {
 	let client = Arc::new(TestApi {});
 	let api = MessagesHandler::new(client);
 
-	let result: GetMessagesBySchemaResult = api.get_messages_by_schema(
+	let result: GetMessagesBySchemaResult = api.get_messages_by_schema_id(
 		0, // Schema Id
 		BlockPaginationRequest { from_block: 1, to_block: 5, from_index: 0, page_size: 10 },
 	);
@@ -100,7 +100,7 @@ async fn get_messages_by_schema_with_success() {
 	let client = Arc::new(TestApi {});
 	let api = MessagesHandler::new(client);
 
-	let result: GetMessagesBySchemaResult = api.get_messages_by_schema(
+	let result: GetMessagesBySchemaResult = api.get_messages_by_schema_id(
 		SCHEMA_ID_HAS_MESSAGES, // Schema Id
 		BlockPaginationRequest { from_block: 1, to_block: 5, from_index: 0, page_size: 2 },
 	);


### PR DESCRIPTION
# Goal
The goal of this PR is to rename the `messages_getBySchema` RPC.

# Discussion
This PR partially completes #508.

# Checklist
- [x] Design doc(s) updated
- [x] Tests added
