### PR TITLE
Update mainnet SS58Prefix

### DIFF
--- a/runtime/frequency/src/lib.rs
+++ b/runtime/frequency/src/lib.rs
@@ -192,7 +192,7 @@ parameter_types! {
 		.avg_block_initialization(AVERAGE_ON_INITIALIZE_RATIO)
 		.build_or_panic();
 
-	pub const SS58Prefix: u16 = 42;
+	pub const SS58Prefix: u16 = 90;
 }
 
 // Configure FRAME pallets to include in runtime.


### PR DESCRIPTION
# Goal
The goal of this PR is to set the Frequency mainnet SS58 prefix to 90

References #365

Related PR to spot check the Frequency account type https://github.com/LibertyDSNP/ss58-registry/pull/1

Note: if the linked PR in LibertyDSNP/ss58-registry looks good, it can be mirrored to a PR into paritytech/ss58-registry