### PR TITLE
retire_msa check and update for dos attack #605

### DIFF
--- a/pallets/msa/src/benchmarking.rs
+++ b/pallets/msa/src/benchmarking.rs
@@ -60,7 +60,7 @@ fn create_account_with_msa_id<T: Config>(n: u32) -> (T::AccountId, MessageSource
 
 	assert_ok!(Msa::<T>::create(RawOrigin::Signed(provider.clone()).into()));
 
-	let msa_id = Msa::<T>::try_get_msa_from_public_key(&provider).unwrap();
+	let msa_id = Msa::<T>::ensure_valid_msa_key(&provider).unwrap();
 
 	(provider.clone(), msa_id)
 }
@@ -138,7 +138,7 @@ benchmarks! {
 
 		// Create a MSA account
 		assert_ok!(Msa::<T>::create(RawOrigin::Signed(caller.clone()).into()));
-		let msa_id = Msa::<T>::try_get_msa_from_public_key(&caller).unwrap();
+		let msa_id = Msa::<T>::ensure_valid_msa_key(&caller).unwrap();
 
 		assert_eq!(Msa::<T>::is_registered_provider(msa_id),false);
 

--- a/pallets/msa/src/mock.rs
+++ b/pallets/msa/src/mock.rs
@@ -179,8 +179,7 @@ pub fn test_create_delegator_msa_with_provider() -> (u64, Public) {
 	assert_ok!(Msa::create(Origin::signed(provider_account.into())));
 	assert_ok!(Msa::create(Origin::signed(delegator_account.into())));
 
-	let provider_msa_id =
-		Msa::try_get_msa_from_public_key(&AccountId32::new(provider_account.0)).unwrap();
+	let provider_msa_id = Msa::ensure_valid_msa_key(&AccountId32::new(provider_account.0)).unwrap();
 
 	let (delegator_signature, add_provider_payload) =
 		create_and_sign_add_provider_payload(delegator_key_pair, provider_msa_id);

--- a/pallets/msa/src/tests.rs
+++ b/pallets/msa/src/tests.rs
@@ -406,7 +406,7 @@ fn test_retire_msa_success() {
 		// Create provider account and get its MSA ID (u64)
 		assert_ok!(Msa::create(Origin::signed(provider_account.into())));
 		let provider_msa_id =
-			Msa::try_get_msa_from_public_key(&AccountId32::new(provider_account.0)).unwrap();
+			Msa::ensure_valid_msa_key(&AccountId32::new(provider_account.0)).unwrap();
 
 		assert_ok!(Msa::create_provider(Origin::signed(provider_account.into()), Vec::from("Foo")));
 
@@ -537,12 +537,12 @@ pub fn add_provider_to_msa_is_success() {
 		// Create provider account and get its MSA ID (u64)
 		assert_ok!(Msa::create(Origin::signed(provider_account.into())));
 		let provider_msa =
-			Msa::try_get_msa_from_public_key(&AccountId32::new(provider_account.0)).unwrap();
+			Msa::ensure_valid_msa_key(&AccountId32::new(provider_account.0)).unwrap();
 
 		// Create delegator account and get its MSA ID (u64)
 		assert_ok!(Msa::create(Origin::signed(delegator_account.into())));
 		let delegator_msa =
-			Msa::try_get_msa_from_public_key(&AccountId32::new(delegator_account.0)).unwrap();
+			Msa::ensure_valid_msa_key(&AccountId32::new(delegator_account.0)).unwrap();
 
 		// Register provider
 		assert_ok!(Msa::create_provider(Origin::signed(provider_account.into()), Vec::from("Foo")));
@@ -689,7 +689,7 @@ pub fn grant_delegation_throws_unauthorized_delegator_error() {
 		let delegator_account = delegator_key_pair.public();
 		assert_ok!(Msa::create(Origin::signed(delegator_account.into())));
 		let delegator_msa_id =
-			Msa::try_get_msa_from_public_key(&AccountId32::new(delegator_account.0)).unwrap();
+			Msa::ensure_valid_msa_key(&AccountId32::new(delegator_account.0)).unwrap();
 
 		let expiration: BlockNumber = 10;
 		let add_provider_payload = AddProvider::new(delegator_msa_id, None, expiration);
@@ -971,7 +971,7 @@ pub fn revoke_delegation_by_delegatoris_successful() {
 		assert_ok!(Msa::create_provider(Origin::signed(provider_account.into()), Vec::from("Foo")));
 
 		let provider_msa =
-			Msa::try_get_msa_from_public_key(&AccountId32::new(provider_account.0)).unwrap();
+			Msa::ensure_valid_msa_key(&AccountId32::new(provider_account.0)).unwrap();
 
 		let (delegator_signature, add_provider_payload) =
 			create_and_sign_add_provider_payload(delegator_pair, provider_msa);
@@ -1007,7 +1007,7 @@ pub fn revoke_provider_is_successful() {
 		assert_ok!(Msa::create(Origin::signed(provider_account.into())));
 
 		let provider_msa =
-			Msa::try_get_msa_from_public_key(&AccountId32::new(provider_account.0)).unwrap();
+			Msa::ensure_valid_msa_key(&AccountId32::new(provider_account.0)).unwrap();
 
 		let (delegator_signature, add_provider_payload) =
 			create_and_sign_add_provider_payload(delegator_pair, provider_msa);
@@ -1023,7 +1023,7 @@ pub fn revoke_provider_is_successful() {
 		));
 
 		let delegator_msa =
-			Msa::try_get_msa_from_public_key(&AccountId32::new(delegator_account.0)).unwrap();
+			Msa::ensure_valid_msa_key(&AccountId32::new(delegator_account.0)).unwrap();
 
 		let provider = Provider(provider_msa);
 		let delegator = Delegator(delegator_msa);
@@ -1084,7 +1084,7 @@ fn revoke_provider_throws_error_when_delegation_already_revoked() {
 		assert_ok!(Msa::create(Origin::signed(provider_account.into())));
 
 		let provider_msa =
-			Msa::try_get_msa_from_public_key(&AccountId32::new(provider_account.0)).unwrap();
+			Msa::ensure_valid_msa_key(&AccountId32::new(provider_account.0)).unwrap();
 
 		let (delegator_signature, add_provider_payload) =
 			create_and_sign_add_provider_payload(delegator_pair, provider_msa);


### PR DESCRIPTION
# Goal
The goal of this PR is to address the retire_msa section of #605 : ensure that the extrinsic cannot fail and instead, any potential failures happen in the SignedExtension.

# Discussion
The main change is to move all db access inside a match that fetches the MSA, mainly for clarity.

A check for an MSA is already made in the SignedExtension so it fails if the Origin (actually the AccountId) does not have an MSA.  It also verifies that there is only one key, the AccountId, associated with it, and that it's not a registered provider.  This means that we should never get into the extrinsic unless there is an MSA. We're required to provide a None option in our match so if we somehow strangely wind up in there, it logs a warning and exits.

- [ ]  `ensure_signed` - this must remain inside the extrinsic to guarantee having an AccountId for looking up an MSA.
- [ ]  `try_get_msa_from_account_id` - this has been removed, as it is identical to another function. We know already we should have an MSA, so we just fetch it instead of doing a try_get type of function call.
- [ ]  `remove_delegator` - similarly, this being in the match it doesn't happen unless there is an MSA. If there is no delegator - which is allowed, the MSA may already have removed a provider - then there is no failure; this is harmless.
- [ ]  `delete_key_for_msa` - also in the Some(msa_id) clause as above.

## Also
I refactored away a function that wasn't really doing anything extra.

## Verified
Attempting to `retire_msa` fails the SignedExtension validation - and so does not add a txn to the block - under the following conditions:
1. with an account with no MSA ID
2. with an account that has an MSA ID but is a registered provider
3. by submitting an unsigned transaction

# Checklist
## Not applicable:
- Chain spec updated
- Updated the js/api-augment code if a custom RPC added/changed
- N/A Design doc(s) updated
- N/A Tests added
- Benchmarks added
- Weights updated
