### PR TITLE
Remove unused nonce field

### DIFF
--- a/pallets/messages/src/weights.rs
+++ b/pallets/messages/src/weights.rs
@@ -69,8 +69,8 @@ impl<T: frame_system::Config> WeightInfo for SubstrateWeight<T> {
 		Weight::from_ref_time(0 as u64)
 			// Standard Error: 0
 			.saturating_add(Weight::from_ref_time(1_000 as u64).saturating_mul(n as u64))
-			// Standard Error: 3_000
-			.saturating_add(Weight::from_ref_time(267_000 as u64).saturating_mul(m as u64))
+			// Standard Error: 2_000
+			.saturating_add(Weight::from_ref_time(264_000 as u64).saturating_mul(m as u64))
 			.saturating_add(T::DbWeight::get().reads(4 as u64))
 			.saturating_add(T::DbWeight::get().writes(1 as u64))
 	}
@@ -82,7 +82,7 @@ impl<T: frame_system::Config> WeightInfo for SubstrateWeight<T> {
 			// Standard Error: 0
 			.saturating_add(Weight::from_ref_time(2_000 as u64).saturating_mul(n as u64))
 			// Standard Error: 2_000
-			.saturating_add(Weight::from_ref_time(225_000 as u64).saturating_mul(m as u64))
+			.saturating_add(Weight::from_ref_time(223_000 as u64).saturating_mul(m as u64))
 			.saturating_add(T::DbWeight::get().reads(3 as u64))
 			.saturating_add(T::DbWeight::get().writes(1 as u64))
 	}
@@ -91,9 +91,9 @@ impl<T: frame_system::Config> WeightInfo for SubstrateWeight<T> {
 	fn on_initialize(m: u32, s: u32, ) -> Weight {
 		Weight::from_ref_time(0 as u64)
 			// Standard Error: 13_000
-			.saturating_add(Weight::from_ref_time(440_000 as u64).saturating_mul(m as u64))
-			// Standard Error: 140_000
-			.saturating_add(Weight::from_ref_time(5_098_000 as u64).saturating_mul(s as u64))
+			.saturating_add(Weight::from_ref_time(456_000 as u64).saturating_mul(m as u64))
+			// Standard Error: 139_000
+			.saturating_add(Weight::from_ref_time(5_254_000 as u64).saturating_mul(s as u64))
 			.saturating_add(T::DbWeight::get().reads(1 as u64))
 			.saturating_add(T::DbWeight::get().writes((1 as u64).saturating_mul(s as u64)))
 	}
@@ -109,8 +109,8 @@ impl WeightInfo for () {
 		Weight::from_ref_time(0 as u64)
 			// Standard Error: 0
 			.saturating_add(Weight::from_ref_time(1_000 as u64).saturating_mul(n as u64))
-			// Standard Error: 3_000
-			.saturating_add(Weight::from_ref_time(267_000 as u64).saturating_mul(m as u64))
+			// Standard Error: 2_000
+			.saturating_add(Weight::from_ref_time(264_000 as u64).saturating_mul(m as u64))
 			.saturating_add(RocksDbWeight::get().reads(4 as u64))
 			.saturating_add(RocksDbWeight::get().writes(1 as u64))
 	}
@@ -122,7 +122,7 @@ impl WeightInfo for () {
 			// Standard Error: 0
 			.saturating_add(Weight::from_ref_time(2_000 as u64).saturating_mul(n as u64))
 			// Standard Error: 2_000
-			.saturating_add(Weight::from_ref_time(225_000 as u64).saturating_mul(m as u64))
+			.saturating_add(Weight::from_ref_time(223_000 as u64).saturating_mul(m as u64))
 			.saturating_add(RocksDbWeight::get().reads(3 as u64))
 			.saturating_add(RocksDbWeight::get().writes(1 as u64))
 	}
@@ -131,9 +131,9 @@ impl WeightInfo for () {
 	fn on_initialize(m: u32, s: u32, ) -> Weight {
 		Weight::from_ref_time(0 as u64)
 			// Standard Error: 13_000
-			.saturating_add(Weight::from_ref_time(440_000 as u64).saturating_mul(m as u64))
-			// Standard Error: 140_000
-			.saturating_add(Weight::from_ref_time(5_098_000 as u64).saturating_mul(s as u64))
+			.saturating_add(Weight::from_ref_time(456_000 as u64).saturating_mul(m as u64))
+			// Standard Error: 139_000
+			.saturating_add(Weight::from_ref_time(5_254_000 as u64).saturating_mul(s as u64))
 			.saturating_add(RocksDbWeight::get().reads(1 as u64))
 			.saturating_add(RocksDbWeight::get().writes((1 as u64).saturating_mul(s as u64)))
 	}

--- a/pallets/msa/src/benchmarking.rs
+++ b/pallets/msa/src/benchmarking.rs
@@ -47,7 +47,7 @@ fn create_payload_and_signature<T: Config>() -> (AddProvider, MultiSignature, T:
 
 fn add_key_payload_and_signature<T: Config>() -> (AddKeyData, MultiSignature, T::AccountId) {
 	let account = SignerId::generate_pair(None);
-	let add_key_payload = AddKeyData { msa_id: 1u64.into(), nonce: 0, expiration: 10 };
+	let add_key_payload = AddKeyData { msa_id: 1u64.into(), expiration: 10 };
 	let encode_add_provider_data = wrap_binary_data(add_key_payload.encode());
 
 	let signature = account.sign(&encode_add_provider_data).unwrap();

--- a/pallets/msa/src/replay_tests.rs
+++ b/pallets/msa/src/replay_tests.rs
@@ -35,7 +35,7 @@ pub fn user_adds_key_to_msa(
 	delegator_pair: sp_core::sr25519::Pair,
 	new_pair: sp_core::sr25519::Pair,
 ) {
-	let add_key_payload: AddKeyData = AddKeyData { msa_id: 2, nonce: 0, expiration: 109 };
+	let add_key_payload: AddKeyData = AddKeyData { msa_id: 2, expiration: 109 };
 	let encode_add_key_data = wrap_binary_data(add_key_payload.encode());
 	let add_key_signature_delegator = delegator_pair.sign(&encode_add_key_data);
 	let add_key_signature_new_key = new_pair.sign(&encode_add_key_data);
@@ -252,7 +252,7 @@ fn replaying_create_sponsored_account_with_delegation_fails_03() {
 		let (new_key_pair, _) = sr25519::Pair::generate();
 		let new_public_key = new_key_pair.public();
 
-		let add_new_key_data = AddKeyData { nonce: 1, msa_id: 2, expiration: 10 };
+		let add_new_key_data = AddKeyData { msa_id: 2, expiration: 10 };
 		let encode_add_key_data = wrap_binary_data(add_new_key_data.encode());
 
 		let add_key_signature_delegator = delegator_keypair.sign(&encode_add_key_data);

--- a/pallets/msa/src/tests.rs
+++ b/pallets/msa/src/tests.rs
@@ -78,7 +78,7 @@ fn it_throws_error_when_key_verification_fails() {
 
 		let fake_account = key_pair_2.public();
 
-		let add_new_key_data = AddKeyData { nonce: 1, msa_id: new_msa_id, expiration: 10 };
+		let add_new_key_data = AddKeyData { msa_id: new_msa_id, expiration: 10 };
 		let encode_data_new_key_data = wrap_binary_data(add_new_key_data.encode());
 
 		let signature: MultiSignature = key_pair.sign(&encode_data_new_key_data).into();
@@ -111,7 +111,7 @@ fn it_throws_error_when_not_msa_owner() {
 		let new_account = key_pair_2.public();
 		let (_new_msa_id2, _) = Msa::create_account(new_account.into(), EMPTY_FUNCTION).unwrap();
 
-		let add_new_key_data = AddKeyData { nonce: 0, msa_id: new_msa_id, expiration: 10 };
+		let add_new_key_data = AddKeyData { msa_id: new_msa_id, expiration: 10 };
 		let encode_data_new_key_data = wrap_binary_data(add_new_key_data.encode());
 
 		let signature: MultiSignature = key_pair_2.sign(&encode_data_new_key_data).into();
@@ -139,7 +139,7 @@ fn it_throws_error_when_for_duplicate_key() {
 
 		let (new_msa_id, _) = Msa::create_account(new_account.into(), EMPTY_FUNCTION).unwrap();
 
-		let add_new_key_data = AddKeyData { nonce: 1, msa_id: new_msa_id, expiration: 10 };
+		let add_new_key_data = AddKeyData { msa_id: new_msa_id, expiration: 10 };
 		let encode_data_new_key_data = wrap_binary_data(add_new_key_data.encode());
 
 		let signature: MultiSignature = key_pair.sign(&encode_data_new_key_data).into();
@@ -165,7 +165,7 @@ fn add_key_with_more_than_allowed_should_panic() {
 		let (key_pair, _) = sr25519::Pair::generate();
 		let account = key_pair.public();
 		let (new_msa_id, _) = Msa::create_account(account.into(), EMPTY_FUNCTION).unwrap();
-		let add_new_key_data = AddKeyData { nonce: 1, msa_id: new_msa_id, expiration: 10 };
+		let add_new_key_data = AddKeyData { msa_id: new_msa_id, expiration: 10 };
 		let encode_data_new_key_data = wrap_binary_data(add_new_key_data.encode());
 
 		for _ in 1..<Test as Config>::MaxPublicKeysPerMsa::get() {
@@ -215,7 +215,7 @@ fn add_key_with_valid_request_should_store_value_and_event() {
 
 		let new_key = key_pair_2.public();
 
-		let add_new_key_data = AddKeyData { nonce: 1, msa_id: new_msa_id, expiration: 10 };
+		let add_new_key_data = AddKeyData { msa_id: new_msa_id, expiration: 10 };
 		let encode_data_new_key_data = wrap_binary_data(add_new_key_data.encode());
 		let signature_owner: MultiSignature = key_pair.sign(&encode_data_new_key_data).into();
 		let signature_new_key: MultiSignature = key_pair_2.sign(&encode_data_new_key_data).into();
@@ -257,7 +257,7 @@ fn add_key_with_expired_proof_fails() {
 
 		// The current block is 1, therefore setting the proof expiration to 1 shoud cause
 		// the extrinsic to fail because the proof has expired.
-		let add_new_key_data = AddKeyData { nonce: 1, msa_id: new_msa_id, expiration: 1 };
+		let add_new_key_data = AddKeyData { msa_id: new_msa_id, expiration: 1 };
 		let encode_data_new_key_data = wrap_binary_data(add_new_key_data.encode());
 
 		System::set_block_number(2);
@@ -294,7 +294,7 @@ fn add_key_with_proof_too_far_into_future_fails() {
 		// The current block is 1, therefore setting the proof expiration to  + 1
 		// should cause the extrinsic to fail because the proof is only valid for
 		// more blocks.
-		let add_new_key_data = AddKeyData { nonce: 1, msa_id: new_msa_id, expiration: 202 };
+		let add_new_key_data = AddKeyData { msa_id: new_msa_id, expiration: 202 };
 		let encode_data_new_key_data = wrap_binary_data(add_new_key_data.encode());
 
 		let signature: MultiSignature = key_pair_2.sign(&encode_data_new_key_data).into();
@@ -384,7 +384,7 @@ fn test_retire_msa_success() {
 		let new_account2 = key_pair2.public();
 		let (msa_id2, _) = Msa::create_account(new_account2.into(), EMPTY_FUNCTION).unwrap();
 
-		let add_new_key_data = AddKeyData { nonce: 1, msa_id: msa_id2, expiration: 10 };
+		let add_new_key_data = AddKeyData { msa_id: msa_id2, expiration: 10 };
 		let encode_data_new_key_data = wrap_binary_data(add_new_key_data.encode());
 		let signature: MultiSignature = key_pair1.sign(&encode_data_new_key_data).into();
 		assert_noop!(
@@ -1494,7 +1494,7 @@ fn double_add_key_two_msa_fails() {
 		let (msa_id1, _) = Msa::create_account(new_account1.into(), EMPTY_FUNCTION).unwrap();
 		let (_msa_id2, _) = Msa::create_account(new_account2.into(), EMPTY_FUNCTION).unwrap();
 
-		let add_new_key_data = AddKeyData { nonce: 1, msa_id: msa_id1, expiration: 10 };
+		let add_new_key_data = AddKeyData { msa_id: msa_id1, expiration: 10 };
 		let encode_data_new_key_data = wrap_binary_data(add_new_key_data.encode());
 		let signature: MultiSignature = key_pair1.sign(&encode_data_new_key_data).into();
 		assert_noop!(
@@ -1524,7 +1524,7 @@ fn add_removed_key_to_msa_pass() {
 
 		assert_ok!(Msa::delete_key_for_msa(msa_id1, &new_account1.into()));
 
-		let add_new_key_data = AddKeyData { nonce: 1, msa_id: msa_id2, expiration: 10 };
+		let add_new_key_data = AddKeyData { msa_id: msa_id2, expiration: 10 };
 		let encode_data_new_key_data = wrap_binary_data(add_new_key_data.encode());
 		let signature_owner: MultiSignature = key_pair2.sign(&encode_data_new_key_data).into();
 		let signature_new_key: MultiSignature = key_pair1.sign(&encode_data_new_key_data).into();
@@ -2101,8 +2101,7 @@ pub fn add_msa_key_replay_fails() {
 		let nonce = 1u32;
 		for tc in test_cases {
 			System::set_block_number(tc.current);
-			let add_new_key_data =
-				AddKeyData { nonce, msa_id: new_msa_id, expiration: tc.mortality };
+			let add_new_key_data = AddKeyData { msa_id: new_msa_id, expiration: tc.mortality };
 			let encode_data_new_key_data = wrap_binary_data(add_new_key_data.encode());
 			let (new_key_pair, _) = sr25519::Pair::generate();
 			let new_delegator_account = new_key_pair.public();

--- a/pallets/msa/src/types.rs
+++ b/pallets/msa/src/types.rs
@@ -18,8 +18,6 @@ pub const EMPTY_FUNCTION: fn(MessageSourceId) -> DispatchResult = |_| Ok(());
 pub struct AddKeyData {
 	/// Message Source Account identifier
 	pub msa_id: MessageSourceId,
-	/// A cryptographic nonce.
-	pub nonce: u32,
 	/// The block number at which the signed proof for add_public_key_to_msa expires.
 	pub expiration: BlockNumber,
 }

--- a/pallets/msa/src/weights.rs
+++ b/pallets/msa/src/weights.rs
@@ -72,9 +72,9 @@ impl<T: frame_system::Config> WeightInfo for SubstrateWeight<T> {
 	// Storage: Msa PublicKeyToMsaId (r:1 w:1)
 	// Storage: Msa PublicKeyCountForMsaId (r:1 w:1)
 	fn create(s: u32, ) -> Weight {
-		Weight::from_ref_time(50_141_000 as u64)
+		Weight::from_ref_time(50_067_000 as u64)
 			// Standard Error: 4_000
-			.saturating_add(Weight::from_ref_time(53_000 as u64).saturating_mul(s as u64))
+			.saturating_add(Weight::from_ref_time(56_000 as u64).saturating_mul(s as u64))
 			.saturating_add(T::DbWeight::get().reads(3 as u64))
 			.saturating_add(T::DbWeight::get().writes(3 as u64))
 	}
@@ -86,16 +86,16 @@ impl<T: frame_system::Config> WeightInfo for SubstrateWeight<T> {
 	// Storage: Schemas CurrentSchemaIdentifierMaximum (r:1 w:0)
 	// Storage: Msa DelegatorAndProviderToDelegation (r:1 w:1)
 	fn create_sponsored_account_with_delegation() -> Weight {
-		Weight::from_ref_time(102_749_000 as u64)
+		Weight::from_ref_time(101_957_000 as u64)
 			.saturating_add(T::DbWeight::get().reads(8 as u64))
 			.saturating_add(T::DbWeight::get().writes(5 as u64))
 	}
 	// Storage: Msa PublicKeyToMsaId (r:1 w:0)
 	// Storage: Msa DelegatorAndProviderToDelegation (r:1 w:1)
 	fn revoke_delegation_by_provider(s: u32, ) -> Weight {
-		Weight::from_ref_time(47_692_000 as u64)
-			// Standard Error: 4_000
-			.saturating_add(Weight::from_ref_time(94_000 as u64).saturating_mul(s as u64))
+		Weight::from_ref_time(45_478_000 as u64)
+			// Standard Error: 3_000
+			.saturating_add(Weight::from_ref_time(96_000 as u64).saturating_mul(s as u64))
 			.saturating_add(T::DbWeight::get().reads(2 as u64))
 			.saturating_add(T::DbWeight::get().writes(1 as u64))
 	}
@@ -103,21 +103,21 @@ impl<T: frame_system::Config> WeightInfo for SubstrateWeight<T> {
 	// Storage: Msa PublicKeyToMsaId (r:2 w:1)
 	// Storage: Msa PublicKeyCountForMsaId (r:1 w:1)
 	fn add_public_key_to_msa() -> Weight {
-		Weight::from_ref_time(141_996_000 as u64)
+		Weight::from_ref_time(141_649_000 as u64)
 			.saturating_add(T::DbWeight::get().reads(4 as u64))
 			.saturating_add(T::DbWeight::get().writes(3 as u64))
 	}
 	// Storage: Msa PublicKeyToMsaId (r:2 w:1)
 	// Storage: Msa PublicKeyCountForMsaId (r:1 w:1)
 	fn delete_msa_public_key() -> Weight {
-		Weight::from_ref_time(28_480_000 as u64)
+		Weight::from_ref_time(28_617_000 as u64)
 			.saturating_add(T::DbWeight::get().reads(3 as u64))
 			.saturating_add(T::DbWeight::get().writes(2 as u64))
 	}
 	// Storage: Msa PublicKeyToMsaId (r:1 w:1)
 	// Storage: Msa PublicKeyCountForMsaId (r:1 w:1)
 	fn retire_msa() -> Weight {
-		Weight::from_ref_time(29_868_000 as u64)
+		Weight::from_ref_time(30_135_000 as u64)
 			.saturating_add(T::DbWeight::get().reads(2 as u64))
 			.saturating_add(T::DbWeight::get().writes(2 as u64))
 	}
@@ -127,28 +127,28 @@ impl<T: frame_system::Config> WeightInfo for SubstrateWeight<T> {
 	// Storage: Schemas CurrentSchemaIdentifierMaximum (r:1 w:0)
 	// Storage: Msa DelegatorAndProviderToDelegation (r:1 w:1)
 	fn grant_delegation() -> Weight {
-		Weight::from_ref_time(93_732_000 as u64)
+		Weight::from_ref_time(92_574_000 as u64)
 			.saturating_add(T::DbWeight::get().reads(6 as u64))
 			.saturating_add(T::DbWeight::get().writes(2 as u64))
 	}
 	// Storage: Msa PublicKeyToMsaId (r:1 w:0)
 	// Storage: Msa DelegatorAndProviderToDelegation (r:1 w:1)
 	fn revoke_delegation_by_delegator() -> Weight {
-		Weight::from_ref_time(25_188_000 as u64)
+		Weight::from_ref_time(24_773_000 as u64)
 			.saturating_add(T::DbWeight::get().reads(2 as u64))
 			.saturating_add(T::DbWeight::get().writes(1 as u64))
 	}
 	// Storage: Msa PublicKeyToMsaId (r:1 w:0)
 	// Storage: Msa ProviderToRegistryEntry (r:1 w:1)
 	fn create_provider() -> Weight {
-		Weight::from_ref_time(20_918_000 as u64)
+		Weight::from_ref_time(20_605_000 as u64)
 			.saturating_add(T::DbWeight::get().reads(2 as u64))
 			.saturating_add(T::DbWeight::get().writes(1 as u64))
 	}
 	fn on_initialize(m: u32, ) -> Weight {
-		Weight::from_ref_time(11_950_000 as u64)
+		Weight::from_ref_time(11_493_000 as u64)
 			// Standard Error: 0
-			.saturating_add(Weight::from_ref_time(2_000 as u64).saturating_mul(m as u64))
+			.saturating_add(Weight::from_ref_time(3_000 as u64).saturating_mul(m as u64))
 	}
 }
 
@@ -158,9 +158,9 @@ impl WeightInfo for () {
 	// Storage: Msa PublicKeyToMsaId (r:1 w:1)
 	// Storage: Msa PublicKeyCountForMsaId (r:1 w:1)
 	fn create(s: u32, ) -> Weight {
-		Weight::from_ref_time(50_141_000 as u64)
+		Weight::from_ref_time(50_067_000 as u64)
 			// Standard Error: 4_000
-			.saturating_add(Weight::from_ref_time(53_000 as u64).saturating_mul(s as u64))
+			.saturating_add(Weight::from_ref_time(56_000 as u64).saturating_mul(s as u64))
 			.saturating_add(RocksDbWeight::get().reads(3 as u64))
 			.saturating_add(RocksDbWeight::get().writes(3 as u64))
 	}
@@ -172,16 +172,16 @@ impl WeightInfo for () {
 	// Storage: Schemas CurrentSchemaIdentifierMaximum (r:1 w:0)
 	// Storage: Msa DelegatorAndProviderToDelegation (r:1 w:1)
 	fn create_sponsored_account_with_delegation() -> Weight {
-		Weight::from_ref_time(102_749_000 as u64)
+		Weight::from_ref_time(101_957_000 as u64)
 			.saturating_add(RocksDbWeight::get().reads(8 as u64))
 			.saturating_add(RocksDbWeight::get().writes(5 as u64))
 	}
 	// Storage: Msa PublicKeyToMsaId (r:1 w:0)
 	// Storage: Msa DelegatorAndProviderToDelegation (r:1 w:1)
 	fn revoke_delegation_by_provider(s: u32, ) -> Weight {
-		Weight::from_ref_time(47_692_000 as u64)
-			// Standard Error: 4_000
-			.saturating_add(Weight::from_ref_time(94_000 as u64).saturating_mul(s as u64))
+		Weight::from_ref_time(45_478_000 as u64)
+			// Standard Error: 3_000
+			.saturating_add(Weight::from_ref_time(96_000 as u64).saturating_mul(s as u64))
 			.saturating_add(RocksDbWeight::get().reads(2 as u64))
 			.saturating_add(RocksDbWeight::get().writes(1 as u64))
 	}
@@ -189,21 +189,21 @@ impl WeightInfo for () {
 	// Storage: Msa PublicKeyToMsaId (r:2 w:1)
 	// Storage: Msa PublicKeyCountForMsaId (r:1 w:1)
 	fn add_public_key_to_msa() -> Weight {
-		Weight::from_ref_time(141_996_000 as u64)
+		Weight::from_ref_time(141_649_000 as u64)
 			.saturating_add(RocksDbWeight::get().reads(4 as u64))
 			.saturating_add(RocksDbWeight::get().writes(3 as u64))
 	}
 	// Storage: Msa PublicKeyToMsaId (r:2 w:1)
 	// Storage: Msa PublicKeyCountForMsaId (r:1 w:1)
 	fn delete_msa_public_key() -> Weight {
-		Weight::from_ref_time(28_480_000 as u64)
+		Weight::from_ref_time(28_617_000 as u64)
 			.saturating_add(RocksDbWeight::get().reads(3 as u64))
 			.saturating_add(RocksDbWeight::get().writes(2 as u64))
 	}
 	// Storage: Msa PublicKeyToMsaId (r:1 w:1)
 	// Storage: Msa PublicKeyCountForMsaId (r:1 w:1)
 	fn retire_msa() -> Weight {
-		Weight::from_ref_time(29_868_000 as u64)
+		Weight::from_ref_time(30_135_000 as u64)
 			.saturating_add(RocksDbWeight::get().reads(2 as u64))
 			.saturating_add(RocksDbWeight::get().writes(2 as u64))
 	}
@@ -213,27 +213,27 @@ impl WeightInfo for () {
 	// Storage: Schemas CurrentSchemaIdentifierMaximum (r:1 w:0)
 	// Storage: Msa DelegatorAndProviderToDelegation (r:1 w:1)
 	fn grant_delegation() -> Weight {
-		Weight::from_ref_time(93_732_000 as u64)
+		Weight::from_ref_time(92_574_000 as u64)
 			.saturating_add(RocksDbWeight::get().reads(6 as u64))
 			.saturating_add(RocksDbWeight::get().writes(2 as u64))
 	}
 	// Storage: Msa PublicKeyToMsaId (r:1 w:0)
 	// Storage: Msa DelegatorAndProviderToDelegation (r:1 w:1)
 	fn revoke_delegation_by_delegator() -> Weight {
-		Weight::from_ref_time(25_188_000 as u64)
+		Weight::from_ref_time(24_773_000 as u64)
 			.saturating_add(RocksDbWeight::get().reads(2 as u64))
 			.saturating_add(RocksDbWeight::get().writes(1 as u64))
 	}
 	// Storage: Msa PublicKeyToMsaId (r:1 w:0)
 	// Storage: Msa ProviderToRegistryEntry (r:1 w:1)
 	fn create_provider() -> Weight {
-		Weight::from_ref_time(20_918_000 as u64)
+		Weight::from_ref_time(20_605_000 as u64)
 			.saturating_add(RocksDbWeight::get().reads(2 as u64))
 			.saturating_add(RocksDbWeight::get().writes(1 as u64))
 	}
 	fn on_initialize(m: u32, ) -> Weight {
-		Weight::from_ref_time(11_950_000 as u64)
+		Weight::from_ref_time(11_493_000 as u64)
 			// Standard Error: 0
-			.saturating_add(Weight::from_ref_time(2_000 as u64).saturating_mul(m as u64))
+			.saturating_add(Weight::from_ref_time(3_000 as u64).saturating_mul(m as u64))
 	}
 }

--- a/pallets/schemas/src/weights.rs
+++ b/pallets/schemas/src/weights.rs
@@ -67,7 +67,7 @@ impl<T: frame_system::Config> WeightInfo for SubstrateWeight<T> {
 			// Standard Error: 0
 			.saturating_add(Weight::from_ref_time(32_000 as u64).saturating_mul(m as u64))
 			// Standard Error: 8_000
-			.saturating_add(Weight::from_ref_time(116_000 as u64).saturating_mul(n as u64))
+			.saturating_add(Weight::from_ref_time(119_000 as u64).saturating_mul(n as u64))
 			.saturating_add(T::DbWeight::get().reads(2 as u64))
 			.saturating_add(T::DbWeight::get().writes(2 as u64))
 	}
@@ -83,7 +83,7 @@ impl WeightInfo for () {
 			// Standard Error: 0
 			.saturating_add(Weight::from_ref_time(32_000 as u64).saturating_mul(m as u64))
 			// Standard Error: 8_000
-			.saturating_add(Weight::from_ref_time(116_000 as u64).saturating_mul(n as u64))
+			.saturating_add(Weight::from_ref_time(119_000 as u64).saturating_mul(n as u64))
 			.saturating_add(RocksDbWeight::get().reads(2 as u64))
 			.saturating_add(RocksDbWeight::get().writes(2 as u64))
 	}

--- a/runtime/common/src/weights/orml_vesting.rs
+++ b/runtime/common/src/weights/orml_vesting.rs
@@ -38,7 +38,7 @@ impl<T: frame_system::Config> orml_vesting::WeightInfo for SubstrateWeight<T> {
 	// Storage: System Account (r:2 w:2)
 	// Storage: Balances Locks (r:1 w:1)
 	fn vested_transfer() -> Weight {
-		Weight::from_ref_time(59_128_000 as u64)
+		Weight::from_ref_time(57_715_000 as u64)
 			.saturating_add(T::DbWeight::get().reads(5 as u64))
 			.saturating_add(T::DbWeight::get().writes(4 as u64))
 	}
@@ -47,9 +47,9 @@ impl<T: frame_system::Config> orml_vesting::WeightInfo for SubstrateWeight<T> {
 	// Storage: Balances Locks (r:1 w:1)
 	/// The range of component `i` is `[1, 50]`.
 	fn claim(i: u32, ) -> Weight {
-		Weight::from_ref_time(38_950_000 as u64)
+		Weight::from_ref_time(38_465_000 as u64)
 			// Standard Error: 1_000
-			.saturating_add(Weight::from_ref_time(74_000 as u64).saturating_mul(i as u64))
+			.saturating_add(Weight::from_ref_time(81_000 as u64).saturating_mul(i as u64))
 			.saturating_add(T::DbWeight::get().reads(3 as u64))
 			.saturating_add(T::DbWeight::get().writes(2 as u64))
 	}
@@ -58,9 +58,9 @@ impl<T: frame_system::Config> orml_vesting::WeightInfo for SubstrateWeight<T> {
 	// Storage: Vesting VestingSchedules (r:0 w:1)
 	/// The range of component `i` is `[1, 50]`.
 	fn update_vesting_schedules(i: u32, ) -> Weight {
-		Weight::from_ref_time(31_743_000 as u64)
+		Weight::from_ref_time(31_382_000 as u64)
 			// Standard Error: 1_000
-			.saturating_add(Weight::from_ref_time(55_000 as u64).saturating_mul(i as u64))
+			.saturating_add(Weight::from_ref_time(59_000 as u64).saturating_mul(i as u64))
 			.saturating_add(T::DbWeight::get().reads(2 as u64))
 			.saturating_add(T::DbWeight::get().writes(3 as u64))
 	}

--- a/runtime/common/src/weights/pallet_democracy.rs
+++ b/runtime/common/src/weights/pallet_democracy.rs
@@ -38,16 +38,16 @@ impl<T: frame_system::Config> pallet_democracy::WeightInfo for SubstrateWeight<T
 	// Storage: Democracy Blacklist (r:1 w:0)
 	// Storage: Democracy DepositOf (r:0 w:1)
 	fn propose() -> Weight {
-		Weight::from_ref_time(57_129_000 as u64)
+		Weight::from_ref_time(62_684_000 as u64)
 			.saturating_add(T::DbWeight::get().reads(3 as u64))
 			.saturating_add(T::DbWeight::get().writes(3 as u64))
 	}
 	// Storage: Democracy DepositOf (r:1 w:1)
 	/// The range of component `s` is `[0, 100]`.
 	fn second(s: u32, ) -> Weight {
-		Weight::from_ref_time(36_521_000 as u64)
+		Weight::from_ref_time(36_002_000 as u64)
 			// Standard Error: 1_000
-			.saturating_add(Weight::from_ref_time(168_000 as u64).saturating_mul(s as u64))
+			.saturating_add(Weight::from_ref_time(173_000 as u64).saturating_mul(s as u64))
 			.saturating_add(T::DbWeight::get().reads(1 as u64))
 			.saturating_add(T::DbWeight::get().writes(1 as u64))
 	}
@@ -56,9 +56,9 @@ impl<T: frame_system::Config> pallet_democracy::WeightInfo for SubstrateWeight<T
 	// Storage: Balances Locks (r:1 w:1)
 	/// The range of component `r` is `[1, 99]`.
 	fn vote_new(r: u32, ) -> Weight {
-		Weight::from_ref_time(49_514_000 as u64)
-			// Standard Error: 2_000
-			.saturating_add(Weight::from_ref_time(255_000 as u64).saturating_mul(r as u64))
+		Weight::from_ref_time(48_260_000 as u64)
+			// Standard Error: 1_000
+			.saturating_add(Weight::from_ref_time(296_000 as u64).saturating_mul(r as u64))
 			.saturating_add(T::DbWeight::get().reads(3 as u64))
 			.saturating_add(T::DbWeight::get().writes(3 as u64))
 	}
@@ -67,16 +67,16 @@ impl<T: frame_system::Config> pallet_democracy::WeightInfo for SubstrateWeight<T
 	// Storage: Balances Locks (r:1 w:1)
 	/// The range of component `r` is `[1, 99]`.
 	fn vote_existing(r: u32, ) -> Weight {
-		Weight::from_ref_time(49_303_000 as u64)
-			// Standard Error: 2_000
-			.saturating_add(Weight::from_ref_time(255_000 as u64).saturating_mul(r as u64))
+		Weight::from_ref_time(48_416_000 as u64)
+			// Standard Error: 1_000
+			.saturating_add(Weight::from_ref_time(283_000 as u64).saturating_mul(r as u64))
 			.saturating_add(T::DbWeight::get().reads(3 as u64))
 			.saturating_add(T::DbWeight::get().writes(3 as u64))
 	}
 	// Storage: Democracy ReferendumInfoOf (r:1 w:1)
 	// Storage: Democracy Cancellations (r:1 w:1)
 	fn emergency_cancel() -> Weight {
-		Weight::from_ref_time(23_469_000 as u64)
+		Weight::from_ref_time(23_046_000 as u64)
 			.saturating_add(T::DbWeight::get().reads(2 as u64))
 			.saturating_add(T::DbWeight::get().writes(2 as u64))
 	}
@@ -88,9 +88,9 @@ impl<T: frame_system::Config> pallet_democracy::WeightInfo for SubstrateWeight<T
 	// Storage: System Account (r:1 w:1)
 	/// The range of component `p` is `[1, 100]`.
 	fn blacklist(p: u32, ) -> Weight {
-		Weight::from_ref_time(58_085_000 as u64)
+		Weight::from_ref_time(57_429_000 as u64)
 			// Standard Error: 6_000
-			.saturating_add(Weight::from_ref_time(325_000 as u64).saturating_mul(p as u64))
+			.saturating_add(Weight::from_ref_time(346_000 as u64).saturating_mul(p as u64))
 			.saturating_add(T::DbWeight::get().reads(5 as u64))
 			.saturating_add(T::DbWeight::get().writes(6 as u64))
 	}
@@ -98,27 +98,27 @@ impl<T: frame_system::Config> pallet_democracy::WeightInfo for SubstrateWeight<T
 	// Storage: Democracy Blacklist (r:1 w:0)
 	/// The range of component `v` is `[1, 100]`.
 	fn external_propose(v: u32, ) -> Weight {
-		Weight::from_ref_time(16_989_000 as u64)
+		Weight::from_ref_time(17_047_000 as u64)
 			// Standard Error: 0
-			.saturating_add(Weight::from_ref_time(16_000 as u64).saturating_mul(v as u64))
+			.saturating_add(Weight::from_ref_time(14_000 as u64).saturating_mul(v as u64))
 			.saturating_add(T::DbWeight::get().reads(2 as u64))
 			.saturating_add(T::DbWeight::get().writes(1 as u64))
 	}
 	// Storage: Democracy NextExternal (r:0 w:1)
 	fn external_propose_majority() -> Weight {
-		Weight::from_ref_time(5_296_000 as u64)
+		Weight::from_ref_time(5_115_000 as u64)
 			.saturating_add(T::DbWeight::get().writes(1 as u64))
 	}
 	// Storage: Democracy NextExternal (r:0 w:1)
 	fn external_propose_default() -> Weight {
-		Weight::from_ref_time(5_406_000 as u64)
+		Weight::from_ref_time(5_338_000 as u64)
 			.saturating_add(T::DbWeight::get().writes(1 as u64))
 	}
 	// Storage: Democracy NextExternal (r:1 w:1)
 	// Storage: Democracy ReferendumCount (r:1 w:1)
 	// Storage: Democracy ReferendumInfoOf (r:0 w:1)
 	fn fast_track() -> Weight {
-		Weight::from_ref_time(23_784_000 as u64)
+		Weight::from_ref_time(23_441_000 as u64)
 			.saturating_add(T::DbWeight::get().reads(2 as u64))
 			.saturating_add(T::DbWeight::get().writes(3 as u64))
 	}
@@ -126,9 +126,9 @@ impl<T: frame_system::Config> pallet_democracy::WeightInfo for SubstrateWeight<T
 	// Storage: Democracy Blacklist (r:1 w:1)
 	/// The range of component `v` is `[0, 100]`.
 	fn veto_external(v: u32, ) -> Weight {
-		Weight::from_ref_time(25_594_000 as u64)
+		Weight::from_ref_time(25_684_000 as u64)
 			// Standard Error: 0
-			.saturating_add(Weight::from_ref_time(35_000 as u64).saturating_mul(v as u64))
+			.saturating_add(Weight::from_ref_time(31_000 as u64).saturating_mul(v as u64))
 			.saturating_add(T::DbWeight::get().reads(2 as u64))
 			.saturating_add(T::DbWeight::get().writes(2 as u64))
 	}
@@ -137,24 +137,24 @@ impl<T: frame_system::Config> pallet_democracy::WeightInfo for SubstrateWeight<T
 	// Storage: System Account (r:1 w:1)
 	/// The range of component `p` is `[1, 100]`.
 	fn cancel_proposal(p: u32, ) -> Weight {
-		Weight::from_ref_time(46_885_000 as u64)
-			// Standard Error: 3_000
-			.saturating_add(Weight::from_ref_time(303_000 as u64).saturating_mul(p as u64))
+		Weight::from_ref_time(45_691_000 as u64)
+			// Standard Error: 2_000
+			.saturating_add(Weight::from_ref_time(329_000 as u64).saturating_mul(p as u64))
 			.saturating_add(T::DbWeight::get().reads(3 as u64))
 			.saturating_add(T::DbWeight::get().writes(3 as u64))
 	}
 	// Storage: Democracy ReferendumInfoOf (r:0 w:1)
 	fn cancel_referendum() -> Weight {
-		Weight::from_ref_time(15_151_000 as u64)
+		Weight::from_ref_time(14_895_000 as u64)
 			.saturating_add(T::DbWeight::get().writes(1 as u64))
 	}
 	// Storage: Scheduler Lookup (r:1 w:1)
 	// Storage: Scheduler Agenda (r:1 w:1)
 	/// The range of component `r` is `[1, 99]`.
 	fn cancel_queued(r: u32, ) -> Weight {
-		Weight::from_ref_time(28_454_000 as u64)
-			// Standard Error: 3_000
-			.saturating_add(Weight::from_ref_time(636_000 as u64).saturating_mul(r as u64))
+		Weight::from_ref_time(27_786_000 as u64)
+			// Standard Error: 2_000
+			.saturating_add(Weight::from_ref_time(646_000 as u64).saturating_mul(r as u64))
 			.saturating_add(T::DbWeight::get().reads(2 as u64))
 			.saturating_add(T::DbWeight::get().writes(2 as u64))
 	}
@@ -163,9 +163,9 @@ impl<T: frame_system::Config> pallet_democracy::WeightInfo for SubstrateWeight<T
 	// Storage: Democracy ReferendumInfoOf (r:1 w:0)
 	/// The range of component `r` is `[1, 99]`.
 	fn on_initialize_base(r: u32, ) -> Weight {
-		Weight::from_ref_time(8_598_000 as u64)
+		Weight::from_ref_time(9_016_000 as u64)
 			// Standard Error: 4_000
-			.saturating_add(Weight::from_ref_time(2_606_000 as u64).saturating_mul(r as u64))
+			.saturating_add(Weight::from_ref_time(2_580_000 as u64).saturating_mul(r as u64))
 			.saturating_add(T::DbWeight::get().reads(2 as u64))
 			.saturating_add(T::DbWeight::get().reads((1 as u64).saturating_mul(r as u64)))
 			.saturating_add(T::DbWeight::get().writes(1 as u64))
@@ -178,7 +178,7 @@ impl<T: frame_system::Config> pallet_democracy::WeightInfo for SubstrateWeight<T
 	// Storage: Democracy ReferendumInfoOf (r:1 w:0)
 	/// The range of component `r` is `[1, 99]`.
 	fn on_initialize_base_with_launch_period(r: u32, ) -> Weight {
-		Weight::from_ref_time(11_744_000 as u64)
+		Weight::from_ref_time(11_436_000 as u64)
 			// Standard Error: 4_000
 			.saturating_add(Weight::from_ref_time(2_589_000 as u64).saturating_mul(r as u64))
 			.saturating_add(T::DbWeight::get().reads(5 as u64))
@@ -190,9 +190,9 @@ impl<T: frame_system::Config> pallet_democracy::WeightInfo for SubstrateWeight<T
 	// Storage: Balances Locks (r:1 w:1)
 	/// The range of component `r` is `[1, 99]`.
 	fn delegate(r: u32, ) -> Weight {
-		Weight::from_ref_time(52_718_000 as u64)
+		Weight::from_ref_time(52_044_000 as u64)
 			// Standard Error: 5_000
-			.saturating_add(Weight::from_ref_time(3_847_000 as u64).saturating_mul(r as u64))
+			.saturating_add(Weight::from_ref_time(3_871_000 as u64).saturating_mul(r as u64))
 			.saturating_add(T::DbWeight::get().reads(4 as u64))
 			.saturating_add(T::DbWeight::get().reads((1 as u64).saturating_mul(r as u64)))
 			.saturating_add(T::DbWeight::get().writes(4 as u64))
@@ -202,9 +202,9 @@ impl<T: frame_system::Config> pallet_democracy::WeightInfo for SubstrateWeight<T
 	// Storage: Democracy ReferendumInfoOf (r:1 w:1)
 	/// The range of component `r` is `[1, 99]`.
 	fn undelegate(r: u32, ) -> Weight {
-		Weight::from_ref_time(30_608_000 as u64)
+		Weight::from_ref_time(29_269_000 as u64)
 			// Standard Error: 5_000
-			.saturating_add(Weight::from_ref_time(3_806_000 as u64).saturating_mul(r as u64))
+			.saturating_add(Weight::from_ref_time(3_892_000 as u64).saturating_mul(r as u64))
 			.saturating_add(T::DbWeight::get().reads(2 as u64))
 			.saturating_add(T::DbWeight::get().reads((1 as u64).saturating_mul(r as u64)))
 			.saturating_add(T::DbWeight::get().writes(2 as u64))
@@ -212,13 +212,13 @@ impl<T: frame_system::Config> pallet_democracy::WeightInfo for SubstrateWeight<T
 	}
 	// Storage: Democracy PublicProps (r:0 w:1)
 	fn clear_public_proposals() -> Weight {
-		Weight::from_ref_time(6_387_000 as u64)
+		Weight::from_ref_time(6_186_000 as u64)
 			.saturating_add(T::DbWeight::get().writes(1 as u64))
 	}
 	// Storage: Democracy Preimages (r:1 w:1)
 	/// The range of component `b` is `[0, 16384]`.
 	fn note_preimage(b: u32, ) -> Weight {
-		Weight::from_ref_time(32_922_000 as u64)
+		Weight::from_ref_time(32_592_000 as u64)
 			// Standard Error: 0
 			.saturating_add(Weight::from_ref_time(2_000 as u64).saturating_mul(b as u64))
 			.saturating_add(T::DbWeight::get().reads(1 as u64))
@@ -227,7 +227,7 @@ impl<T: frame_system::Config> pallet_democracy::WeightInfo for SubstrateWeight<T
 	// Storage: Democracy Preimages (r:1 w:1)
 	/// The range of component `b` is `[0, 16384]`.
 	fn note_imminent_preimage(b: u32, ) -> Weight {
-		Weight::from_ref_time(25_269_000 as u64)
+		Weight::from_ref_time(24_992_000 as u64)
 			// Standard Error: 0
 			.saturating_add(Weight::from_ref_time(2_000 as u64).saturating_mul(b as u64))
 			.saturating_add(T::DbWeight::get().reads(1 as u64))
@@ -237,7 +237,7 @@ impl<T: frame_system::Config> pallet_democracy::WeightInfo for SubstrateWeight<T
 	// Storage: System Account (r:1 w:1)
 	/// The range of component `b` is `[0, 16384]`.
 	fn reap_preimage(b: u32, ) -> Weight {
-		Weight::from_ref_time(43_267_000 as u64)
+		Weight::from_ref_time(42_718_000 as u64)
 			// Standard Error: 0
 			.saturating_add(Weight::from_ref_time(1_000 as u64).saturating_mul(b as u64))
 			.saturating_add(T::DbWeight::get().reads(2 as u64))
@@ -248,9 +248,9 @@ impl<T: frame_system::Config> pallet_democracy::WeightInfo for SubstrateWeight<T
 	// Storage: System Account (r:1 w:1)
 	/// The range of component `r` is `[1, 99]`.
 	fn unlock_remove(r: u32, ) -> Weight {
-		Weight::from_ref_time(35_559_000 as u64)
-			// Standard Error: 2_000
-			.saturating_add(Weight::from_ref_time(191_000 as u64).saturating_mul(r as u64))
+		Weight::from_ref_time(35_465_000 as u64)
+			// Standard Error: 1_000
+			.saturating_add(Weight::from_ref_time(198_000 as u64).saturating_mul(r as u64))
 			.saturating_add(T::DbWeight::get().reads(3 as u64))
 			.saturating_add(T::DbWeight::get().writes(3 as u64))
 	}
@@ -259,9 +259,9 @@ impl<T: frame_system::Config> pallet_democracy::WeightInfo for SubstrateWeight<T
 	// Storage: System Account (r:1 w:1)
 	/// The range of component `r` is `[1, 99]`.
 	fn unlock_set(r: u32, ) -> Weight {
-		Weight::from_ref_time(34_151_000 as u64)
+		Weight::from_ref_time(34_339_000 as u64)
 			// Standard Error: 1_000
-			.saturating_add(Weight::from_ref_time(258_000 as u64).saturating_mul(r as u64))
+			.saturating_add(Weight::from_ref_time(252_000 as u64).saturating_mul(r as u64))
 			.saturating_add(T::DbWeight::get().reads(3 as u64))
 			.saturating_add(T::DbWeight::get().writes(3 as u64))
 	}
@@ -269,9 +269,9 @@ impl<T: frame_system::Config> pallet_democracy::WeightInfo for SubstrateWeight<T
 	// Storage: Democracy VotingOf (r:1 w:1)
 	/// The range of component `r` is `[1, 99]`.
 	fn remove_vote(r: u32, ) -> Weight {
-		Weight::from_ref_time(20_842_000 as u64)
+		Weight::from_ref_time(20_631_000 as u64)
 			// Standard Error: 1_000
-			.saturating_add(Weight::from_ref_time(256_000 as u64).saturating_mul(r as u64))
+			.saturating_add(Weight::from_ref_time(253_000 as u64).saturating_mul(r as u64))
 			.saturating_add(T::DbWeight::get().reads(2 as u64))
 			.saturating_add(T::DbWeight::get().writes(2 as u64))
 	}
@@ -279,9 +279,9 @@ impl<T: frame_system::Config> pallet_democracy::WeightInfo for SubstrateWeight<T
 	// Storage: Democracy VotingOf (r:1 w:1)
 	/// The range of component `r` is `[1, 99]`.
 	fn remove_other_vote(r: u32, ) -> Weight {
-		Weight::from_ref_time(20_993_000 as u64)
+		Weight::from_ref_time(20_602_000 as u64)
 			// Standard Error: 1_000
-			.saturating_add(Weight::from_ref_time(252_000 as u64).saturating_mul(r as u64))
+			.saturating_add(Weight::from_ref_time(254_000 as u64).saturating_mul(r as u64))
 			.saturating_add(T::DbWeight::get().reads(2 as u64))
 			.saturating_add(T::DbWeight::get().writes(2 as u64))
 	}

--- a/runtime/common/src/weights/pallet_preimage.rs
+++ b/runtime/common/src/weights/pallet_preimage.rs
@@ -66,32 +66,32 @@ impl<T: frame_system::Config> pallet_preimage::WeightInfo for SubstrateWeight<T>
 	// Storage: Preimage StatusFor (r:1 w:1)
 	// Storage: Preimage PreimageFor (r:0 w:1)
 	fn unnote_preimage() -> Weight {
-		Weight::from_ref_time(60_514_000 as u64)
+		Weight::from_ref_time(50_442_000 as u64)
 			.saturating_add(T::DbWeight::get().reads(1 as u64))
 			.saturating_add(T::DbWeight::get().writes(2 as u64))
 	}
 	// Storage: Preimage StatusFor (r:1 w:1)
 	// Storage: Preimage PreimageFor (r:0 w:1)
 	fn unnote_no_deposit_preimage() -> Weight {
-		Weight::from_ref_time(35_328_000 as u64)
+		Weight::from_ref_time(42_787_000 as u64)
 			.saturating_add(T::DbWeight::get().reads(1 as u64))
 			.saturating_add(T::DbWeight::get().writes(2 as u64))
 	}
 	// Storage: Preimage StatusFor (r:1 w:1)
 	fn request_preimage() -> Weight {
-		Weight::from_ref_time(50_630_000 as u64)
+		Weight::from_ref_time(50_818_000 as u64)
 			.saturating_add(T::DbWeight::get().reads(1 as u64))
 			.saturating_add(T::DbWeight::get().writes(1 as u64))
 	}
 	// Storage: Preimage StatusFor (r:1 w:1)
 	fn request_no_deposit_preimage() -> Weight {
-		Weight::from_ref_time(43_189_000 as u64)
+		Weight::from_ref_time(40_213_000 as u64)
 			.saturating_add(T::DbWeight::get().reads(1 as u64))
 			.saturating_add(T::DbWeight::get().writes(1 as u64))
 	}
 	// Storage: Preimage StatusFor (r:1 w:1)
 	fn request_unnoted_preimage() -> Weight {
-		Weight::from_ref_time(29_645_000 as u64)
+		Weight::from_ref_time(25_369_000 as u64)
 			.saturating_add(T::DbWeight::get().reads(1 as u64))
 			.saturating_add(T::DbWeight::get().writes(1 as u64))
 	}
@@ -104,20 +104,20 @@ impl<T: frame_system::Config> pallet_preimage::WeightInfo for SubstrateWeight<T>
 	// Storage: Preimage StatusFor (r:1 w:1)
 	// Storage: Preimage PreimageFor (r:0 w:1)
 	fn unrequest_preimage() -> Weight {
-		Weight::from_ref_time(36_332_000 as u64)
+		Weight::from_ref_time(39_813_000 as u64)
 			.saturating_add(T::DbWeight::get().reads(1 as u64))
 			.saturating_add(T::DbWeight::get().writes(2 as u64))
 	}
 	// Storage: Preimage StatusFor (r:1 w:1)
 	// Storage: Preimage PreimageFor (r:0 w:1)
 	fn unrequest_unnoted_preimage() -> Weight {
-		Weight::from_ref_time(22_351_000 as u64)
+		Weight::from_ref_time(23_613_000 as u64)
 			.saturating_add(T::DbWeight::get().reads(1 as u64))
 			.saturating_add(T::DbWeight::get().writes(2 as u64))
 	}
 	// Storage: Preimage StatusFor (r:1 w:1)
 	fn unrequest_multi_referenced_preimage() -> Weight {
-		Weight::from_ref_time(10_395_000 as u64)
+		Weight::from_ref_time(10_938_000 as u64)
 			.saturating_add(T::DbWeight::get().reads(1 as u64))
 			.saturating_add(T::DbWeight::get().writes(1 as u64))
 	}

--- a/runtime/common/src/weights/pallet_scheduler.rs
+++ b/runtime/common/src/weights/pallet_scheduler.rs
@@ -39,9 +39,9 @@ impl<T: frame_system::Config> pallet_scheduler::WeightInfo for SubstrateWeight<T
 	// Storage: Scheduler Lookup (r:0 w:1)
 	/// The range of component `s` is `[1, 50]`.
 	fn on_initialize_periodic_named_resolved(s: u32, ) -> Weight {
-		Weight::from_ref_time(18_638_000 as u64)
-			// Standard Error: 15_000
-			.saturating_add(Weight::from_ref_time(20_533_000 as u64).saturating_mul(s as u64))
+		Weight::from_ref_time(16_150_000 as u64)
+			// Standard Error: 13_000
+			.saturating_add(Weight::from_ref_time(20_450_000 as u64).saturating_mul(s as u64))
 			.saturating_add(T::DbWeight::get().reads(1 as u64))
 			.saturating_add(T::DbWeight::get().reads((3 as u64).saturating_mul(s as u64)))
 			.saturating_add(T::DbWeight::get().writes(1 as u64))
@@ -53,9 +53,9 @@ impl<T: frame_system::Config> pallet_scheduler::WeightInfo for SubstrateWeight<T
 	// Storage: Scheduler Lookup (r:0 w:1)
 	/// The range of component `s` is `[1, 50]`.
 	fn on_initialize_named_resolved(s: u32, ) -> Weight {
-		Weight::from_ref_time(15_177_000 as u64)
-			// Standard Error: 14_000
-			.saturating_add(Weight::from_ref_time(16_452_000 as u64).saturating_mul(s as u64))
+		Weight::from_ref_time(14_855_000 as u64)
+			// Standard Error: 16_000
+			.saturating_add(Weight::from_ref_time(16_442_000 as u64).saturating_mul(s as u64))
 			.saturating_add(T::DbWeight::get().reads(1 as u64))
 			.saturating_add(T::DbWeight::get().reads((2 as u64).saturating_mul(s as u64)))
 			.saturating_add(T::DbWeight::get().writes(1 as u64))
@@ -66,9 +66,9 @@ impl<T: frame_system::Config> pallet_scheduler::WeightInfo for SubstrateWeight<T
 	// Storage: Preimage StatusFor (r:1 w:1)
 	/// The range of component `s` is `[1, 50]`.
 	fn on_initialize_periodic_resolved(s: u32, ) -> Weight {
-		Weight::from_ref_time(16_276_000 as u64)
-			// Standard Error: 14_000
-			.saturating_add(Weight::from_ref_time(17_272_000 as u64).saturating_mul(s as u64))
+		Weight::from_ref_time(15_721_000 as u64)
+			// Standard Error: 16_000
+			.saturating_add(Weight::from_ref_time(17_268_000 as u64).saturating_mul(s as u64))
 			.saturating_add(T::DbWeight::get().reads(1 as u64))
 			.saturating_add(T::DbWeight::get().reads((3 as u64).saturating_mul(s as u64)))
 			.saturating_add(T::DbWeight::get().writes(1 as u64))
@@ -79,9 +79,9 @@ impl<T: frame_system::Config> pallet_scheduler::WeightInfo for SubstrateWeight<T
 	// Storage: Preimage StatusFor (r:1 w:1)
 	/// The range of component `s` is `[1, 50]`.
 	fn on_initialize_resolved(s: u32, ) -> Weight {
-		Weight::from_ref_time(16_995_000 as u64)
-			// Standard Error: 12_000
-			.saturating_add(Weight::from_ref_time(14_859_000 as u64).saturating_mul(s as u64))
+		Weight::from_ref_time(17_235_000 as u64)
+			// Standard Error: 11_000
+			.saturating_add(Weight::from_ref_time(14_943_000 as u64).saturating_mul(s as u64))
 			.saturating_add(T::DbWeight::get().reads(1 as u64))
 			.saturating_add(T::DbWeight::get().reads((2 as u64).saturating_mul(s as u64)))
 			.saturating_add(T::DbWeight::get().writes(1 as u64))
@@ -92,9 +92,9 @@ impl<T: frame_system::Config> pallet_scheduler::WeightInfo for SubstrateWeight<T
 	// Storage: Scheduler Lookup (r:0 w:1)
 	/// The range of component `s` is `[1, 50]`.
 	fn on_initialize_named_aborted(s: u32, ) -> Weight {
-		Weight::from_ref_time(7_309_000 as u64)
+		Weight::from_ref_time(7_404_000 as u64)
 			// Standard Error: 6_000
-			.saturating_add(Weight::from_ref_time(5_713_000 as u64).saturating_mul(s as u64))
+			.saturating_add(Weight::from_ref_time(5_608_000 as u64).saturating_mul(s as u64))
 			.saturating_add(T::DbWeight::get().reads(2 as u64))
 			.saturating_add(T::DbWeight::get().reads((1 as u64).saturating_mul(s as u64)))
 			.saturating_add(T::DbWeight::get().writes(2 as u64))
@@ -104,9 +104,9 @@ impl<T: frame_system::Config> pallet_scheduler::WeightInfo for SubstrateWeight<T
 	// Storage: Preimage PreimageFor (r:1 w:0)
 	/// The range of component `s` is `[1, 50]`.
 	fn on_initialize_aborted(s: u32, ) -> Weight {
-		Weight::from_ref_time(10_498_000 as u64)
-			// Standard Error: 3_000
-			.saturating_add(Weight::from_ref_time(2_720_000 as u64).saturating_mul(s as u64))
+		Weight::from_ref_time(9_903_000 as u64)
+			// Standard Error: 2_000
+			.saturating_add(Weight::from_ref_time(2_792_000 as u64).saturating_mul(s as u64))
 			.saturating_add(T::DbWeight::get().reads(2 as u64))
 			.saturating_add(T::DbWeight::get().reads((1 as u64).saturating_mul(s as u64)))
 			.saturating_add(T::DbWeight::get().writes(2 as u64))
@@ -115,9 +115,9 @@ impl<T: frame_system::Config> pallet_scheduler::WeightInfo for SubstrateWeight<T
 	// Storage: Scheduler Lookup (r:0 w:1)
 	/// The range of component `s` is `[1, 50]`.
 	fn on_initialize_periodic_named(s: u32, ) -> Weight {
-		Weight::from_ref_time(17_510_000 as u64)
+		Weight::from_ref_time(16_378_000 as u64)
 			// Standard Error: 8_000
-			.saturating_add(Weight::from_ref_time(9_972_000 as u64).saturating_mul(s as u64))
+			.saturating_add(Weight::from_ref_time(9_852_000 as u64).saturating_mul(s as u64))
 			.saturating_add(T::DbWeight::get().reads(1 as u64))
 			.saturating_add(T::DbWeight::get().reads((1 as u64).saturating_mul(s as u64)))
 			.saturating_add(T::DbWeight::get().writes(1 as u64))
@@ -126,9 +126,9 @@ impl<T: frame_system::Config> pallet_scheduler::WeightInfo for SubstrateWeight<T
 	// Storage: Scheduler Agenda (r:2 w:2)
 	/// The range of component `s` is `[1, 50]`.
 	fn on_initialize_periodic(s: u32, ) -> Weight {
-		Weight::from_ref_time(15_606_000 as u64)
+		Weight::from_ref_time(16_305_000 as u64)
 			// Standard Error: 5_000
-			.saturating_add(Weight::from_ref_time(6_980_000 as u64).saturating_mul(s as u64))
+			.saturating_add(Weight::from_ref_time(6_814_000 as u64).saturating_mul(s as u64))
 			.saturating_add(T::DbWeight::get().reads(1 as u64))
 			.saturating_add(T::DbWeight::get().reads((1 as u64).saturating_mul(s as u64)))
 			.saturating_add(T::DbWeight::get().writes(1 as u64))
@@ -138,9 +138,9 @@ impl<T: frame_system::Config> pallet_scheduler::WeightInfo for SubstrateWeight<T
 	// Storage: Scheduler Lookup (r:0 w:1)
 	/// The range of component `s` is `[1, 50]`.
 	fn on_initialize_named(s: u32, ) -> Weight {
-		Weight::from_ref_time(15_839_000 as u64)
+		Weight::from_ref_time(15_569_000 as u64)
 			// Standard Error: 5_000
-			.saturating_add(Weight::from_ref_time(6_205_000 as u64).saturating_mul(s as u64))
+			.saturating_add(Weight::from_ref_time(6_077_000 as u64).saturating_mul(s as u64))
 			.saturating_add(T::DbWeight::get().reads(1 as u64))
 			.saturating_add(T::DbWeight::get().writes(1 as u64))
 			.saturating_add(T::DbWeight::get().writes((1 as u64).saturating_mul(s as u64)))
@@ -148,18 +148,18 @@ impl<T: frame_system::Config> pallet_scheduler::WeightInfo for SubstrateWeight<T
 	// Storage: Scheduler Agenda (r:1 w:1)
 	/// The range of component `s` is `[1, 50]`.
 	fn on_initialize(s: u32, ) -> Weight {
-		Weight::from_ref_time(16_080_000 as u64)
+		Weight::from_ref_time(15_747_000 as u64)
 			// Standard Error: 3_000
-			.saturating_add(Weight::from_ref_time(4_830_000 as u64).saturating_mul(s as u64))
+			.saturating_add(Weight::from_ref_time(4_810_000 as u64).saturating_mul(s as u64))
 			.saturating_add(T::DbWeight::get().reads(1 as u64))
 			.saturating_add(T::DbWeight::get().writes(1 as u64))
 	}
 	// Storage: Scheduler Agenda (r:1 w:1)
 	/// The range of component `s` is `[0, 50]`.
 	fn schedule(s: u32, ) -> Weight {
-		Weight::from_ref_time(20_287_000 as u64)
+		Weight::from_ref_time(19_961_000 as u64)
 			// Standard Error: 1_000
-			.saturating_add(Weight::from_ref_time(121_000 as u64).saturating_mul(s as u64))
+			.saturating_add(Weight::from_ref_time(129_000 as u64).saturating_mul(s as u64))
 			.saturating_add(T::DbWeight::get().reads(1 as u64))
 			.saturating_add(T::DbWeight::get().writes(1 as u64))
 	}
@@ -167,9 +167,9 @@ impl<T: frame_system::Config> pallet_scheduler::WeightInfo for SubstrateWeight<T
 	// Storage: Scheduler Lookup (r:0 w:1)
 	/// The range of component `s` is `[1, 50]`.
 	fn cancel(s: u32, ) -> Weight {
-		Weight::from_ref_time(20_910_000 as u64)
+		Weight::from_ref_time(20_051_000 as u64)
 			// Standard Error: 1_000
-			.saturating_add(Weight::from_ref_time(559_000 as u64).saturating_mul(s as u64))
+			.saturating_add(Weight::from_ref_time(575_000 as u64).saturating_mul(s as u64))
 			.saturating_add(T::DbWeight::get().reads(1 as u64))
 			.saturating_add(T::DbWeight::get().writes(2 as u64))
 	}
@@ -177,9 +177,9 @@ impl<T: frame_system::Config> pallet_scheduler::WeightInfo for SubstrateWeight<T
 	// Storage: Scheduler Agenda (r:1 w:1)
 	/// The range of component `s` is `[0, 50]`.
 	fn schedule_named(s: u32, ) -> Weight {
-		Weight::from_ref_time(24_876_000 as u64)
+		Weight::from_ref_time(24_252_000 as u64)
 			// Standard Error: 3_000
-			.saturating_add(Weight::from_ref_time(174_000 as u64).saturating_mul(s as u64))
+			.saturating_add(Weight::from_ref_time(186_000 as u64).saturating_mul(s as u64))
 			.saturating_add(T::DbWeight::get().reads(2 as u64))
 			.saturating_add(T::DbWeight::get().writes(2 as u64))
 	}
@@ -187,9 +187,9 @@ impl<T: frame_system::Config> pallet_scheduler::WeightInfo for SubstrateWeight<T
 	// Storage: Scheduler Agenda (r:1 w:1)
 	/// The range of component `s` is `[1, 50]`.
 	fn cancel_named(s: u32, ) -> Weight {
-		Weight::from_ref_time(24_034_000 as u64)
+		Weight::from_ref_time(23_580_000 as u64)
 			// Standard Error: 3_000
-			.saturating_add(Weight::from_ref_time(621_000 as u64).saturating_mul(s as u64))
+			.saturating_add(Weight::from_ref_time(626_000 as u64).saturating_mul(s as u64))
 			.saturating_add(T::DbWeight::get().reads(2 as u64))
 			.saturating_add(T::DbWeight::get().writes(2 as u64))
 	}

--- a/runtime/common/src/weights/pallet_treasury.rs
+++ b/runtime/common/src/weights/pallet_treasury.rs
@@ -34,19 +34,19 @@ use sp_std::marker::PhantomData;
 pub struct SubstrateWeight<T>(PhantomData<T>);
 impl<T: frame_system::Config> pallet_treasury::WeightInfo for SubstrateWeight<T> {
 	fn spend() -> Weight {
-		Weight::from_ref_time(151_000 as u64)
+		Weight::from_ref_time(198_000 as u64)
 	}
 	// Storage: Treasury ProposalCount (r:1 w:1)
 	// Storage: Treasury Proposals (r:0 w:1)
 	fn propose_spend() -> Weight {
-		Weight::from_ref_time(29_893_000 as u64)
+		Weight::from_ref_time(29_375_000 as u64)
 			.saturating_add(T::DbWeight::get().reads(1 as u64))
 			.saturating_add(T::DbWeight::get().writes(2 as u64))
 	}
 	// Storage: Treasury Proposals (r:1 w:1)
 	// Storage: System Account (r:1 w:1)
 	fn reject_proposal() -> Weight {
-		Weight::from_ref_time(36_805_000 as u64)
+		Weight::from_ref_time(36_116_000 as u64)
 			.saturating_add(T::DbWeight::get().reads(2 as u64))
 			.saturating_add(T::DbWeight::get().writes(2 as u64))
 	}
@@ -54,15 +54,15 @@ impl<T: frame_system::Config> pallet_treasury::WeightInfo for SubstrateWeight<T>
 	// Storage: Treasury Approvals (r:1 w:1)
 	/// The range of component `p` is `[0, 63]`.
 	fn approve_proposal(p: u32, ) -> Weight {
-		Weight::from_ref_time(13_427_000 as u64)
+		Weight::from_ref_time(13_451_000 as u64)
 			// Standard Error: 1_000
-			.saturating_add(Weight::from_ref_time(218_000 as u64).saturating_mul(p as u64))
+			.saturating_add(Weight::from_ref_time(217_000 as u64).saturating_mul(p as u64))
 			.saturating_add(T::DbWeight::get().reads(2 as u64))
 			.saturating_add(T::DbWeight::get().writes(1 as u64))
 	}
 	// Storage: Treasury Approvals (r:1 w:1)
 	fn remove_approval() -> Weight {
-		Weight::from_ref_time(9_701_000 as u64)
+		Weight::from_ref_time(9_489_000 as u64)
 			.saturating_add(T::DbWeight::get().reads(1 as u64))
 			.saturating_add(T::DbWeight::get().writes(1 as u64))
 	}
@@ -71,9 +71,9 @@ impl<T: frame_system::Config> pallet_treasury::WeightInfo for SubstrateWeight<T>
 	// Storage: Treasury Proposals (r:1 w:1)
 	/// The range of component `p` is `[0, 64]`.
 	fn on_initialize_proposals(p: u32, ) -> Weight {
-		Weight::from_ref_time(42_672_000 as u64)
-			// Standard Error: 15_000
-			.saturating_add(Weight::from_ref_time(30_109_000 as u64).saturating_mul(p as u64))
+		Weight::from_ref_time(42_712_000 as u64)
+			// Standard Error: 17_000
+			.saturating_add(Weight::from_ref_time(29_059_000 as u64).saturating_mul(p as u64))
 			.saturating_add(T::DbWeight::get().reads(2 as u64))
 			.saturating_add(T::DbWeight::get().reads((3 as u64).saturating_mul(p as u64)))
 			.saturating_add(T::DbWeight::get().writes(2 as u64))

--- a/runtime/common/src/weights/pallet_utility.rs
+++ b/runtime/common/src/weights/pallet_utility.rs
@@ -35,26 +35,26 @@ pub struct SubstrateWeight<T>(PhantomData<T>);
 impl<T: frame_system::Config> pallet_utility::WeightInfo for SubstrateWeight<T> {
 	/// The range of component `c` is `[0, 1000]`.
 	fn batch(c: u32, ) -> Weight {
-		Weight::from_ref_time(16_825_000 as u64)
-			// Standard Error: 0
-			.saturating_add(Weight::from_ref_time(4_045_000 as u64).saturating_mul(c as u64))
+		Weight::from_ref_time(22_524_000 as u64)
+			// Standard Error: 3_000
+			.saturating_add(Weight::from_ref_time(3_911_000 as u64).saturating_mul(c as u64))
 	}
 	fn as_derivative() -> Weight {
-		Weight::from_ref_time(6_711_000 as u64)
+		Weight::from_ref_time(6_743_000 as u64)
 	}
 	/// The range of component `c` is `[0, 1000]`.
 	fn batch_all(c: u32, ) -> Weight {
-		Weight::from_ref_time(17_867_000 as u64)
-			// Standard Error: 1_000
-			.saturating_add(Weight::from_ref_time(4_151_000 as u64).saturating_mul(c as u64))
+		Weight::from_ref_time(30_596_000 as u64)
+			// Standard Error: 3_000
+			.saturating_add(Weight::from_ref_time(3_987_000 as u64).saturating_mul(c as u64))
 	}
 	fn dispatch_as() -> Weight {
-		Weight::from_ref_time(14_444_000 as u64)
+		Weight::from_ref_time(14_568_000 as u64)
 	}
 	/// The range of component `c` is `[0, 1000]`.
 	fn force_batch(c: u32, ) -> Weight {
-		Weight::from_ref_time(17_368_000 as u64)
-			// Standard Error: 0
-			.saturating_add(Weight::from_ref_time(4_056_000 as u64).saturating_mul(c as u64))
+		Weight::from_ref_time(18_852_000 as u64)
+			// Standard Error: 1_000
+			.saturating_add(Weight::from_ref_time(4_003_000 as u64).saturating_mul(c as u64))
 	}
 }


### PR DESCRIPTION
# Goal
The goal of this PR is to remove the unused and unneeded nonce field from the AddKeyData

Closes #573 

# Discussion
- Simple removal

# Checklist
- [x] N/A Chain spec updated
- [x] Updated the js/api-augment code if a custom RPC added/changed
- [x] Design doc(s) updated
- [x] Tests updated
- [x] Benchmarks updated
