### PR TITLE
Documentation Update: Runtime and Custom APIs

### DIFF
--- a/pallets/README.md
+++ b/pallets/README.md
@@ -5,6 +5,7 @@
 In these files:
 - `src/lib.rs`
 - `src/runtime-api/src/lib.rs`
+- `src/rpc/src/lib.rs`
 
 Add these lines:
 

--- a/pallets/README.md
+++ b/pallets/README.md
@@ -2,13 +2,18 @@
 
 ## Add Documentation Lints
 
-In `src/lib.rs` add these lines:
+In these files:
+- `src/lib.rs`
+- `src/runtime-api/src/lib.rs`
+
+Add these lines:
 
 ```rust
 // Strong Documentation Lints
 #![deny(
     rustdoc::broken_intra_doc_links,
     rustdoc::missing_crate_level_docs,
-    rustdoc::invalid_codeblock_attributes
+    rustdoc::invalid_codeblock_attributes,
+    missing_docs
 )]
 ```

--- a/pallets/messages/src/rpc/src/lib.rs
+++ b/pallets/messages/src/rpc/src/lib.rs
@@ -29,7 +29,7 @@ pub trait MessagesApi<BlockNumber> {
 	) -> RpcResult<BlockPaginationResponse<BlockNumber, MessageResponse<BlockNumber>>>;
 }
 
-/// The client handler for the API.
+/// The client handler for the API used by Frequency Service RPC with `jsonrpsee`
 pub struct MessagesHandler<C, M> {
 	client: Arc<C>,
 	_marker: std::marker::PhantomData<M>,

--- a/pallets/messages/src/rpc/src/lib.rs
+++ b/pallets/messages/src/rpc/src/lib.rs
@@ -29,14 +29,14 @@ pub trait MessagesApi<BlockNumber> {
 	) -> RpcResult<BlockPaginationResponse<BlockNumber, MessageResponse<BlockNumber>>>;
 }
 
-/// A struct that implements the `MessagesApi`.
+/// The client handler for the API.
 pub struct MessagesHandler<C, M> {
 	client: Arc<C>,
 	_marker: std::marker::PhantomData<M>,
 }
 
 impl<C, M> MessagesHandler<C, M> {
-	/// Create new `MessagesApi` instance with the given reference to the client.
+	/// Create new instance with the given reference to the client.
 	pub fn new(client: Arc<C>) -> Self {
 		Self { client, _marker: Default::default() }
 	}

--- a/pallets/messages/src/rpc/src/lib.rs
+++ b/pallets/messages/src/rpc/src/lib.rs
@@ -6,7 +6,7 @@
 	missing_docs
 )]
 
-//! Custom APIs for [Messages](pallet-messages)
+//! Custom APIs for [Messages](../pallet_messages/index.html)
 
 use codec::Codec;
 #[cfg(feature = "std")]

--- a/pallets/messages/src/rpc/src/lib.rs
+++ b/pallets/messages/src/rpc/src/lib.rs
@@ -1,3 +1,13 @@
+// Strong Documentation Lints
+#![deny(
+	rustdoc::broken_intra_doc_links,
+	rustdoc::missing_crate_level_docs,
+	rustdoc::invalid_codeblock_attributes,
+	missing_docs
+)]
+
+//! Custom APIs for [Messages](pallet-messages)
+
 use codec::Codec;
 #[cfg(feature = "std")]
 use common_helpers::rpc::*;
@@ -19,8 +29,10 @@ use std::sync::Arc;
 #[cfg(test)]
 mod tests;
 
+/// Frequency Messages Custom RPC API
 #[rpc(client, server)]
 pub trait MessagesApi<BlockNumber> {
+	/// Retrieve paginated messages by schema id
 	#[method(name = "messages_getBySchemaId")]
 	fn get_messages_by_schema_id(
 		&self,
@@ -42,6 +54,7 @@ impl<C, M> MessagesHandler<C, M> {
 	}
 }
 
+/// Errors that occur on the client RPC
 #[derive(Debug)]
 pub enum MessageRpcError {
 	/// Pagination request is bad

--- a/pallets/messages/src/runtime-api/src/lib.rs
+++ b/pallets/messages/src/runtime-api/src/lib.rs
@@ -1,20 +1,38 @@
 #![cfg_attr(not(feature = "std"), no_std)]
 #![allow(clippy::too_many_arguments)]
 #![allow(clippy::unnecessary_mut_passed)]
+// Strong Documentation Lints
+#![deny(
+	rustdoc::broken_intra_doc_links,
+	rustdoc::missing_crate_level_docs,
+	rustdoc::invalid_codeblock_attributes,
+	missing_docs
+)]
+
+//! Runtime API definition for [Messages](pallet-messages)
+//!
+//! This api must be implemented by the node runtime.
+//! Runtime APIs Provide:
+//! - An interface between the runtime and Custom RPCs.
+//! - Runtime interfaces for end users beyond just State Queries
 
 use codec::Codec;
 use common_primitives::{messages::*, schema::*};
 use frame_support::inherent::Vec;
 
 // Here we declare the runtime API. It is implemented it the `impl` block in
-// runtime file (the `runtime/src/lib.rs`)
+// runtime files (the `runtime` folder)
 sp_api::decl_runtime_apis! {
+
+	/// Runtime APIs for [Messages](pallet-messages)
 	pub trait MessagesRuntimeApi<BlockNumber> where
 		BlockNumber: Codec,
 	{
+		/// Retrieve the messages for a particular schema and block number
 		fn get_messages_by_schema_and_block(schema_id: SchemaId, schema_payload_location: PayloadLocation, block_number: BlockNumber) ->
 			Vec<MessageResponse<BlockNumber>>;
 
+		/// Retrieve a schema by id
 		fn get_schema_by_id(schema_id: SchemaId) -> Option<SchemaResponse>;
 	}
 }

--- a/pallets/messages/src/runtime-api/src/lib.rs
+++ b/pallets/messages/src/runtime-api/src/lib.rs
@@ -9,7 +9,7 @@
 	missing_docs
 )]
 
-//! Runtime API definition for [Messages](pallet-messages)
+//! Runtime API definition for [Messages](../pallet_messages/index.html)
 //!
 //! This api must be implemented by the node runtime.
 //! Runtime APIs Provide:
@@ -24,7 +24,7 @@ use frame_support::inherent::Vec;
 // runtime files (the `runtime` folder)
 sp_api::decl_runtime_apis! {
 
-	/// Runtime APIs for [Messages](pallet-messages)
+	/// Runtime APIs for [Messages](../pallet_messages/index.html)
 	pub trait MessagesRuntimeApi<BlockNumber> where
 		BlockNumber: Codec,
 	{

--- a/pallets/msa/src/rpc/src/lib.rs
+++ b/pallets/msa/src/rpc/src/lib.rs
@@ -34,14 +34,14 @@ pub trait MsaApi<BlockHash, AccountId> {
 	) -> RpcResult<Option<Vec<SchemaId>>>;
 }
 
-/// A struct that implements the `MessagesApi`.
+/// The client handler for the API.
 pub struct MsaHandler<C, M> {
 	client: Arc<C>,
 	_marker: std::marker::PhantomData<M>,
 }
 
 impl<C, M> MsaHandler<C, M> {
-	/// Create new `MessagesApi` instance with the given reference to the client.
+	/// Create new instance with the given reference to the client.
 	pub fn new(client: Arc<C>) -> Self {
 		Self { client, _marker: Default::default() }
 	}

--- a/pallets/msa/src/rpc/src/lib.rs
+++ b/pallets/msa/src/rpc/src/lib.rs
@@ -1,3 +1,13 @@
+// Strong Documentation Lints
+#![deny(
+	rustdoc::broken_intra_doc_links,
+	rustdoc::missing_crate_level_docs,
+	rustdoc::invalid_codeblock_attributes,
+	missing_docs
+)]
+
+//! Custom APIs for [MSA](pallet-msa)
+
 use codec::Codec;
 use common_helpers::rpc::*;
 use common_primitives::{
@@ -16,8 +26,12 @@ use sp_blockchain::HeaderBackend;
 use sp_runtime::{generic::BlockId, traits::Block as BlockT};
 use std::sync::Arc;
 
+/// Frequency MSA Custom RPC API
 #[rpc(client, server)]
 pub trait MsaApi<BlockHash, AccountId> {
+	/// Check for a list of delegations
+	/// Given a single provider, test a list of potential delegators
+	/// At a given block number
 	#[method(name = "msa_checkDelegations")]
 	fn check_delegations(
 		&self,
@@ -26,6 +40,7 @@ pub trait MsaApi<BlockHash, AccountId> {
 		block_number: Option<BlockNumber>,
 	) -> RpcResult<Vec<(MessageSourceId, bool)>>;
 
+	/// Retrieve the list of currently granted schemas given a delegator and provider pair
 	#[method(name = "msa_grantedSchemaIdsByMsaId")]
 	fn get_granted_schemas_by_msa_id(
 		&self,

--- a/pallets/msa/src/rpc/src/lib.rs
+++ b/pallets/msa/src/rpc/src/lib.rs
@@ -34,7 +34,7 @@ pub trait MsaApi<BlockHash, AccountId> {
 	) -> RpcResult<Option<Vec<SchemaId>>>;
 }
 
-/// The client handler for the API.
+/// The client handler for the API used by Frequency Service RPC with `jsonrpsee`
 pub struct MsaHandler<C, M> {
 	client: Arc<C>,
 	_marker: std::marker::PhantomData<M>,

--- a/pallets/msa/src/rpc/src/lib.rs
+++ b/pallets/msa/src/rpc/src/lib.rs
@@ -6,7 +6,7 @@
 	missing_docs
 )]
 
-//! Custom APIs for [MSA](pallet-msa)
+//! Custom APIs for [MSA](../pallet_msa/index.html)
 
 use codec::Codec;
 use common_helpers::rpc::*;

--- a/pallets/msa/src/runtime-api/src/lib.rs
+++ b/pallets/msa/src/runtime-api/src/lib.rs
@@ -9,7 +9,7 @@
 	missing_docs
 )]
 
-//! Runtime API definition for [MSA](pallet-msa)
+//! Runtime API definition for [MSA](../pallet_msa/index.html)
 //!
 //! This api must be implemented by the node runtime.
 //! Runtime APIs Provide:
@@ -24,7 +24,7 @@ use sp_std::vec::Vec;
 // Here we declare the runtime API. It is implemented it the `impl` block in
 // runtime files (the `runtime` folder)
 sp_api::decl_runtime_apis! {
-	/// Runtime API definition for [MSA](pallet-msa)
+	/// Runtime API definition for [MSA](../pallet_msa/index.html)
 	pub trait MsaRuntimeApi<AccountId> where
 		AccountId: Codec,
 	{

--- a/pallets/msa/src/runtime-api/src/lib.rs
+++ b/pallets/msa/src/runtime-api/src/lib.rs
@@ -1,6 +1,20 @@
 #![cfg_attr(not(feature = "std"), no_std)]
 #![allow(clippy::too_many_arguments)]
 #![allow(clippy::unnecessary_mut_passed)]
+// Strong Documentation Lints
+#![deny(
+	rustdoc::broken_intra_doc_links,
+	rustdoc::missing_crate_level_docs,
+	rustdoc::invalid_codeblock_attributes,
+	missing_docs
+)]
+
+//! Runtime API definition for [MSA](pallet-msa)
+//!
+//! This api must be implemented by the node runtime.
+//! Runtime APIs Provide:
+//! - An interface between the runtime and Custom RPCs.
+//! - Runtime interfaces for end users beyond just State Queries
 
 use codec::Codec;
 use common_primitives::{msa::*, node::BlockNumber};
@@ -8,16 +22,19 @@ use frame_support::dispatch::DispatchError;
 use sp_std::vec::Vec;
 
 // Here we declare the runtime API. It is implemented it the `impl` block in
-// runtime file (the `runtime/src/lib.rs`)
+// runtime files (the `runtime` folder)
 sp_api::decl_runtime_apis! {
+	/// Runtime API definition for [MSA](pallet-msa)
 	pub trait MsaRuntimeApi<AccountId> where
 		AccountId: Codec,
 	{
 		// *Temporarily Removed* until https://github.com/LibertyDSNP/frequency/issues/418 is completed
 		// fn get_msa_keys(msa_id: MessageSourceId) ->	Result<Vec<KeyInfoResponse<AccountId>>, DispatchError>;
 
+		/// Check to see if a delegation existed between the given delegator and provider at a given block
 		fn has_delegation(delegator: Delegator, provider: Provider, block_number: Option<BlockNumber>) -> bool;
 
+		/// Get the list of schema ids (if any) that exist in any delegation between the delegator and provider
 		fn get_granted_schemas_by_msa_id(delegator: Delegator, provider: Provider) -> Result<Option<Vec<SchemaId>>, DispatchError>;
 	}
 }

--- a/pallets/schemas/src/rpc/src/lib.rs
+++ b/pallets/schemas/src/rpc/src/lib.rs
@@ -32,7 +32,7 @@ impl From<Error> for i32 {
 	}
 }
 
-/// Frequency Schema API
+/// Frequency Schema Custom RPC API
 #[rpc(client, server)]
 pub trait SchemasApi<BlockHash> {
 	/// retrieving schema by schema id
@@ -44,7 +44,7 @@ pub trait SchemasApi<BlockHash> {
 	fn check_schema_validity(&self, model: Vec<u8>, at: Option<BlockHash>) -> RpcResult<bool>;
 }
 
-/// The client handler for the API.
+/// The client handler for the API used by Frequency Service RPC with `jsonrpsee`
 pub struct SchemasHandler<C, M> {
 	client: Arc<C>,
 	_marker: std::marker::PhantomData<M>,

--- a/pallets/schemas/src/rpc/src/lib.rs
+++ b/pallets/schemas/src/rpc/src/lib.rs
@@ -6,7 +6,7 @@
 	missing_docs
 )]
 
-//! Custom APIs for [Schemas](pallet-schemas)
+//! Custom APIs for [Schemas](../pallet_schemas/index.html)
 
 use common_helpers::{avro, rpc::*};
 use common_primitives::schema::*;

--- a/pallets/schemas/src/rpc/src/lib.rs
+++ b/pallets/schemas/src/rpc/src/lib.rs
@@ -44,12 +44,14 @@ pub trait SchemasApi<BlockHash> {
 	fn check_schema_validity(&self, model: Vec<u8>, at: Option<BlockHash>) -> RpcResult<bool>;
 }
 
+/// The client handler for the API.
 pub struct SchemasHandler<C, M> {
 	client: Arc<C>,
 	_marker: std::marker::PhantomData<M>,
 }
 
 impl<C, M> SchemasHandler<C, M> {
+	/// Create new instance with the given reference to the client.
 	pub fn new(client: Arc<C>) -> Self {
 		Self { client, _marker: Default::default() }
 	}

--- a/pallets/schemas/src/rpc/src/lib.rs
+++ b/pallets/schemas/src/rpc/src/lib.rs
@@ -1,3 +1,13 @@
+// Strong Documentation Lints
+#![deny(
+	rustdoc::broken_intra_doc_links,
+	rustdoc::missing_crate_level_docs,
+	rustdoc::invalid_codeblock_attributes,
+	missing_docs
+)]
+
+//! Custom APIs for [Schemas](pallet-schemas)
+
 use common_helpers::{avro, rpc::*};
 use common_primitives::schema::*;
 use jsonrpsee::{
@@ -12,22 +22,22 @@ use sp_runtime::{generic::BlockId, traits::Block as BlockT};
 use sp_std::vec::Vec;
 use std::sync::Arc;
 
-/// Error type of this RPC api.
-pub enum Error {
+/// Errors that occur on the client RPC
+pub enum SchemaRpcError {
 	/// No schema was found for the given id.
 	SchemaNotFound,
 	/// Failed to fetch latest schema.
 	SchemaSearchError,
-	// Schema validation error.
+	/// Schema model did not validate
 	SchemaValidationError,
 }
 
-impl From<Error> for i32 {
-	fn from(e: Error) -> i32 {
+impl From<SchemaRpcError> for i32 {
+	fn from(e: SchemaRpcError) -> i32 {
 		match e {
-			Error::SchemaNotFound => 1,
-			Error::SchemaSearchError => 2,
-			Error::SchemaValidationError => 3,
+			SchemaRpcError::SchemaNotFound => 1,
+			SchemaRpcError::SchemaSearchError => 2,
+			SchemaRpcError::SchemaValidationError => 3,
 		}
 	}
 }
@@ -73,7 +83,7 @@ where
 		match validated_schema {
 			Ok(_) => Ok(true),
 			Err(e) => Err(RpcError::Call(CallError::Custom(ErrorObject::owned(
-				Error::SchemaValidationError.into(),
+				SchemaRpcError::SchemaValidationError.into(),
 				"Unable to validate schema",
 				Some(format!("{:?}", e)),
 			)))),

--- a/pallets/schemas/src/runtime-api/src/lib.rs
+++ b/pallets/schemas/src/runtime-api/src/lib.rs
@@ -9,7 +9,7 @@
 	missing_docs
 )]
 
-//! Runtime API definition for [Schemas](pallet-schemas)
+//! Runtime API definition for [Schemas](../pallet_schemas/index.html)
 //!
 //! This api must be implemented by the node runtime.
 //! Runtime APIs Provide:
@@ -20,7 +20,7 @@ use common_primitives::schema::*;
 use frame_support::dispatch::DispatchError;
 
 sp_api::decl_runtime_apis! {
-	/// Runtime API definition for [Schemas](pallet-schemas)
+	/// Runtime API definition for [Schemas](../pallet_schemas/index.html)
 	pub trait SchemasRuntimeApi
 	{
 		/// Fetch the schema by id

--- a/pallets/schemas/src/runtime-api/src/lib.rs
+++ b/pallets/schemas/src/runtime-api/src/lib.rs
@@ -1,13 +1,29 @@
 #![cfg_attr(not(feature = "std"), no_std)]
 #![allow(clippy::too_many_arguments)]
 #![allow(clippy::unnecessary_mut_passed)]
+// Strong Documentation Lints
+#![deny(
+	rustdoc::broken_intra_doc_links,
+	rustdoc::missing_crate_level_docs,
+	rustdoc::invalid_codeblock_attributes,
+	missing_docs
+)]
+
+//! Runtime API definition for [Schemas](pallet-schemas)
+//!
+//! This api must be implemented by the node runtime.
+//! Runtime APIs Provide:
+//! - An interface between the runtime and Custom RPCs.
+//! - Runtime interfaces for end users beyond just State Queries
 
 use common_primitives::schema::*;
 use frame_support::dispatch::DispatchError;
 
 sp_api::decl_runtime_apis! {
+	/// Runtime API definition for [Schemas](pallet-schemas)
 	pub trait SchemasRuntimeApi
 	{
+		/// Fetch the schema by id
 		fn get_by_schema_id(schema_id: SchemaId) -> Result<Option<SchemaResponse>, DispatchError>;
 	}
 }


### PR DESCRIPTION
# Goal
The goal of this PR is to standardize and add documentation to the Runtime and Custom RPC pallets

Part of #255 

# Discussion
- One internal name update: `Error` -> `SchemaRpcError`
- Added documentation requirements to the RPC pallets
