### PR TITLE
Code Audit: Compact Encoding for Extrinsic Params

### DIFF
--- a/pallets/messages/src/lib.rs
+++ b/pallets/messages/src/lib.rs
@@ -197,9 +197,9 @@ pub mod pallet {
 		#[pallet::weight(T::WeightInfo::add_ipfs_message(cid.len() as u32, 1_000))]
 		pub fn add_ipfs_message(
 			origin: OriginFor<T>,
-			schema_id: SchemaId,
+			#[pallet::compact] schema_id: SchemaId,
 			cid: Vec<u8>,
-			payload_length: u32,
+			#[pallet::compact] payload_length: u32,
 		) -> DispatchResultWithPostInfo {
 			let provider_key = ensure_signed(origin)?;
 			let payload_tuple: OffchainPayloadType = (cid.clone(), payload_length);
@@ -233,7 +233,7 @@ pub mod pallet {
 		pub fn add_onchain_message(
 			origin: OriginFor<T>,
 			on_behalf_of: Option<MessageSourceId>,
-			schema_id: SchemaId,
+			#[pallet::compact] schema_id: SchemaId,
 			payload: Vec<u8>,
 		) -> DispatchResultWithPostInfo {
 			let provider_key = ensure_signed(origin)?;

--- a/pallets/msa/src/lib.rs
+++ b/pallets/msa/src/lib.rs
@@ -492,7 +492,7 @@ pub mod pallet {
 		#[pallet::weight((T::WeightInfo::revoke_delegation_by_delegator(), DispatchClass::Normal, Pays::No))]
 		pub fn revoke_delegation_by_delegator(
 			origin: OriginFor<T>,
-			provider_msa_id: MessageSourceId,
+			#[pallet::compact] provider_msa_id: MessageSourceId,
 		) -> DispatchResult {
 			let delegator_key = ensure_signed(origin)?;
 
@@ -611,7 +611,7 @@ pub mod pallet {
 		#[pallet::weight((T::WeightInfo::revoke_delegation_by_provider(20_000), DispatchClass::Normal, Pays::No))]
 		pub fn revoke_delegation_by_provider(
 			origin: OriginFor<T>,
-			delegator: MessageSourceId,
+			#[pallet::compact] delegator: MessageSourceId,
 		) -> DispatchResult {
 			let provider_key = ensure_signed(origin)?;
 

--- a/pallets/schemas/src/lib.rs
+++ b/pallets/schemas/src/lib.rs
@@ -238,7 +238,7 @@ pub mod pallet {
 		#[pallet::weight(30_000)]
 		pub fn set_max_schema_model_bytes(
 			origin: OriginFor<T>,
-			#[pallet::compact] max_size: u32
+			#[pallet::compact] max_size: u32,
 		) -> DispatchResult {
 			ensure_root(origin)?;
 			ensure!(

--- a/pallets/schemas/src/lib.rs
+++ b/pallets/schemas/src/lib.rs
@@ -236,7 +236,10 @@ pub mod pallet {
 		/// Set a new value for the Schema maximum number of bytes.  Must be <= the limit of the
 		/// Schema BoundedVec used for registration.
 		#[pallet::weight(30_000)]
-		pub fn set_max_schema_model_bytes(origin: OriginFor<T>, max_size: u32) -> DispatchResult {
+		pub fn set_max_schema_model_bytes(
+			origin: OriginFor<T>,
+			#[pallet::compact] max_size: u32
+		) -> DispatchResult {
 			ensure_root(origin)?;
 			ensure!(
 				max_size <= T::SchemaModelMaxBytesBoundedVecLimit::get(),


### PR DESCRIPTION
# Goal
The goal of this PR is to continue the general code audit by adding compact integer encoding to all extrinsic parameters.

Closes #582 

# Discussion
It looks like pallet compact encoding can only be used on extrinsic code. There may be a way to add encoding for integer types used in RPC but it will need some investigation.

# Checklist
- [ ] Weights updated
