### PR TITLE
Rename/runtime api standardization

### DIFF
--- a/node/service/src/rpc.rs
+++ b/node/service/src/rpc.rs
@@ -49,7 +49,7 @@ where
 	C::Api: BlockBuilder<Block>,
 	C::Api: pallet_messages_runtime_api::MessagesApi<Block, BlockNumber>,
 	C::Api: pallet_schemas_runtime_api::SchemasRuntimeApi<Block>,
-	C::Api: pallet_msa_runtime_api::MsaApi<Block, AccountId>,
+	C::Api: pallet_msa_runtime_api::MsaRuntimeApi<Block, AccountId>,
 	P: TransactionPool + Sync + Send + 'static,
 {
 	use pallet_transaction_payment_rpc::{TransactionPayment, TransactionPaymentApiServer};

--- a/node/service/src/rpc.rs
+++ b/node/service/src/rpc.rs
@@ -47,7 +47,7 @@ where
 	C::Api: pallet_transaction_payment_rpc::TransactionPaymentRuntimeApi<Block, Balance>,
 	C::Api: substrate_frame_rpc_system::AccountNonceApi<Block, AccountId, Nonce>,
 	C::Api: BlockBuilder<Block>,
-	C::Api: pallet_messages_runtime_api::MessagesApi<Block, BlockNumber>,
+	C::Api: pallet_messages_runtime_api::MessagesRuntimeApi<Block, BlockNumber>,
 	C::Api: pallet_schemas_runtime_api::SchemasRuntimeApi<Block>,
 	C::Api: pallet_msa_runtime_api::MsaRuntimeApi<Block, AccountId>,
 	P: TransactionPool + Sync + Send + 'static,

--- a/node/service/src/service.rs
+++ b/node/service/src/service.rs
@@ -285,7 +285,7 @@ where
 		+ cumulus_primitives_core::CollectCollationInfo<Block>
 		+ pallet_transaction_payment_rpc::TransactionPaymentRuntimeApi<Block, Balance>
 		+ substrate_frame_rpc_system::AccountNonceApi<Block, AccountId, Nonce>
-		+ pallet_messages_runtime_api::MessagesApi<Block, BlockNumber>
+		+ pallet_messages_runtime_api::MessagesRuntimeApi<Block, BlockNumber>
 		+ pallet_schemas_runtime_api::SchemasRuntimeApi<Block>
 		+ pallet_msa_runtime_api::MsaRuntimeApi<Block, AccountId>,
 	sc_client_api::StateBackendFor<TFullBackend<Block>, Block>: sp_api::StateBackend<BlakeTwo256>,
@@ -559,7 +559,7 @@ where
 		+ cumulus_primitives_core::CollectCollationInfo<Block>
 		+ pallet_transaction_payment_rpc::TransactionPaymentRuntimeApi<Block, Balance>
 		+ substrate_frame_rpc_system::AccountNonceApi<Block, AccountId, Nonce>
-		+ pallet_messages_runtime_api::MessagesApi<Block, BlockNumber>
+		+ pallet_messages_runtime_api::MessagesRuntimeApi<Block, BlockNumber>
 		+ pallet_schemas_runtime_api::SchemasRuntimeApi<Block>
 		+ pallet_msa_runtime_api::MsaRuntimeApi<Block, AccountId>,
 	Executor: sc_executor::NativeExecutionDispatch + 'static,

--- a/node/service/src/service.rs
+++ b/node/service/src/service.rs
@@ -287,7 +287,7 @@ where
 		+ substrate_frame_rpc_system::AccountNonceApi<Block, AccountId, Nonce>
 		+ pallet_messages_runtime_api::MessagesApi<Block, BlockNumber>
 		+ pallet_schemas_runtime_api::SchemasRuntimeApi<Block>
-		+ pallet_msa_runtime_api::MsaApi<Block, AccountId>,
+		+ pallet_msa_runtime_api::MsaRuntimeApi<Block, AccountId>,
 	sc_client_api::StateBackendFor<TFullBackend<Block>, Block>: sp_api::StateBackend<BlakeTwo256>,
 	Executor: sc_executor::NativeExecutionDispatch + 'static,
 	RB: Fn(
@@ -561,7 +561,7 @@ where
 		+ substrate_frame_rpc_system::AccountNonceApi<Block, AccountId, Nonce>
 		+ pallet_messages_runtime_api::MessagesApi<Block, BlockNumber>
 		+ pallet_schemas_runtime_api::SchemasRuntimeApi<Block>
-		+ pallet_msa_runtime_api::MsaApi<Block, AccountId>,
+		+ pallet_msa_runtime_api::MsaRuntimeApi<Block, AccountId>,
 	Executor: sc_executor::NativeExecutionDispatch + 'static,
 	sc_client_api::StateBackendFor<TFullBackend<Block>, Block>: sp_api::StateBackend<BlakeTwo256>,
 {

--- a/pallets/messages/src/rpc/src/lib.rs
+++ b/pallets/messages/src/rpc/src/lib.rs
@@ -7,7 +7,7 @@ use jsonrpsee::{
 	core::{async_trait, error::Error as RpcError, RpcResult},
 	proc_macros::rpc,
 };
-use pallet_messages_runtime_api::MessagesApi as MessagesRuntimeApi;
+use pallet_messages_runtime_api::MessagesRuntimeApi;
 use sp_api::ProvideRuntimeApi;
 use sp_blockchain::HeaderBackend;
 use sp_runtime::{

--- a/pallets/messages/src/rpc/src/tests/mod.rs
+++ b/pallets/messages/src/rpc/src/tests/mod.rs
@@ -4,7 +4,7 @@ use super::*;
 use rpc_mock::*;
 
 use common_primitives::node::BlockNumber;
-use pallet_messages_runtime_api::MessagesApi as MessagesRuntimeApi;
+use pallet_messages_runtime_api::MessagesRuntimeApi;
 use std::sync::Arc;
 use substrate_test_runtime_client::runtime::Block;
 

--- a/pallets/messages/src/runtime-api/src/lib.rs
+++ b/pallets/messages/src/runtime-api/src/lib.rs
@@ -9,7 +9,7 @@ use frame_support::inherent::Vec;
 // Here we declare the runtime API. It is implemented it the `impl` block in
 // runtime file (the `runtime/src/lib.rs`)
 sp_api::decl_runtime_apis! {
-	pub trait MessagesApi<BlockNumber> where
+	pub trait MessagesRuntimeApi<BlockNumber> where
 		BlockNumber: Codec,
 	{
 		fn get_messages_by_schema_and_block(schema_id: SchemaId, schema_payload_location: PayloadLocation, block_number: BlockNumber) ->

--- a/pallets/msa/src/rpc/src/lib.rs
+++ b/pallets/msa/src/rpc/src/lib.rs
@@ -10,7 +10,7 @@ use jsonrpsee::{
 	core::{async_trait, RpcResult},
 	proc_macros::rpc,
 };
-use pallet_msa_runtime_api::MsaApi as MsaRuntimeApi;
+use pallet_msa_runtime_api::MsaRuntimeApi;
 use sp_api::ProvideRuntimeApi;
 use sp_blockchain::HeaderBackend;
 use sp_runtime::{generic::BlockId, traits::Block as BlockT};

--- a/pallets/msa/src/runtime-api/src/lib.rs
+++ b/pallets/msa/src/runtime-api/src/lib.rs
@@ -10,7 +10,7 @@ use sp_std::vec::Vec;
 // Here we declare the runtime API. It is implemented it the `impl` block in
 // runtime file (the `runtime/src/lib.rs`)
 sp_api::decl_runtime_apis! {
-	pub trait MsaApi<AccountId> where
+	pub trait MsaRuntimeApi<AccountId> where
 		AccountId: Codec,
 	{
 		// *Temporarily Removed* until https://github.com/LibertyDSNP/frequency/issues/418 is completed

--- a/runtime/frequency-rococo/src/lib.rs
+++ b/runtime/frequency-rococo/src/lib.rs
@@ -807,7 +807,7 @@ impl_runtime_apis! {
 		}
 	}
 
-	impl pallet_msa_runtime_api::MsaApi<Block, AccountId> for Runtime {
+	impl pallet_msa_runtime_api::MsaRuntimeApi<Block, AccountId> for Runtime {
 		// *Temporarily Removed* until https://github.com/LibertyDSNP/frequency/issues/418 is completed
 		// fn get_msa_keys(msa_id: MessageSourceId) -> Result<Vec<KeyInfoResponse<AccountId>>, DispatchError> {
 		// 	Ok(Msa::fetch_msa_keys(msa_id))

--- a/runtime/frequency-rococo/src/lib.rs
+++ b/runtime/frequency-rococo/src/lib.rs
@@ -790,7 +790,7 @@ impl_runtime_apis! {
 	}
 
 	// Unfinished runtime APIs
-	impl pallet_messages_runtime_api::MessagesApi<Block, BlockNumber> for Runtime {
+	impl pallet_messages_runtime_api::MessagesRuntimeApi<Block, BlockNumber> for Runtime {
 		fn get_messages_by_schema_and_block(schema_id: SchemaId, schema_payload_location: PayloadLocation, block_number: BlockNumber) ->
 			Vec<MessageResponse<BlockNumber>> {
 			Messages::get_messages_by_schema_and_block(schema_id, schema_payload_location, block_number)

--- a/runtime/frequency/src/lib.rs
+++ b/runtime/frequency/src/lib.rs
@@ -856,7 +856,7 @@ impl_runtime_apis! {
 		}
 	}
 
-	impl pallet_msa_runtime_api::MsaApi<Block, AccountId> for Runtime {
+	impl pallet_msa_runtime_api::MsaRuntimeApi<Block, AccountId> for Runtime {
 		// *Temporarily Removed* until https://github.com/LibertyDSNP/frequency/issues/418 is completed
 		// fn get_msa_keys(msa_id: MessageSourceId) -> Result<Vec<KeyInfoResponse<AccountId>>, DispatchError> {
 		// 	Ok(Msa::fetch_msa_keys(msa_id))

--- a/runtime/frequency/src/lib.rs
+++ b/runtime/frequency/src/lib.rs
@@ -839,7 +839,7 @@ impl_runtime_apis! {
 	}
 
 	// Unfinished runtime APIs
-	impl pallet_messages_runtime_api::MessagesApi<Block, BlockNumber> for Runtime {
+	impl pallet_messages_runtime_api::MessagesRuntimeApi<Block, BlockNumber> for Runtime {
 		fn get_messages_by_schema_and_block(schema_id: SchemaId, schema_payload_location: PayloadLocation, block_number: BlockNumber,) ->
 			Vec<MessageResponse<BlockNumber>> {
 			Messages::get_messages_by_schema_and_block(schema_id, schema_payload_location, block_number)


### PR DESCRIPTION
# Goal
The goal of this PR is to make our code less confusing around our APIs by aligning our naming for runtime api traits.

Part of #255 

# Discussion
- No external or breaking changes
- `pallet_msa_runtime_api::MsaApi` -> `pallet_msa_runtime_api::MsaRuntimeApi`
- `pallet_messages_runtime_api::MessagesApi` -> `pallet_messages_runtime_api::MessagesRuntimeApi`

# Checklist
- [x] No Breaking renaming changes
