### PR TITLE
feat(schemas): update schema permission storage 

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1036,7 +1036,6 @@ version = "0.1.0"
 dependencies = [
  "frame-support",
  "impl-serde 0.4.0",
- "orml-utilities",
  "parity-scale-codec",
  "scale-info",
  "serde",
@@ -5316,7 +5315,6 @@ dependencies = [
  "frame-support",
  "parity-scale-codec",
  "scale-info",
- "serde",
  "sp-io 6.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-v0.9.29)",
  "sp-runtime 6.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-v0.9.29)",
  "sp-std 4.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-v0.9.29)",
@@ -5837,7 +5835,6 @@ dependencies = [
  "frame-benchmarking",
  "frame-support",
  "frame-system",
- "orml-utilities",
  "pallet-schemas",
  "parity-scale-codec",
  "scale-info",

--- a/common/primitives/Cargo.toml
+++ b/common/primitives/Cargo.toml
@@ -30,8 +30,6 @@ sp-api = {git = "https://github.com/paritytech/substrate", default-features = fa
 sp-core = {git = "https://github.com/paritytech/substrate", default-features = false, branch = "polkadot-v0.9.29"}
 sp-runtime = {git = "https://github.com/paritytech/substrate", default-features = false, branch = "polkadot-v0.9.29"}
 sp-std = {git = "https://github.com/paritytech/substrate", default-features = false, branch = "polkadot-v0.9.29"}
-#ORML
-orml-utilities = {git = "https://github.com/open-web3-stack/open-runtime-module-library", default-features = false, branch = "polkadot-v0.9.29"}
 
 [features]
 default = ['std']
@@ -42,5 +40,4 @@ std = [
   'sp-std/std',
   'sp-runtime/std',
   'sp-api/std',
-  "orml-utilities/std",
 ]

--- a/common/primitives/src/msa.rs
+++ b/common/primitives/src/msa.rs
@@ -1,5 +1,7 @@
 use codec::{Decode, Encode, EncodeLike, Error, MaxEncodedLen};
-use frame_support::{dispatch::DispatchResult, traits::Get, BoundedVec, RuntimeDebug};
+use frame_support::{
+	dispatch::DispatchResult, traits::Get, BoundedBTreeMap, BoundedVec, RuntimeDebug,
+};
 use scale_info::TypeInfo;
 #[cfg(feature = "std")]
 use serde::{Deserialize, Serialize};
@@ -7,7 +9,6 @@ use sp_runtime::DispatchError;
 use sp_std::prelude::Vec;
 
 pub use crate::schema::SchemaId;
-pub use orml_utilities::OrderedSet;
 
 /// Message Source Id or msaId is the unique identifier for Message Source Accounts
 /// Message Source Id or msaId is the unique identifier for Message Source Accounts
@@ -48,16 +49,17 @@ impl From<Delegator> for MessageSourceId {
 }
 
 /// Struct for the information of the relationship between an MSA and a Provider
-#[derive(TypeInfo, RuntimeDebug, Clone, Decode, Encode, PartialEq, Default, MaxEncodedLen)]
+#[derive(TypeInfo, RuntimeDebug, Clone, Decode, Encode, PartialEq, MaxEncodedLen, Eq)]
 #[scale_info(skip_type_params(MaxSchemaGrantsPerDelegation))]
-pub struct Delegation<BlockNumber, MaxSchemaGrantsPerDelegation>
+pub struct Delegation<SchemaId, BlockNumber, MaxSchemaGrantsPerDelegation>
 where
 	MaxSchemaGrantsPerDelegation: Get<u32>,
 {
 	/// Block number the grant will be revoked.
-	pub expired: BlockNumber,
+	pub revoked_at: BlockNumber,
 	/// Schemas that the provider is allowed to use for a delegated message.
-	pub schemas: OrderedSet<SchemaId, MaxSchemaGrantsPerDelegation>,
+	pub schema_permissions:
+		BoundedBTreeMap<SchemaId, Option<BlockNumber>, MaxSchemaGrantsPerDelegation>,
 }
 
 /// Provider is the recipient of a delegation.
@@ -139,6 +141,8 @@ pub trait ProviderLookup {
 	type BlockNumber;
 	/// Type for maximum number of schemas that can be granted to a provider.
 	type MaxSchemaGrantsPerDelegation: Get<u32> + Clone + Eq;
+	/// Schema Id is the unique identifier for a Schema
+	type SchemaId;
 
 	/// Gets the relationship information for this delegator, provider pair
 	/// # Arguments
@@ -149,7 +153,7 @@ pub trait ProviderLookup {
 	fn get_delegation_of(
 		delegator: Delegator,
 		provider: Provider,
-	) -> Option<Delegation<Self::BlockNumber, Self::MaxSchemaGrantsPerDelegation>>;
+	) -> Option<Delegation<Self::SchemaId, Self::BlockNumber, Self::MaxSchemaGrantsPerDelegation>>;
 }
 
 /// A behavior that allows for validating a delegator-provider relationship
@@ -158,6 +162,8 @@ pub trait DelegationValidator {
 	type BlockNumber;
 	/// Type for maximum number of schemas that can be granted to a provider.
 	type MaxSchemaGrantsPerDelegation: Get<u32> + Clone + Eq;
+	/// Schema Id is the unique identifier for a Schema
+	type SchemaId;
 
 	/// Validates that the delegator and provider have a relationship at this point
 	/// # Arguments
@@ -169,7 +175,10 @@ pub trait DelegationValidator {
 		provider: Provider,
 		delegator: Delegator,
 		block_number: Option<Self::BlockNumber>,
-	) -> Result<Delegation<Self::BlockNumber, Self::MaxSchemaGrantsPerDelegation>, DispatchError>;
+	) -> Result<
+		Delegation<Self::SchemaId, Self::BlockNumber, Self::MaxSchemaGrantsPerDelegation>,
+		DispatchError,
+	>;
 }
 
 /// A behavior that allows for validating a schema grant

--- a/common/primitives/src/schema.rs
+++ b/common/primitives/src/schema.rs
@@ -73,7 +73,7 @@ pub trait SchemaProvider<SchemaId> {
 /// This allows other Pallets to check validity of schema ids.
 pub trait SchemaValidator<SchemaId> {
 	/// Checks that a collection of SchemaIds are all valid
-	fn are_all_schema_ids_valid(schema_ids: Vec<SchemaId>) -> bool;
+	fn are_all_schema_ids_valid(schema_ids: &Vec<SchemaId>) -> bool;
 
 	/// Set the schema counter for testing purposes.
 	#[cfg(any(feature = "std", feature = "runtime-benchmarks", test))]

--- a/pallets/messages/src/mock.rs
+++ b/pallets/messages/src/mock.rs
@@ -2,7 +2,7 @@ use crate as pallet_messages;
 use common_primitives::{
 	msa::{
 		Delegation, DelegationValidator, Delegator, MessageSourceId, MsaLookup, MsaValidator,
-		OrderedSet, Provider, ProviderLookup, SchemaGrantValidator,
+		Provider, ProviderLookup, SchemaGrantValidator,
 	},
 	schema::*,
 };
@@ -150,31 +150,36 @@ impl MsaValidator for MsaInfoHandler {
 impl ProviderLookup for DelegationInfoHandler {
 	type BlockNumber = u64;
 	type MaxSchemaGrantsPerDelegation = MaxSchemaGrantsPerDelegation;
+	type SchemaId = SchemaId;
 
 	fn get_delegation_of(
 		_delegator: Delegator,
 		provider: Provider,
-	) -> Option<Delegation<Self::BlockNumber, MaxSchemaGrantsPerDelegation>> {
+	) -> Option<Delegation<SchemaId, Self::BlockNumber, MaxSchemaGrantsPerDelegation>> {
 		if provider == Provider(2000) {
 			return None
 		};
-		Some(Delegation { expired: 100, schemas: OrderedSet::new() })
+		Some(Delegation { revoked_at: 100, schema_permissions: Default::default() })
 	}
 }
 impl DelegationValidator for DelegationInfoHandler {
 	type BlockNumber = u64;
 	type MaxSchemaGrantsPerDelegation = MaxSchemaGrantsPerDelegation;
+	type SchemaId = SchemaId;
 
 	fn ensure_valid_delegation(
 		provider: Provider,
 		_delegator: Delegator,
 		_block_number: Option<Self::BlockNumber>,
-	) -> Result<Delegation<Self::BlockNumber, Self::MaxSchemaGrantsPerDelegation>, DispatchError> {
+	) -> Result<
+		Delegation<SchemaId, Self::BlockNumber, Self::MaxSchemaGrantsPerDelegation>,
+		DispatchError,
+	> {
 		if provider == Provider(2000) {
 			return Err(DispatchError::Other("some delegation error"))
 		};
 
-		Ok(Delegation { schemas: OrderedSet::new(), expired: Default::default() })
+		Ok(Delegation { schema_permissions: Default::default(), revoked_at: Default::default() })
 	}
 }
 impl SchemaGrantValidator for SchemaGrantValidationHandler {

--- a/pallets/msa/Cargo.toml
+++ b/pallets/msa/Cargo.toml
@@ -23,13 +23,11 @@ scale-info = {version = "2.1.2", default-features = false, features = [
   "derive",
 ]}
 sp-core = {default-features = false, git = "https://github.com/paritytech/substrate.git", branch = "polkadot-v0.9.29"}
-sp-io = { default-features = false, git = "https://github.com/paritytech/substrate.git", branch = "polkadot-v0.9.29" }
+sp-io = {default-features = false, git = "https://github.com/paritytech/substrate.git", branch = "polkadot-v0.9.29"}
 sp-runtime = {default-features = false, git = "https://github.com/paritytech/substrate.git", branch = "polkadot-v0.9.29"}
 sp-std = {default-features = false, git = "https://github.com/paritytech/substrate.git", branch = "polkadot-v0.9.29"}
 # Frequency related dependencies
 common-primitives = {default-features = false, path = "../../common/primitives"}
-#ORML
-orml-utilities = {git = "https://github.com/open-web3-stack/open-runtime-module-library", default-features = false, branch = "polkadot-v0.9.29"}
 
 [dev-dependencies]
 common-runtime = {path = '../../runtime/common', default-features = false}
@@ -46,9 +44,10 @@ std = [
   "frame-support/std",
   "frame-system/std",
   "frame-benchmarking/std",
-  "orml-utilities/std",
   "sp-runtime/std",
   "sp-std/std",
   "sp-core/std",
+  "pallet-schemas/std",
+  "common-primitives/std",
 ]
 try-runtime = ["frame-support/try-runtime"]

--- a/pallets/schemas/src/lib.rs
+++ b/pallets/schemas/src/lib.rs
@@ -318,9 +318,9 @@ pub mod pallet {
 }
 
 impl<T: Config> SchemaValidator<SchemaId> for Pallet<T> {
-	fn are_all_schema_ids_valid(schema_ids: Vec<SchemaId>) -> bool {
+	fn are_all_schema_ids_valid(schema_ids: &Vec<SchemaId>) -> bool {
 		let latest_issue_schema_id = Self::get_current_schema_identifier_maximum();
-		schema_ids.into_iter().all(|id| id <= latest_issue_schema_id)
+		schema_ids.iter().all(|id| id <= &latest_issue_schema_id)
 	}
 
 	#[cfg(any(feature = "std", feature = "runtime-benchmarks", test))]


### PR DESCRIPTION
# Goal
Update the schema-permission storage to use a
BoundedBTreeMap instead of an OrderSet.

This update increase performance when writing and
updating schema permissions.

Additionally, each schema permission
stores a field, "revoked_at," that indicates the
block number for which the permission expires.
If set to "None" type, it means that
the permission is not revoked and is valid.

issue-455