### PR TITLE
Fix incorrect/unclear errors

### DIFF
--- a/pallets/msa/src/lib.rs
+++ b/pallets/msa/src/lib.rs
@@ -299,11 +299,13 @@ pub mod pallet {
 		/// Origin attempted to add a different delegate than what was in the payload
 		UnauthorizedProvider,
 		/// The operation was attempted with a revoked delegation
+		///
+		/// # Situations
+		/// * Had a prior delegation
+		/// * Has an active delegation, but the schema permission is revoked
 		DelegationRevoked,
 		/// The operation was attempted with an unknown delegation
 		DelegationNotFound,
-		/// The operation was attempted with an expired delegation
-		DelegationExpired,
 		/// The MSA id submitted for provider creation has already been associated with a provider
 		DuplicateProviderRegistryEntry,
 		/// The maximum length for a provider name has been exceeded
@@ -849,7 +851,7 @@ impl<T: Config> Pallet<T> {
 	/// * [`Delegation`]
 	/// # Errors
 	/// * [`Error::<T>::DelegationNotFound`] - If no delegation
-	/// * [`Error::<T>::DelegationExpired`] - If delegation revoked
+	/// * [`Error::<T>::DelegationRevoked`] - If delegation revoked
 	pub fn ensure_valid_delegation(
 		provider: Provider,
 		delegator: Delegator,
@@ -869,7 +871,7 @@ impl<T: Config> Pallet<T> {
 		if info.revoked_at == T::BlockNumber::zero() {
 			return Ok(info)
 		}
-		ensure!(info.revoked_at >= requested_block, Error::<T>::DelegationExpired);
+		ensure!(info.revoked_at >= requested_block, Error::<T>::DelegationRevoked);
 		Ok(info)
 	}
 

--- a/pallets/msa/src/tests.rs
+++ b/pallets/msa/src/tests.rs
@@ -1319,7 +1319,7 @@ pub fn delegation_expired() {
 
 		assert_noop!(
 			Msa::ensure_valid_delegation(provider, delegator, None),
-			Error::<Test>::DelegationExpired
+			Error::<Test>::DelegationRevoked
 		);
 	})
 }
@@ -1864,7 +1864,7 @@ pub fn delegation_expired_long_back() {
 
 		assert_noop!(
 			Msa::ensure_valid_delegation(provider, delegator, Some(151)),
-			Error::<Test>::DelegationExpired
+			Error::<Test>::DelegationRevoked
 		);
 		assert_ok!(Msa::ensure_valid_delegation(provider, delegator, Some(6)));
 		assert_noop!(

--- a/pallets/schemas/src/lib.rs
+++ b/pallets/schemas/src/lib.rs
@@ -243,7 +243,7 @@ pub mod pallet {
 			ensure_root(origin)?;
 			ensure!(
 				max_size <= T::SchemaModelMaxBytesBoundedVecLimit::get(),
-				Error::<T>::ExceedsGovernanceSchemaModelMaxValue
+				Error::<T>::ExceedsMaxSchemaModelBytes
 			);
 			GovernanceSchemaModelMaxBytes::<T>::set(max_size);
 			Self::deposit_event(Event::SchemaMaxSizeChanged(max_size));

--- a/pallets/schemas/src/tests.rs
+++ b/pallets/schemas/src/tests.rs
@@ -115,7 +115,7 @@ fn set_max_schema_size_fails_if_not_root() {
 fn set_max_schema_size_fails_if_larger_than_bound() {
 	new_test_ext().execute_with(|| {
 		let new_size: u32 = 68_000;
-		let expected_err = Error::<Test>::ExceedsGovernanceSchemaModelMaxValue;
+		let expected_err = Error::<Test>::ExceedsMaxSchemaModelBytes;
 		assert_noop!(
 			SchemasPallet::set_max_schema_model_bytes(RawOrigin::Root.into(), new_size),
 			expected_err


### PR DESCRIPTION
# Goal
The goal of this PR is to clean up some confusing errors

Part of #255 

# Discussion
- set_max_schema_model_bytes had wrong error `ExceedsGovernanceSchemaModelMaxValue` and needed `ExceedsMaxSchemaModelBytes`
- Merge errors `DelegationExpired` and `DelegationRevoked` and now `DelegationRevoked` is used for when the entire delegation has been revoked as well as when just a particular schema permission is revoked

# Checklist
- [x] Update documentation
- [x] Clear errors
