### PR TITLE
fix(extrinsic): ensure signature includes key 

### DIFF
--- a/pallets/messages/src/weights.rs
+++ b/pallets/messages/src/weights.rs
@@ -66,11 +66,11 @@ impl<T: frame_system::Config> WeightInfo for SubstrateWeight<T> {
 	// Storage: Msa DelegatorAndProviderToDelegation (r:1 w:0)
 	// Storage: Messages BlockMessages (r:1 w:1)
 	fn add_onchain_message(n: u32, m: u32, ) -> Weight {
-		Weight::from_ref_time(3_054_000 as u64)
+		Weight::from_ref_time(2_775_000 as u64)
 			// Standard Error: 0
 			.saturating_add(Weight::from_ref_time(1_000 as u64).saturating_mul(n as u64))
 			// Standard Error: 2_000
-			.saturating_add(Weight::from_ref_time(227_000 as u64).saturating_mul(m as u64))
+			.saturating_add(Weight::from_ref_time(222_000 as u64).saturating_mul(m as u64))
 			.saturating_add(T::DbWeight::get().reads(4 as u64))
 			.saturating_add(T::DbWeight::get().writes(1 as u64))
 	}
@@ -78,11 +78,11 @@ impl<T: frame_system::Config> WeightInfo for SubstrateWeight<T> {
 	// Storage: Msa PublicKeyToMsaId (r:1 w:0)
 	// Storage: Messages BlockMessages (r:1 w:1)
 	fn add_ipfs_message(n: u32, m: u32, ) -> Weight {
-		Weight::from_ref_time(3_403_000 as u64)
+		Weight::from_ref_time(4_153_000 as u64)
 			// Standard Error: 0
 			.saturating_add(Weight::from_ref_time(2_000 as u64).saturating_mul(n as u64))
 			// Standard Error: 2_000
-			.saturating_add(Weight::from_ref_time(196_000 as u64).saturating_mul(m as u64))
+			.saturating_add(Weight::from_ref_time(190_000 as u64).saturating_mul(m as u64))
 			.saturating_add(T::DbWeight::get().reads(3 as u64))
 			.saturating_add(T::DbWeight::get().writes(1 as u64))
 	}
@@ -90,10 +90,10 @@ impl<T: frame_system::Config> WeightInfo for SubstrateWeight<T> {
 	// Storage: Messages Messages (r:0 w:1)
 	fn on_initialize(m: u32, s: u32, ) -> Weight {
 		Weight::from_ref_time(0 as u64)
-			// Standard Error: 17_000
-			.saturating_add(Weight::from_ref_time(369_000 as u64).saturating_mul(m as u64))
-			// Standard Error: 178_000
-			.saturating_add(Weight::from_ref_time(5_036_000 as u64).saturating_mul(s as u64))
+			// Standard Error: 15_000
+			.saturating_add(Weight::from_ref_time(384_000 as u64).saturating_mul(m as u64))
+			// Standard Error: 155_000
+			.saturating_add(Weight::from_ref_time(5_167_000 as u64).saturating_mul(s as u64))
 			.saturating_add(T::DbWeight::get().reads(1 as u64))
 			.saturating_add(T::DbWeight::get().writes((1 as u64).saturating_mul(s as u64)))
 	}
@@ -106,11 +106,11 @@ impl WeightInfo for () {
 	// Storage: Msa DelegatorAndProviderToDelegation (r:1 w:0)
 	// Storage: Messages BlockMessages (r:1 w:1)
 	fn add_onchain_message(n: u32, m: u32, ) -> Weight {
-		Weight::from_ref_time(3_054_000 as u64)
+		Weight::from_ref_time(2_775_000 as u64)
 			// Standard Error: 0
 			.saturating_add(Weight::from_ref_time(1_000 as u64).saturating_mul(n as u64))
 			// Standard Error: 2_000
-			.saturating_add(Weight::from_ref_time(227_000 as u64).saturating_mul(m as u64))
+			.saturating_add(Weight::from_ref_time(222_000 as u64).saturating_mul(m as u64))
 			.saturating_add(RocksDbWeight::get().reads(4 as u64))
 			.saturating_add(RocksDbWeight::get().writes(1 as u64))
 	}
@@ -118,11 +118,11 @@ impl WeightInfo for () {
 	// Storage: Msa PublicKeyToMsaId (r:1 w:0)
 	// Storage: Messages BlockMessages (r:1 w:1)
 	fn add_ipfs_message(n: u32, m: u32, ) -> Weight {
-		Weight::from_ref_time(3_403_000 as u64)
+		Weight::from_ref_time(4_153_000 as u64)
 			// Standard Error: 0
 			.saturating_add(Weight::from_ref_time(2_000 as u64).saturating_mul(n as u64))
 			// Standard Error: 2_000
-			.saturating_add(Weight::from_ref_time(196_000 as u64).saturating_mul(m as u64))
+			.saturating_add(Weight::from_ref_time(190_000 as u64).saturating_mul(m as u64))
 			.saturating_add(RocksDbWeight::get().reads(3 as u64))
 			.saturating_add(RocksDbWeight::get().writes(1 as u64))
 	}
@@ -130,10 +130,10 @@ impl WeightInfo for () {
 	// Storage: Messages Messages (r:0 w:1)
 	fn on_initialize(m: u32, s: u32, ) -> Weight {
 		Weight::from_ref_time(0 as u64)
-			// Standard Error: 17_000
-			.saturating_add(Weight::from_ref_time(369_000 as u64).saturating_mul(m as u64))
-			// Standard Error: 178_000
-			.saturating_add(Weight::from_ref_time(5_036_000 as u64).saturating_mul(s as u64))
+			// Standard Error: 15_000
+			.saturating_add(Weight::from_ref_time(384_000 as u64).saturating_mul(m as u64))
+			// Standard Error: 155_000
+			.saturating_add(Weight::from_ref_time(5_167_000 as u64).saturating_mul(s as u64))
 			.saturating_add(RocksDbWeight::get().reads(1 as u64))
 			.saturating_add(RocksDbWeight::get().writes((1 as u64).saturating_mul(s as u64)))
 	}

--- a/pallets/msa/src/types.rs
+++ b/pallets/msa/src/types.rs
@@ -17,12 +17,15 @@ use scale_info::TypeInfo;
 pub const EMPTY_FUNCTION: fn(MessageSourceId) -> DispatchResult = |_| Ok(());
 
 /// A type definition for the payload of adding an MSA key - `pallet_msa::add_public_key_to_msa`
-#[derive(TypeInfo, Debug, Clone, Decode, Encode, PartialEq, Eq)]
-pub struct AddKeyData {
+#[derive(TypeInfo, RuntimeDebugNoBound, Clone, Decode, Encode, PartialEq, Eq)]
+#[scale_info(skip_type_params(T))]
+pub struct AddKeyData<T: Config> {
 	/// Message Source Account identifier
 	pub msa_id: MessageSourceId,
 	/// The block number at which the signed proof for add_public_key_to_msa expires.
-	pub expiration: BlockNumber,
+	pub expiration: T::BlockNumber,
+	/// The public key to be added.
+	pub new_public_key: T::AccountId,
 }
 
 /// Structure that is signed for granting permissions to a Provider

--- a/pallets/msa/src/weights.rs
+++ b/pallets/msa/src/weights.rs
@@ -74,9 +74,9 @@ impl<T: frame_system::Config> WeightInfo for SubstrateWeight<T> {
 	// Storage: Msa PublicKeyToMsaId (r:1 w:1)
 	// Storage: Msa PublicKeyCountForMsaId (r:1 w:1)
 	fn create(s: u32, ) -> Weight {
-		Weight::from_ref_time(51_558_000 as u64)
+		Weight::from_ref_time(51_661_000 as u64)
 			// Standard Error: 4_000
-			.saturating_add(Weight::from_ref_time(45_000 as u64).saturating_mul(s as u64))
+			.saturating_add(Weight::from_ref_time(47_000 as u64).saturating_mul(s as u64))
 			.saturating_add(T::DbWeight::get().reads(3 as u64))
 			.saturating_add(T::DbWeight::get().writes(3 as u64))
 	}
@@ -88,38 +88,38 @@ impl<T: frame_system::Config> WeightInfo for SubstrateWeight<T> {
 	// Storage: Msa DelegatorAndProviderToDelegation (r:1 w:1)
 	// Storage: Schemas CurrentSchemaIdentifierMaximum (r:1 w:0)
 	fn create_sponsored_account_with_delegation() -> Weight {
-		Weight::from_ref_time(101_295_000 as u64)
+		Weight::from_ref_time(101_654_000 as u64)
 			.saturating_add(T::DbWeight::get().reads(8 as u64))
 			.saturating_add(T::DbWeight::get().writes(5 as u64))
 	}
 	// Storage: Msa PublicKeyToMsaId (r:1 w:0)
 	// Storage: Msa DelegatorAndProviderToDelegation (r:1 w:1)
 	fn revoke_delegation_by_provider(s: u32, ) -> Weight {
-		Weight::from_ref_time(49_008_000 as u64)
-			// Standard Error: 3_000
-			.saturating_add(Weight::from_ref_time(81_000 as u64).saturating_mul(s as u64))
+		Weight::from_ref_time(47_478_000 as u64)
+			// Standard Error: 2_000
+			.saturating_add(Weight::from_ref_time(83_000 as u64).saturating_mul(s as u64))
 			.saturating_add(T::DbWeight::get().reads(2 as u64))
 			.saturating_add(T::DbWeight::get().writes(1 as u64))
 	}
-	// Storage: Msa PayloadSignatureRegistry (r:1 w:1)
+	// Storage: Msa PayloadSignatureRegistry (r:2 w:2)
 	// Storage: Msa PublicKeyToMsaId (r:2 w:1)
 	// Storage: Msa PublicKeyCountForMsaId (r:1 w:1)
 	fn add_public_key_to_msa() -> Weight {
-		Weight::from_ref_time(139_833_000 as u64)
-			.saturating_add(T::DbWeight::get().reads(4 as u64))
-			.saturating_add(T::DbWeight::get().writes(3 as u64))
+		Weight::from_ref_time(145_828_000 as u64)
+			.saturating_add(T::DbWeight::get().reads(5 as u64))
+			.saturating_add(T::DbWeight::get().writes(4 as u64))
 	}
 	// Storage: Msa PublicKeyToMsaId (r:2 w:1)
 	// Storage: Msa PublicKeyCountForMsaId (r:1 w:1)
 	fn delete_msa_public_key() -> Weight {
-		Weight::from_ref_time(29_267_000 as u64)
+		Weight::from_ref_time(30_633_000 as u64)
 			.saturating_add(T::DbWeight::get().reads(3 as u64))
 			.saturating_add(T::DbWeight::get().writes(2 as u64))
 	}
 	// Storage: Msa PublicKeyToMsaId (r:1 w:1)
 	// Storage: Msa PublicKeyCountForMsaId (r:1 w:1)
 	fn retire_msa() -> Weight {
-		Weight::from_ref_time(30_084_000 as u64)
+		Weight::from_ref_time(29_830_000 as u64)
 			.saturating_add(T::DbWeight::get().reads(2 as u64))
 			.saturating_add(T::DbWeight::get().writes(2 as u64))
 	}
@@ -129,26 +129,26 @@ impl<T: frame_system::Config> WeightInfo for SubstrateWeight<T> {
 	// Storage: Msa DelegatorAndProviderToDelegation (r:1 w:1)
 	// Storage: Schemas CurrentSchemaIdentifierMaximum (r:1 w:0)
 	fn grant_delegation() -> Weight {
-		Weight::from_ref_time(92_979_000 as u64)
+		Weight::from_ref_time(94_608_000 as u64)
 			.saturating_add(T::DbWeight::get().reads(6 as u64))
 			.saturating_add(T::DbWeight::get().writes(2 as u64))
 	}
 	// Storage: Msa PublicKeyToMsaId (r:1 w:0)
 	// Storage: Msa DelegatorAndProviderToDelegation (r:1 w:1)
 	fn revoke_delegation_by_delegator() -> Weight {
-		Weight::from_ref_time(27_154_000 as u64)
+		Weight::from_ref_time(26_842_000 as u64)
 			.saturating_add(T::DbWeight::get().reads(2 as u64))
 			.saturating_add(T::DbWeight::get().writes(1 as u64))
 	}
 	// Storage: Msa PublicKeyToMsaId (r:1 w:0)
 	// Storage: Msa ProviderToRegistryEntry (r:1 w:1)
 	fn create_provider() -> Weight {
-		Weight::from_ref_time(21_009_000 as u64)
+		Weight::from_ref_time(21_431_000 as u64)
 			.saturating_add(T::DbWeight::get().reads(2 as u64))
 			.saturating_add(T::DbWeight::get().writes(1 as u64))
 	}
 	fn on_initialize(m: u32, ) -> Weight {
-		Weight::from_ref_time(10_913_000 as u64)
+		Weight::from_ref_time(10_587_000 as u64)
 			// Standard Error: 0
 			.saturating_add(Weight::from_ref_time(2_000 as u64).saturating_mul(m as u64))
 	}
@@ -156,9 +156,9 @@ impl<T: frame_system::Config> WeightInfo for SubstrateWeight<T> {
 	// Storage: Msa DelegatorAndProviderToDelegation (r:1 w:1)
 	// Storage: Schemas CurrentSchemaIdentifierMaximum (r:1 w:0)
 	fn grant_schema_permissions(s: u32, ) -> Weight {
-		Weight::from_ref_time(60_177_000 as u64)
+		Weight::from_ref_time(61_082_000 as u64)
 			// Standard Error: 3_000
-			.saturating_add(Weight::from_ref_time(80_000 as u64).saturating_mul(s as u64))
+			.saturating_add(Weight::from_ref_time(75_000 as u64).saturating_mul(s as u64))
 			.saturating_add(T::DbWeight::get().reads(3 as u64))
 			.saturating_add(T::DbWeight::get().writes(1 as u64))
 	}
@@ -166,9 +166,9 @@ impl<T: frame_system::Config> WeightInfo for SubstrateWeight<T> {
 	// Storage: Msa DelegatorAndProviderToDelegation (r:1 w:1)
 	// Storage: Schemas CurrentSchemaIdentifierMaximum (r:1 w:0)
 	fn revoke_schema_permissions(s: u32, ) -> Weight {
-		Weight::from_ref_time(60_165_000 as u64)
+		Weight::from_ref_time(61_425_000 as u64)
 			// Standard Error: 3_000
-			.saturating_add(Weight::from_ref_time(84_000 as u64).saturating_mul(s as u64))
+			.saturating_add(Weight::from_ref_time(80_000 as u64).saturating_mul(s as u64))
 			.saturating_add(T::DbWeight::get().reads(3 as u64))
 			.saturating_add(T::DbWeight::get().writes(1 as u64))
 	}
@@ -180,9 +180,9 @@ impl WeightInfo for () {
 	// Storage: Msa PublicKeyToMsaId (r:1 w:1)
 	// Storage: Msa PublicKeyCountForMsaId (r:1 w:1)
 	fn create(s: u32, ) -> Weight {
-		Weight::from_ref_time(51_558_000 as u64)
+		Weight::from_ref_time(51_661_000 as u64)
 			// Standard Error: 4_000
-			.saturating_add(Weight::from_ref_time(45_000 as u64).saturating_mul(s as u64))
+			.saturating_add(Weight::from_ref_time(47_000 as u64).saturating_mul(s as u64))
 			.saturating_add(RocksDbWeight::get().reads(3 as u64))
 			.saturating_add(RocksDbWeight::get().writes(3 as u64))
 	}
@@ -194,38 +194,38 @@ impl WeightInfo for () {
 	// Storage: Msa DelegatorAndProviderToDelegation (r:1 w:1)
 	// Storage: Schemas CurrentSchemaIdentifierMaximum (r:1 w:0)
 	fn create_sponsored_account_with_delegation() -> Weight {
-		Weight::from_ref_time(101_295_000 as u64)
+		Weight::from_ref_time(101_654_000 as u64)
 			.saturating_add(RocksDbWeight::get().reads(8 as u64))
 			.saturating_add(RocksDbWeight::get().writes(5 as u64))
 	}
 	// Storage: Msa PublicKeyToMsaId (r:1 w:0)
 	// Storage: Msa DelegatorAndProviderToDelegation (r:1 w:1)
 	fn revoke_delegation_by_provider(s: u32, ) -> Weight {
-		Weight::from_ref_time(49_008_000 as u64)
-			// Standard Error: 3_000
-			.saturating_add(Weight::from_ref_time(81_000 as u64).saturating_mul(s as u64))
+		Weight::from_ref_time(47_478_000 as u64)
+			// Standard Error: 2_000
+			.saturating_add(Weight::from_ref_time(83_000 as u64).saturating_mul(s as u64))
 			.saturating_add(RocksDbWeight::get().reads(2 as u64))
 			.saturating_add(RocksDbWeight::get().writes(1 as u64))
 	}
-	// Storage: Msa PayloadSignatureRegistry (r:1 w:1)
+	// Storage: Msa PayloadSignatureRegistry (r:2 w:2)
 	// Storage: Msa PublicKeyToMsaId (r:2 w:1)
 	// Storage: Msa PublicKeyCountForMsaId (r:1 w:1)
 	fn add_public_key_to_msa() -> Weight {
-		Weight::from_ref_time(139_833_000 as u64)
-			.saturating_add(RocksDbWeight::get().reads(4 as u64))
-			.saturating_add(RocksDbWeight::get().writes(3 as u64))
+		Weight::from_ref_time(145_828_000 as u64)
+			.saturating_add(RocksDbWeight::get().reads(5 as u64))
+			.saturating_add(RocksDbWeight::get().writes(4 as u64))
 	}
 	// Storage: Msa PublicKeyToMsaId (r:2 w:1)
 	// Storage: Msa PublicKeyCountForMsaId (r:1 w:1)
 	fn delete_msa_public_key() -> Weight {
-		Weight::from_ref_time(29_267_000 as u64)
+		Weight::from_ref_time(30_633_000 as u64)
 			.saturating_add(RocksDbWeight::get().reads(3 as u64))
 			.saturating_add(RocksDbWeight::get().writes(2 as u64))
 	}
 	// Storage: Msa PublicKeyToMsaId (r:1 w:1)
 	// Storage: Msa PublicKeyCountForMsaId (r:1 w:1)
 	fn retire_msa() -> Weight {
-		Weight::from_ref_time(30_084_000 as u64)
+		Weight::from_ref_time(29_830_000 as u64)
 			.saturating_add(RocksDbWeight::get().reads(2 as u64))
 			.saturating_add(RocksDbWeight::get().writes(2 as u64))
 	}
@@ -235,26 +235,26 @@ impl WeightInfo for () {
 	// Storage: Msa DelegatorAndProviderToDelegation (r:1 w:1)
 	// Storage: Schemas CurrentSchemaIdentifierMaximum (r:1 w:0)
 	fn grant_delegation() -> Weight {
-		Weight::from_ref_time(92_979_000 as u64)
+		Weight::from_ref_time(94_608_000 as u64)
 			.saturating_add(RocksDbWeight::get().reads(6 as u64))
 			.saturating_add(RocksDbWeight::get().writes(2 as u64))
 	}
 	// Storage: Msa PublicKeyToMsaId (r:1 w:0)
 	// Storage: Msa DelegatorAndProviderToDelegation (r:1 w:1)
 	fn revoke_delegation_by_delegator() -> Weight {
-		Weight::from_ref_time(27_154_000 as u64)
+		Weight::from_ref_time(26_842_000 as u64)
 			.saturating_add(RocksDbWeight::get().reads(2 as u64))
 			.saturating_add(RocksDbWeight::get().writes(1 as u64))
 	}
 	// Storage: Msa PublicKeyToMsaId (r:1 w:0)
 	// Storage: Msa ProviderToRegistryEntry (r:1 w:1)
 	fn create_provider() -> Weight {
-		Weight::from_ref_time(21_009_000 as u64)
+		Weight::from_ref_time(21_431_000 as u64)
 			.saturating_add(RocksDbWeight::get().reads(2 as u64))
 			.saturating_add(RocksDbWeight::get().writes(1 as u64))
 	}
 	fn on_initialize(m: u32, ) -> Weight {
-		Weight::from_ref_time(10_913_000 as u64)
+		Weight::from_ref_time(10_587_000 as u64)
 			// Standard Error: 0
 			.saturating_add(Weight::from_ref_time(2_000 as u64).saturating_mul(m as u64))
 	}
@@ -262,9 +262,9 @@ impl WeightInfo for () {
 	// Storage: Msa DelegatorAndProviderToDelegation (r:1 w:1)
 	// Storage: Schemas CurrentSchemaIdentifierMaximum (r:1 w:0)
 	fn grant_schema_permissions(s: u32, ) -> Weight {
-		Weight::from_ref_time(60_177_000 as u64)
+		Weight::from_ref_time(61_082_000 as u64)
 			// Standard Error: 3_000
-			.saturating_add(Weight::from_ref_time(80_000 as u64).saturating_mul(s as u64))
+			.saturating_add(Weight::from_ref_time(75_000 as u64).saturating_mul(s as u64))
 			.saturating_add(RocksDbWeight::get().reads(3 as u64))
 			.saturating_add(RocksDbWeight::get().writes(1 as u64))
 	}
@@ -272,9 +272,9 @@ impl WeightInfo for () {
 	// Storage: Msa DelegatorAndProviderToDelegation (r:1 w:1)
 	// Storage: Schemas CurrentSchemaIdentifierMaximum (r:1 w:0)
 	fn revoke_schema_permissions(s: u32, ) -> Weight {
-		Weight::from_ref_time(60_165_000 as u64)
+		Weight::from_ref_time(61_425_000 as u64)
 			// Standard Error: 3_000
-			.saturating_add(Weight::from_ref_time(84_000 as u64).saturating_mul(s as u64))
+			.saturating_add(Weight::from_ref_time(80_000 as u64).saturating_mul(s as u64))
 			.saturating_add(RocksDbWeight::get().reads(3 as u64))
 			.saturating_add(RocksDbWeight::get().writes(1 as u64))
 	}

--- a/pallets/schemas/src/weights.rs
+++ b/pallets/schemas/src/weights.rs
@@ -65,9 +65,9 @@ impl<T: frame_system::Config> WeightInfo for SubstrateWeight<T> {
 	fn create_schema(m: u32, n: u32, ) -> Weight {
 		Weight::from_ref_time(0 as u64)
 			// Standard Error: 0
-			.saturating_add(Weight::from_ref_time(31_000 as u64).saturating_mul(m as u64))
+			.saturating_add(Weight::from_ref_time(32_000 as u64).saturating_mul(m as u64))
 			// Standard Error: 5_000
-			.saturating_add(Weight::from_ref_time(108_000 as u64).saturating_mul(n as u64))
+			.saturating_add(Weight::from_ref_time(119_000 as u64).saturating_mul(n as u64))
 			.saturating_add(T::DbWeight::get().reads(2 as u64))
 			.saturating_add(T::DbWeight::get().writes(2 as u64))
 	}
@@ -81,9 +81,9 @@ impl WeightInfo for () {
 	fn create_schema(m: u32, n: u32, ) -> Weight {
 		Weight::from_ref_time(0 as u64)
 			// Standard Error: 0
-			.saturating_add(Weight::from_ref_time(31_000 as u64).saturating_mul(m as u64))
+			.saturating_add(Weight::from_ref_time(32_000 as u64).saturating_mul(m as u64))
 			// Standard Error: 5_000
-			.saturating_add(Weight::from_ref_time(108_000 as u64).saturating_mul(n as u64))
+			.saturating_add(Weight::from_ref_time(119_000 as u64).saturating_mul(n as u64))
 			.saturating_add(RocksDbWeight::get().reads(2 as u64))
 			.saturating_add(RocksDbWeight::get().writes(2 as u64))
 	}

--- a/runtime/common/src/weights/orml_vesting.rs
+++ b/runtime/common/src/weights/orml_vesting.rs
@@ -38,7 +38,7 @@ impl<T: frame_system::Config> orml_vesting::WeightInfo for SubstrateWeight<T> {
 	// Storage: System Account (r:2 w:2)
 	// Storage: Balances Locks (r:1 w:1)
 	fn vested_transfer() -> Weight {
-		Weight::from_ref_time(60_394_000 as u64)
+		Weight::from_ref_time(57_236_000 as u64)
 			.saturating_add(T::DbWeight::get().reads(5 as u64))
 			.saturating_add(T::DbWeight::get().writes(4 as u64))
 	}
@@ -47,9 +47,9 @@ impl<T: frame_system::Config> orml_vesting::WeightInfo for SubstrateWeight<T> {
 	// Storage: Balances Locks (r:1 w:1)
 	/// The range of component `i` is `[1, 50]`.
 	fn claim(i: u32, ) -> Weight {
-		Weight::from_ref_time(39_474_000 as u64)
+		Weight::from_ref_time(38_276_000 as u64)
 			// Standard Error: 1_000
-			.saturating_add(Weight::from_ref_time(80_000 as u64).saturating_mul(i as u64))
+			.saturating_add(Weight::from_ref_time(79_000 as u64).saturating_mul(i as u64))
 			.saturating_add(T::DbWeight::get().reads(3 as u64))
 			.saturating_add(T::DbWeight::get().writes(2 as u64))
 	}
@@ -58,9 +58,9 @@ impl<T: frame_system::Config> orml_vesting::WeightInfo for SubstrateWeight<T> {
 	// Storage: Vesting VestingSchedules (r:0 w:1)
 	/// The range of component `i` is `[1, 50]`.
 	fn update_vesting_schedules(i: u32, ) -> Weight {
-		Weight::from_ref_time(32_451_000 as u64)
+		Weight::from_ref_time(31_529_000 as u64)
 			// Standard Error: 1_000
-			.saturating_add(Weight::from_ref_time(62_000 as u64).saturating_mul(i as u64))
+			.saturating_add(Weight::from_ref_time(55_000 as u64).saturating_mul(i as u64))
 			.saturating_add(T::DbWeight::get().reads(2 as u64))
 			.saturating_add(T::DbWeight::get().writes(3 as u64))
 	}

--- a/runtime/common/src/weights/pallet_balances.rs
+++ b/runtime/common/src/weights/pallet_balances.rs
@@ -35,43 +35,43 @@ pub struct SubstrateWeight<T>(PhantomData<T>);
 impl<T: frame_system::Config> pallet_balances::WeightInfo for SubstrateWeight<T> {
 	// Storage: System Account (r:1 w:1)
 	fn transfer() -> Weight {
-		Weight::from_ref_time(46_648_000 as u64)
+		Weight::from_ref_time(46_139_000 as u64)
 			.saturating_add(T::DbWeight::get().reads(1 as u64))
 			.saturating_add(T::DbWeight::get().writes(1 as u64))
 	}
 	// Storage: System Account (r:1 w:1)
 	fn transfer_keep_alive() -> Weight {
-		Weight::from_ref_time(34_575_000 as u64)
+		Weight::from_ref_time(34_141_000 as u64)
 			.saturating_add(T::DbWeight::get().reads(1 as u64))
 			.saturating_add(T::DbWeight::get().writes(1 as u64))
 	}
 	// Storage: System Account (r:1 w:1)
 	fn set_balance_creating() -> Weight {
-		Weight::from_ref_time(25_185_000 as u64)
+		Weight::from_ref_time(25_211_000 as u64)
 			.saturating_add(T::DbWeight::get().reads(1 as u64))
 			.saturating_add(T::DbWeight::get().writes(1 as u64))
 	}
 	// Storage: System Account (r:1 w:1)
 	fn set_balance_killing() -> Weight {
-		Weight::from_ref_time(28_624_000 as u64)
+		Weight::from_ref_time(27_912_000 as u64)
 			.saturating_add(T::DbWeight::get().reads(1 as u64))
 			.saturating_add(T::DbWeight::get().writes(1 as u64))
 	}
 	// Storage: System Account (r:2 w:2)
 	fn force_transfer() -> Weight {
-		Weight::from_ref_time(46_133_000 as u64)
+		Weight::from_ref_time(45_142_000 as u64)
 			.saturating_add(T::DbWeight::get().reads(2 as u64))
 			.saturating_add(T::DbWeight::get().writes(2 as u64))
 	}
 	// Storage: System Account (r:1 w:1)
 	fn transfer_all() -> Weight {
-		Weight::from_ref_time(40_367_000 as u64)
+		Weight::from_ref_time(39_651_000 as u64)
 			.saturating_add(T::DbWeight::get().reads(1 as u64))
 			.saturating_add(T::DbWeight::get().writes(1 as u64))
 	}
 	// Storage: System Account (r:1 w:1)
 	fn force_unreserve() -> Weight {
-		Weight::from_ref_time(21_547_000 as u64)
+		Weight::from_ref_time(21_227_000 as u64)
 			.saturating_add(T::DbWeight::get().reads(1 as u64))
 			.saturating_add(T::DbWeight::get().writes(1 as u64))
 	}

--- a/runtime/common/src/weights/pallet_democracy.rs
+++ b/runtime/common/src/weights/pallet_democracy.rs
@@ -38,16 +38,16 @@ impl<T: frame_system::Config> pallet_democracy::WeightInfo for SubstrateWeight<T
 	// Storage: Democracy Blacklist (r:1 w:0)
 	// Storage: Democracy DepositOf (r:0 w:1)
 	fn propose() -> Weight {
-		Weight::from_ref_time(63_453_000 as u64)
+		Weight::from_ref_time(63_782_000 as u64)
 			.saturating_add(T::DbWeight::get().reads(3 as u64))
 			.saturating_add(T::DbWeight::get().writes(3 as u64))
 	}
 	// Storage: Democracy DepositOf (r:1 w:1)
 	/// The range of component `s` is `[0, 100]`.
 	fn second(s: u32, ) -> Weight {
-		Weight::from_ref_time(36_007_000 as u64)
+		Weight::from_ref_time(36_235_000 as u64)
 			// Standard Error: 1_000
-			.saturating_add(Weight::from_ref_time(166_000 as u64).saturating_mul(s as u64))
+			.saturating_add(Weight::from_ref_time(170_000 as u64).saturating_mul(s as u64))
 			.saturating_add(T::DbWeight::get().reads(1 as u64))
 			.saturating_add(T::DbWeight::get().writes(1 as u64))
 	}
@@ -56,9 +56,9 @@ impl<T: frame_system::Config> pallet_democracy::WeightInfo for SubstrateWeight<T
 	// Storage: Balances Locks (r:1 w:1)
 	/// The range of component `r` is `[1, 99]`.
 	fn vote_new(r: u32, ) -> Weight {
-		Weight::from_ref_time(47_908_000 as u64)
-			// Standard Error: 1_000
-			.saturating_add(Weight::from_ref_time(299_000 as u64).saturating_mul(r as u64))
+		Weight::from_ref_time(47_727_000 as u64)
+			// Standard Error: 2_000
+			.saturating_add(Weight::from_ref_time(294_000 as u64).saturating_mul(r as u64))
 			.saturating_add(T::DbWeight::get().reads(3 as u64))
 			.saturating_add(T::DbWeight::get().writes(3 as u64))
 	}
@@ -67,16 +67,16 @@ impl<T: frame_system::Config> pallet_democracy::WeightInfo for SubstrateWeight<T
 	// Storage: Balances Locks (r:1 w:1)
 	/// The range of component `r` is `[1, 99]`.
 	fn vote_existing(r: u32, ) -> Weight {
-		Weight::from_ref_time(48_072_000 as u64)
+		Weight::from_ref_time(48_148_000 as u64)
 			// Standard Error: 2_000
-			.saturating_add(Weight::from_ref_time(281_000 as u64).saturating_mul(r as u64))
+			.saturating_add(Weight::from_ref_time(292_000 as u64).saturating_mul(r as u64))
 			.saturating_add(T::DbWeight::get().reads(3 as u64))
 			.saturating_add(T::DbWeight::get().writes(3 as u64))
 	}
 	// Storage: Democracy ReferendumInfoOf (r:1 w:1)
 	// Storage: Democracy Cancellations (r:1 w:1)
 	fn emergency_cancel() -> Weight {
-		Weight::from_ref_time(23_279_000 as u64)
+		Weight::from_ref_time(23_476_000 as u64)
 			.saturating_add(T::DbWeight::get().reads(2 as u64))
 			.saturating_add(T::DbWeight::get().writes(2 as u64))
 	}
@@ -88,9 +88,9 @@ impl<T: frame_system::Config> pallet_democracy::WeightInfo for SubstrateWeight<T
 	// Storage: System Account (r:1 w:1)
 	/// The range of component `p` is `[1, 100]`.
 	fn blacklist(p: u32, ) -> Weight {
-		Weight::from_ref_time(57_229_000 as u64)
+		Weight::from_ref_time(57_206_000 as u64)
 			// Standard Error: 6_000
-			.saturating_add(Weight::from_ref_time(360_000 as u64).saturating_mul(p as u64))
+			.saturating_add(Weight::from_ref_time(361_000 as u64).saturating_mul(p as u64))
 			.saturating_add(T::DbWeight::get().reads(5 as u64))
 			.saturating_add(T::DbWeight::get().writes(6 as u64))
 	}
@@ -98,27 +98,27 @@ impl<T: frame_system::Config> pallet_democracy::WeightInfo for SubstrateWeight<T
 	// Storage: Democracy Blacklist (r:1 w:0)
 	/// The range of component `v` is `[1, 100]`.
 	fn external_propose(v: u32, ) -> Weight {
-		Weight::from_ref_time(17_212_000 as u64)
+		Weight::from_ref_time(17_134_000 as u64)
 			// Standard Error: 0
-			.saturating_add(Weight::from_ref_time(13_000 as u64).saturating_mul(v as u64))
+			.saturating_add(Weight::from_ref_time(14_000 as u64).saturating_mul(v as u64))
 			.saturating_add(T::DbWeight::get().reads(2 as u64))
 			.saturating_add(T::DbWeight::get().writes(1 as u64))
 	}
 	// Storage: Democracy NextExternal (r:0 w:1)
 	fn external_propose_majority() -> Weight {
-		Weight::from_ref_time(5_128_000 as u64)
+		Weight::from_ref_time(5_314_000 as u64)
 			.saturating_add(T::DbWeight::get().writes(1 as u64))
 	}
 	// Storage: Democracy NextExternal (r:0 w:1)
 	fn external_propose_default() -> Weight {
-		Weight::from_ref_time(5_343_000 as u64)
+		Weight::from_ref_time(5_312_000 as u64)
 			.saturating_add(T::DbWeight::get().writes(1 as u64))
 	}
 	// Storage: Democracy NextExternal (r:1 w:1)
 	// Storage: Democracy ReferendumCount (r:1 w:1)
 	// Storage: Democracy ReferendumInfoOf (r:0 w:1)
 	fn fast_track() -> Weight {
-		Weight::from_ref_time(23_213_000 as u64)
+		Weight::from_ref_time(23_807_000 as u64)
 			.saturating_add(T::DbWeight::get().reads(2 as u64))
 			.saturating_add(T::DbWeight::get().writes(3 as u64))
 	}
@@ -126,9 +126,9 @@ impl<T: frame_system::Config> pallet_democracy::WeightInfo for SubstrateWeight<T
 	// Storage: Democracy Blacklist (r:1 w:1)
 	/// The range of component `v` is `[0, 100]`.
 	fn veto_external(v: u32, ) -> Weight {
-		Weight::from_ref_time(25_604_000 as u64)
+		Weight::from_ref_time(25_721_000 as u64)
 			// Standard Error: 0
-			.saturating_add(Weight::from_ref_time(33_000 as u64).saturating_mul(v as u64))
+			.saturating_add(Weight::from_ref_time(30_000 as u64).saturating_mul(v as u64))
 			.saturating_add(T::DbWeight::get().reads(2 as u64))
 			.saturating_add(T::DbWeight::get().writes(2 as u64))
 	}
@@ -137,24 +137,24 @@ impl<T: frame_system::Config> pallet_democracy::WeightInfo for SubstrateWeight<T
 	// Storage: System Account (r:1 w:1)
 	/// The range of component `p` is `[1, 100]`.
 	fn cancel_proposal(p: u32, ) -> Weight {
-		Weight::from_ref_time(45_700_000 as u64)
+		Weight::from_ref_time(45_965_000 as u64)
 			// Standard Error: 2_000
-			.saturating_add(Weight::from_ref_time(326_000 as u64).saturating_mul(p as u64))
+			.saturating_add(Weight::from_ref_time(316_000 as u64).saturating_mul(p as u64))
 			.saturating_add(T::DbWeight::get().reads(3 as u64))
 			.saturating_add(T::DbWeight::get().writes(3 as u64))
 	}
 	// Storage: Democracy ReferendumInfoOf (r:0 w:1)
 	fn cancel_referendum() -> Weight {
-		Weight::from_ref_time(14_946_000 as u64)
+		Weight::from_ref_time(15_327_000 as u64)
 			.saturating_add(T::DbWeight::get().writes(1 as u64))
 	}
 	// Storage: Scheduler Lookup (r:1 w:1)
 	// Storage: Scheduler Agenda (r:1 w:1)
 	/// The range of component `r` is `[1, 99]`.
 	fn cancel_queued(r: u32, ) -> Weight {
-		Weight::from_ref_time(27_666_000 as u64)
-			// Standard Error: 2_000
-			.saturating_add(Weight::from_ref_time(647_000 as u64).saturating_mul(r as u64))
+		Weight::from_ref_time(28_317_000 as u64)
+			// Standard Error: 3_000
+			.saturating_add(Weight::from_ref_time(589_000 as u64).saturating_mul(r as u64))
 			.saturating_add(T::DbWeight::get().reads(2 as u64))
 			.saturating_add(T::DbWeight::get().writes(2 as u64))
 	}
@@ -163,9 +163,9 @@ impl<T: frame_system::Config> pallet_democracy::WeightInfo for SubstrateWeight<T
 	// Storage: Democracy ReferendumInfoOf (r:1 w:0)
 	/// The range of component `r` is `[1, 99]`.
 	fn on_initialize_base(r: u32, ) -> Weight {
-		Weight::from_ref_time(8_481_000 as u64)
-			// Standard Error: 4_000
-			.saturating_add(Weight::from_ref_time(2_660_000 as u64).saturating_mul(r as u64))
+		Weight::from_ref_time(8_594_000 as u64)
+			// Standard Error: 3_000
+			.saturating_add(Weight::from_ref_time(2_617_000 as u64).saturating_mul(r as u64))
 			.saturating_add(T::DbWeight::get().reads(2 as u64))
 			.saturating_add(T::DbWeight::get().reads((1 as u64).saturating_mul(r as u64)))
 			.saturating_add(T::DbWeight::get().writes(1 as u64))
@@ -178,9 +178,9 @@ impl<T: frame_system::Config> pallet_democracy::WeightInfo for SubstrateWeight<T
 	// Storage: Democracy ReferendumInfoOf (r:1 w:0)
 	/// The range of component `r` is `[1, 99]`.
 	fn on_initialize_base_with_launch_period(r: u32, ) -> Weight {
-		Weight::from_ref_time(11_439_000 as u64)
+		Weight::from_ref_time(11_684_000 as u64)
 			// Standard Error: 4_000
-			.saturating_add(Weight::from_ref_time(2_669_000 as u64).saturating_mul(r as u64))
+			.saturating_add(Weight::from_ref_time(2_615_000 as u64).saturating_mul(r as u64))
 			.saturating_add(T::DbWeight::get().reads(5 as u64))
 			.saturating_add(T::DbWeight::get().reads((1 as u64).saturating_mul(r as u64)))
 			.saturating_add(T::DbWeight::get().writes(1 as u64))
@@ -190,9 +190,9 @@ impl<T: frame_system::Config> pallet_democracy::WeightInfo for SubstrateWeight<T
 	// Storage: Balances Locks (r:1 w:1)
 	/// The range of component `r` is `[1, 99]`.
 	fn delegate(r: u32, ) -> Weight {
-		Weight::from_ref_time(51_596_000 as u64)
+		Weight::from_ref_time(52_439_000 as u64)
 			// Standard Error: 4_000
-			.saturating_add(Weight::from_ref_time(3_914_000 as u64).saturating_mul(r as u64))
+			.saturating_add(Weight::from_ref_time(3_983_000 as u64).saturating_mul(r as u64))
 			.saturating_add(T::DbWeight::get().reads(4 as u64))
 			.saturating_add(T::DbWeight::get().reads((1 as u64).saturating_mul(r as u64)))
 			.saturating_add(T::DbWeight::get().writes(4 as u64))
@@ -202,9 +202,9 @@ impl<T: frame_system::Config> pallet_democracy::WeightInfo for SubstrateWeight<T
 	// Storage: Democracy ReferendumInfoOf (r:1 w:1)
 	/// The range of component `r` is `[1, 99]`.
 	fn undelegate(r: u32, ) -> Weight {
-		Weight::from_ref_time(29_743_000 as u64)
+		Weight::from_ref_time(30_019_000 as u64)
 			// Standard Error: 4_000
-			.saturating_add(Weight::from_ref_time(3_897_000 as u64).saturating_mul(r as u64))
+			.saturating_add(Weight::from_ref_time(3_945_000 as u64).saturating_mul(r as u64))
 			.saturating_add(T::DbWeight::get().reads(2 as u64))
 			.saturating_add(T::DbWeight::get().reads((1 as u64).saturating_mul(r as u64)))
 			.saturating_add(T::DbWeight::get().writes(2 as u64))
@@ -212,13 +212,13 @@ impl<T: frame_system::Config> pallet_democracy::WeightInfo for SubstrateWeight<T
 	}
 	// Storage: Democracy PublicProps (r:0 w:1)
 	fn clear_public_proposals() -> Weight {
-		Weight::from_ref_time(6_586_000 as u64)
+		Weight::from_ref_time(6_214_000 as u64)
 			.saturating_add(T::DbWeight::get().writes(1 as u64))
 	}
 	// Storage: Democracy Preimages (r:1 w:1)
 	/// The range of component `b` is `[0, 16384]`.
 	fn note_preimage(b: u32, ) -> Weight {
-		Weight::from_ref_time(32_902_000 as u64)
+		Weight::from_ref_time(32_385_000 as u64)
 			// Standard Error: 0
 			.saturating_add(Weight::from_ref_time(2_000 as u64).saturating_mul(b as u64))
 			.saturating_add(T::DbWeight::get().reads(1 as u64))
@@ -227,7 +227,7 @@ impl<T: frame_system::Config> pallet_democracy::WeightInfo for SubstrateWeight<T
 	// Storage: Democracy Preimages (r:1 w:1)
 	/// The range of component `b` is `[0, 16384]`.
 	fn note_imminent_preimage(b: u32, ) -> Weight {
-		Weight::from_ref_time(25_269_000 as u64)
+		Weight::from_ref_time(25_123_000 as u64)
 			// Standard Error: 0
 			.saturating_add(Weight::from_ref_time(2_000 as u64).saturating_mul(b as u64))
 			.saturating_add(T::DbWeight::get().reads(1 as u64))
@@ -237,7 +237,7 @@ impl<T: frame_system::Config> pallet_democracy::WeightInfo for SubstrateWeight<T
 	// Storage: System Account (r:1 w:1)
 	/// The range of component `b` is `[0, 16384]`.
 	fn reap_preimage(b: u32, ) -> Weight {
-		Weight::from_ref_time(42_724_000 as u64)
+		Weight::from_ref_time(43_142_000 as u64)
 			// Standard Error: 0
 			.saturating_add(Weight::from_ref_time(1_000 as u64).saturating_mul(b as u64))
 			.saturating_add(T::DbWeight::get().reads(2 as u64))
@@ -248,9 +248,9 @@ impl<T: frame_system::Config> pallet_democracy::WeightInfo for SubstrateWeight<T
 	// Storage: System Account (r:1 w:1)
 	/// The range of component `r` is `[1, 99]`.
 	fn unlock_remove(r: u32, ) -> Weight {
-		Weight::from_ref_time(35_157_000 as u64)
+		Weight::from_ref_time(35_064_000 as u64)
 			// Standard Error: 1_000
-			.saturating_add(Weight::from_ref_time(201_000 as u64).saturating_mul(r as u64))
+			.saturating_add(Weight::from_ref_time(203_000 as u64).saturating_mul(r as u64))
 			.saturating_add(T::DbWeight::get().reads(3 as u64))
 			.saturating_add(T::DbWeight::get().writes(3 as u64))
 	}
@@ -259,9 +259,9 @@ impl<T: frame_system::Config> pallet_democracy::WeightInfo for SubstrateWeight<T
 	// Storage: System Account (r:1 w:1)
 	/// The range of component `r` is `[1, 99]`.
 	fn unlock_set(r: u32, ) -> Weight {
-		Weight::from_ref_time(34_118_000 as u64)
+		Weight::from_ref_time(34_627_000 as u64)
 			// Standard Error: 1_000
-			.saturating_add(Weight::from_ref_time(252_000 as u64).saturating_mul(r as u64))
+			.saturating_add(Weight::from_ref_time(248_000 as u64).saturating_mul(r as u64))
 			.saturating_add(T::DbWeight::get().reads(3 as u64))
 			.saturating_add(T::DbWeight::get().writes(3 as u64))
 	}
@@ -269,9 +269,9 @@ impl<T: frame_system::Config> pallet_democracy::WeightInfo for SubstrateWeight<T
 	// Storage: Democracy VotingOf (r:1 w:1)
 	/// The range of component `r` is `[1, 99]`.
 	fn remove_vote(r: u32, ) -> Weight {
-		Weight::from_ref_time(20_274_000 as u64)
-			// Standard Error: 1_000
-			.saturating_add(Weight::from_ref_time(249_000 as u64).saturating_mul(r as u64))
+		Weight::from_ref_time(20_907_000 as u64)
+			// Standard Error: 2_000
+			.saturating_add(Weight::from_ref_time(242_000 as u64).saturating_mul(r as u64))
 			.saturating_add(T::DbWeight::get().reads(2 as u64))
 			.saturating_add(T::DbWeight::get().writes(2 as u64))
 	}
@@ -279,9 +279,9 @@ impl<T: frame_system::Config> pallet_democracy::WeightInfo for SubstrateWeight<T
 	// Storage: Democracy VotingOf (r:1 w:1)
 	/// The range of component `r` is `[1, 99]`.
 	fn remove_other_vote(r: u32, ) -> Weight {
-		Weight::from_ref_time(20_129_000 as u64)
-			// Standard Error: 1_000
-			.saturating_add(Weight::from_ref_time(259_000 as u64).saturating_mul(r as u64))
+		Weight::from_ref_time(21_048_000 as u64)
+			// Standard Error: 2_000
+			.saturating_add(Weight::from_ref_time(241_000 as u64).saturating_mul(r as u64))
 			.saturating_add(T::DbWeight::get().reads(2 as u64))
 			.saturating_add(T::DbWeight::get().writes(2 as u64))
 	}

--- a/runtime/common/src/weights/pallet_preimage.rs
+++ b/runtime/common/src/weights/pallet_preimage.rs
@@ -37,7 +37,7 @@ impl<T: frame_system::Config> pallet_preimage::WeightInfo for SubstrateWeight<T>
 	// Storage: Preimage StatusFor (r:1 w:1)
 	/// The range of component `s` is `[0, 4194304]`.
 	fn note_preimage(s: u32, ) -> Weight {
-		Weight::from_ref_time(12_668_000 as u64)
+		Weight::from_ref_time(9_986_000 as u64)
 			// Standard Error: 0
 			.saturating_add(Weight::from_ref_time(2_000 as u64).saturating_mul(s as u64))
 			.saturating_add(T::DbWeight::get().reads(2 as u64))
@@ -47,7 +47,7 @@ impl<T: frame_system::Config> pallet_preimage::WeightInfo for SubstrateWeight<T>
 	// Storage: Preimage StatusFor (r:1 w:0)
 	/// The range of component `s` is `[0, 4194304]`.
 	fn note_requested_preimage(s: u32, ) -> Weight {
-		Weight::from_ref_time(0 as u64)
+		Weight::from_ref_time(204_000 as u64)
 			// Standard Error: 0
 			.saturating_add(Weight::from_ref_time(2_000 as u64).saturating_mul(s as u64))
 			.saturating_add(T::DbWeight::get().reads(2 as u64))
@@ -66,58 +66,58 @@ impl<T: frame_system::Config> pallet_preimage::WeightInfo for SubstrateWeight<T>
 	// Storage: Preimage StatusFor (r:1 w:1)
 	// Storage: Preimage PreimageFor (r:0 w:1)
 	fn unnote_preimage() -> Weight {
-		Weight::from_ref_time(40_558_000 as u64)
+		Weight::from_ref_time(40_498_000 as u64)
 			.saturating_add(T::DbWeight::get().reads(1 as u64))
 			.saturating_add(T::DbWeight::get().writes(2 as u64))
 	}
 	// Storage: Preimage StatusFor (r:1 w:1)
 	// Storage: Preimage PreimageFor (r:0 w:1)
 	fn unnote_no_deposit_preimage() -> Weight {
-		Weight::from_ref_time(26_929_000 as u64)
+		Weight::from_ref_time(26_475_000 as u64)
 			.saturating_add(T::DbWeight::get().reads(1 as u64))
 			.saturating_add(T::DbWeight::get().writes(2 as u64))
 	}
 	// Storage: Preimage StatusFor (r:1 w:1)
 	fn request_preimage() -> Weight {
-		Weight::from_ref_time(38_503_000 as u64)
+		Weight::from_ref_time(39_266_000 as u64)
 			.saturating_add(T::DbWeight::get().reads(1 as u64))
 			.saturating_add(T::DbWeight::get().writes(1 as u64))
 	}
 	// Storage: Preimage StatusFor (r:1 w:1)
 	fn request_no_deposit_preimage() -> Weight {
-		Weight::from_ref_time(25_970_000 as u64)
+		Weight::from_ref_time(26_102_000 as u64)
 			.saturating_add(T::DbWeight::get().reads(1 as u64))
 			.saturating_add(T::DbWeight::get().writes(1 as u64))
 	}
 	// Storage: Preimage StatusFor (r:1 w:1)
 	fn request_unnoted_preimage() -> Weight {
-		Weight::from_ref_time(22_511_000 as u64)
+		Weight::from_ref_time(22_290_000 as u64)
 			.saturating_add(T::DbWeight::get().reads(1 as u64))
 			.saturating_add(T::DbWeight::get().writes(1 as u64))
 	}
 	// Storage: Preimage StatusFor (r:1 w:1)
 	fn request_requested_preimage() -> Weight {
-		Weight::from_ref_time(10_408_000 as u64)
+		Weight::from_ref_time(10_460_000 as u64)
 			.saturating_add(T::DbWeight::get().reads(1 as u64))
 			.saturating_add(T::DbWeight::get().writes(1 as u64))
 	}
 	// Storage: Preimage StatusFor (r:1 w:1)
 	// Storage: Preimage PreimageFor (r:0 w:1)
 	fn unrequest_preimage() -> Weight {
-		Weight::from_ref_time(28_377_000 as u64)
+		Weight::from_ref_time(26_159_000 as u64)
 			.saturating_add(T::DbWeight::get().reads(1 as u64))
 			.saturating_add(T::DbWeight::get().writes(2 as u64))
 	}
 	// Storage: Preimage StatusFor (r:1 w:1)
 	// Storage: Preimage PreimageFor (r:0 w:1)
 	fn unrequest_unnoted_preimage() -> Weight {
-		Weight::from_ref_time(21_295_000 as u64)
+		Weight::from_ref_time(21_306_000 as u64)
 			.saturating_add(T::DbWeight::get().reads(1 as u64))
 			.saturating_add(T::DbWeight::get().writes(2 as u64))
 	}
 	// Storage: Preimage StatusFor (r:1 w:1)
 	fn unrequest_multi_referenced_preimage() -> Weight {
-		Weight::from_ref_time(10_300_000 as u64)
+		Weight::from_ref_time(10_094_000 as u64)
 			.saturating_add(T::DbWeight::get().reads(1 as u64))
 			.saturating_add(T::DbWeight::get().writes(1 as u64))
 	}

--- a/runtime/common/src/weights/pallet_scheduler.rs
+++ b/runtime/common/src/weights/pallet_scheduler.rs
@@ -39,9 +39,9 @@ impl<T: frame_system::Config> pallet_scheduler::WeightInfo for SubstrateWeight<T
 	// Storage: Scheduler Lookup (r:0 w:1)
 	/// The range of component `s` is `[1, 50]`.
 	fn on_initialize_periodic_named_resolved(s: u32, ) -> Weight {
-		Weight::from_ref_time(16_073_000 as u64)
+		Weight::from_ref_time(17_731_000 as u64)
 			// Standard Error: 14_000
-			.saturating_add(Weight::from_ref_time(20_636_000 as u64).saturating_mul(s as u64))
+			.saturating_add(Weight::from_ref_time(21_135_000 as u64).saturating_mul(s as u64))
 			.saturating_add(T::DbWeight::get().reads(1 as u64))
 			.saturating_add(T::DbWeight::get().reads((3 as u64).saturating_mul(s as u64)))
 			.saturating_add(T::DbWeight::get().writes(1 as u64))
@@ -53,9 +53,9 @@ impl<T: frame_system::Config> pallet_scheduler::WeightInfo for SubstrateWeight<T
 	// Storage: Scheduler Lookup (r:0 w:1)
 	/// The range of component `s` is `[1, 50]`.
 	fn on_initialize_named_resolved(s: u32, ) -> Weight {
-		Weight::from_ref_time(14_044_000 as u64)
-			// Standard Error: 14_000
-			.saturating_add(Weight::from_ref_time(16_452_000 as u64).saturating_mul(s as u64))
+		Weight::from_ref_time(14_993_000 as u64)
+			// Standard Error: 13_000
+			.saturating_add(Weight::from_ref_time(16_755_000 as u64).saturating_mul(s as u64))
 			.saturating_add(T::DbWeight::get().reads(1 as u64))
 			.saturating_add(T::DbWeight::get().reads((2 as u64).saturating_mul(s as u64)))
 			.saturating_add(T::DbWeight::get().writes(1 as u64))
@@ -66,9 +66,9 @@ impl<T: frame_system::Config> pallet_scheduler::WeightInfo for SubstrateWeight<T
 	// Storage: Preimage StatusFor (r:1 w:1)
 	/// The range of component `s` is `[1, 50]`.
 	fn on_initialize_periodic_resolved(s: u32, ) -> Weight {
-		Weight::from_ref_time(15_238_000 as u64)
-			// Standard Error: 12_000
-			.saturating_add(Weight::from_ref_time(17_443_000 as u64).saturating_mul(s as u64))
+		Weight::from_ref_time(15_308_000 as u64)
+			// Standard Error: 11_000
+			.saturating_add(Weight::from_ref_time(17_616_000 as u64).saturating_mul(s as u64))
 			.saturating_add(T::DbWeight::get().reads(1 as u64))
 			.saturating_add(T::DbWeight::get().reads((3 as u64).saturating_mul(s as u64)))
 			.saturating_add(T::DbWeight::get().writes(1 as u64))
@@ -79,9 +79,9 @@ impl<T: frame_system::Config> pallet_scheduler::WeightInfo for SubstrateWeight<T
 	// Storage: Preimage StatusFor (r:1 w:1)
 	/// The range of component `s` is `[1, 50]`.
 	fn on_initialize_resolved(s: u32, ) -> Weight {
-		Weight::from_ref_time(15_808_000 as u64)
-			// Standard Error: 12_000
-			.saturating_add(Weight::from_ref_time(14_920_000 as u64).saturating_mul(s as u64))
+		Weight::from_ref_time(16_426_000 as u64)
+			// Standard Error: 14_000
+			.saturating_add(Weight::from_ref_time(15_175_000 as u64).saturating_mul(s as u64))
 			.saturating_add(T::DbWeight::get().reads(1 as u64))
 			.saturating_add(T::DbWeight::get().reads((2 as u64).saturating_mul(s as u64)))
 			.saturating_add(T::DbWeight::get().writes(1 as u64))
@@ -92,9 +92,9 @@ impl<T: frame_system::Config> pallet_scheduler::WeightInfo for SubstrateWeight<T
 	// Storage: Scheduler Lookup (r:0 w:1)
 	/// The range of component `s` is `[1, 50]`.
 	fn on_initialize_named_aborted(s: u32, ) -> Weight {
-		Weight::from_ref_time(7_309_000 as u64)
+		Weight::from_ref_time(7_521_000 as u64)
 			// Standard Error: 7_000
-			.saturating_add(Weight::from_ref_time(5_651_000 as u64).saturating_mul(s as u64))
+			.saturating_add(Weight::from_ref_time(5_761_000 as u64).saturating_mul(s as u64))
 			.saturating_add(T::DbWeight::get().reads(2 as u64))
 			.saturating_add(T::DbWeight::get().reads((1 as u64).saturating_mul(s as u64)))
 			.saturating_add(T::DbWeight::get().writes(2 as u64))
@@ -104,9 +104,9 @@ impl<T: frame_system::Config> pallet_scheduler::WeightInfo for SubstrateWeight<T
 	// Storage: Preimage PreimageFor (r:1 w:0)
 	/// The range of component `s` is `[1, 50]`.
 	fn on_initialize_aborted(s: u32, ) -> Weight {
-		Weight::from_ref_time(10_309_000 as u64)
-			// Standard Error: 2_000
-			.saturating_add(Weight::from_ref_time(2_765_000 as u64).saturating_mul(s as u64))
+		Weight::from_ref_time(10_823_000 as u64)
+			// Standard Error: 3_000
+			.saturating_add(Weight::from_ref_time(2_692_000 as u64).saturating_mul(s as u64))
 			.saturating_add(T::DbWeight::get().reads(2 as u64))
 			.saturating_add(T::DbWeight::get().reads((1 as u64).saturating_mul(s as u64)))
 			.saturating_add(T::DbWeight::get().writes(2 as u64))
@@ -115,9 +115,9 @@ impl<T: frame_system::Config> pallet_scheduler::WeightInfo for SubstrateWeight<T
 	// Storage: Scheduler Lookup (r:0 w:1)
 	/// The range of component `s` is `[1, 50]`.
 	fn on_initialize_periodic_named(s: u32, ) -> Weight {
-		Weight::from_ref_time(15_790_000 as u64)
-			// Standard Error: 8_000
-			.saturating_add(Weight::from_ref_time(10_044_000 as u64).saturating_mul(s as u64))
+		Weight::from_ref_time(18_102_000 as u64)
+			// Standard Error: 7_000
+			.saturating_add(Weight::from_ref_time(10_295_000 as u64).saturating_mul(s as u64))
 			.saturating_add(T::DbWeight::get().reads(1 as u64))
 			.saturating_add(T::DbWeight::get().reads((1 as u64).saturating_mul(s as u64)))
 			.saturating_add(T::DbWeight::get().writes(1 as u64))
@@ -126,9 +126,9 @@ impl<T: frame_system::Config> pallet_scheduler::WeightInfo for SubstrateWeight<T
 	// Storage: Scheduler Agenda (r:2 w:2)
 	/// The range of component `s` is `[1, 50]`.
 	fn on_initialize_periodic(s: u32, ) -> Weight {
-		Weight::from_ref_time(14_890_000 as u64)
-			// Standard Error: 3_000
-			.saturating_add(Weight::from_ref_time(7_043_000 as u64).saturating_mul(s as u64))
+		Weight::from_ref_time(15_398_000 as u64)
+			// Standard Error: 4_000
+			.saturating_add(Weight::from_ref_time(7_089_000 as u64).saturating_mul(s as u64))
 			.saturating_add(T::DbWeight::get().reads(1 as u64))
 			.saturating_add(T::DbWeight::get().reads((1 as u64).saturating_mul(s as u64)))
 			.saturating_add(T::DbWeight::get().writes(1 as u64))
@@ -138,9 +138,9 @@ impl<T: frame_system::Config> pallet_scheduler::WeightInfo for SubstrateWeight<T
 	// Storage: Scheduler Lookup (r:0 w:1)
 	/// The range of component `s` is `[1, 50]`.
 	fn on_initialize_named(s: u32, ) -> Weight {
-		Weight::from_ref_time(16_151_000 as u64)
+		Weight::from_ref_time(17_211_000 as u64)
 			// Standard Error: 4_000
-			.saturating_add(Weight::from_ref_time(6_114_000 as u64).saturating_mul(s as u64))
+			.saturating_add(Weight::from_ref_time(6_268_000 as u64).saturating_mul(s as u64))
 			.saturating_add(T::DbWeight::get().reads(1 as u64))
 			.saturating_add(T::DbWeight::get().writes(1 as u64))
 			.saturating_add(T::DbWeight::get().writes((1 as u64).saturating_mul(s as u64)))
@@ -148,18 +148,18 @@ impl<T: frame_system::Config> pallet_scheduler::WeightInfo for SubstrateWeight<T
 	// Storage: Scheduler Agenda (r:1 w:1)
 	/// The range of component `s` is `[1, 50]`.
 	fn on_initialize(s: u32, ) -> Weight {
-		Weight::from_ref_time(15_843_000 as u64)
-			// Standard Error: 3_000
-			.saturating_add(Weight::from_ref_time(4_906_000 as u64).saturating_mul(s as u64))
+		Weight::from_ref_time(16_298_000 as u64)
+			// Standard Error: 6_000
+			.saturating_add(Weight::from_ref_time(4_949_000 as u64).saturating_mul(s as u64))
 			.saturating_add(T::DbWeight::get().reads(1 as u64))
 			.saturating_add(T::DbWeight::get().writes(1 as u64))
 	}
 	// Storage: Scheduler Agenda (r:1 w:1)
 	/// The range of component `s` is `[0, 50]`.
 	fn schedule(s: u32, ) -> Weight {
-		Weight::from_ref_time(20_146_000 as u64)
+		Weight::from_ref_time(20_592_000 as u64)
 			// Standard Error: 1_000
-			.saturating_add(Weight::from_ref_time(105_000 as u64).saturating_mul(s as u64))
+			.saturating_add(Weight::from_ref_time(113_000 as u64).saturating_mul(s as u64))
 			.saturating_add(T::DbWeight::get().reads(1 as u64))
 			.saturating_add(T::DbWeight::get().writes(1 as u64))
 	}
@@ -167,9 +167,9 @@ impl<T: frame_system::Config> pallet_scheduler::WeightInfo for SubstrateWeight<T
 	// Storage: Scheduler Lookup (r:0 w:1)
 	/// The range of component `s` is `[1, 50]`.
 	fn cancel(s: u32, ) -> Weight {
-		Weight::from_ref_time(20_456_000 as u64)
+		Weight::from_ref_time(20_558_000 as u64)
 			// Standard Error: 1_000
-			.saturating_add(Weight::from_ref_time(545_000 as u64).saturating_mul(s as u64))
+			.saturating_add(Weight::from_ref_time(527_000 as u64).saturating_mul(s as u64))
 			.saturating_add(T::DbWeight::get().reads(1 as u64))
 			.saturating_add(T::DbWeight::get().writes(2 as u64))
 	}
@@ -177,9 +177,9 @@ impl<T: frame_system::Config> pallet_scheduler::WeightInfo for SubstrateWeight<T
 	// Storage: Scheduler Agenda (r:1 w:1)
 	/// The range of component `s` is `[0, 50]`.
 	fn schedule_named(s: u32, ) -> Weight {
-		Weight::from_ref_time(24_550_000 as u64)
+		Weight::from_ref_time(25_138_000 as u64)
 			// Standard Error: 3_000
-			.saturating_add(Weight::from_ref_time(170_000 as u64).saturating_mul(s as u64))
+			.saturating_add(Weight::from_ref_time(184_000 as u64).saturating_mul(s as u64))
 			.saturating_add(T::DbWeight::get().reads(2 as u64))
 			.saturating_add(T::DbWeight::get().writes(2 as u64))
 	}
@@ -187,9 +187,9 @@ impl<T: frame_system::Config> pallet_scheduler::WeightInfo for SubstrateWeight<T
 	// Storage: Scheduler Agenda (r:1 w:1)
 	/// The range of component `s` is `[1, 50]`.
 	fn cancel_named(s: u32, ) -> Weight {
-		Weight::from_ref_time(23_930_000 as u64)
+		Weight::from_ref_time(24_040_000 as u64)
 			// Standard Error: 3_000
-			.saturating_add(Weight::from_ref_time(606_000 as u64).saturating_mul(s as u64))
+			.saturating_add(Weight::from_ref_time(594_000 as u64).saturating_mul(s as u64))
 			.saturating_add(T::DbWeight::get().reads(2 as u64))
 			.saturating_add(T::DbWeight::get().writes(2 as u64))
 	}

--- a/runtime/common/src/weights/pallet_session.rs
+++ b/runtime/common/src/weights/pallet_session.rs
@@ -36,14 +36,14 @@ impl<T: frame_system::Config> pallet_session::WeightInfo for SubstrateWeight<T> 
 	// Storage: Session NextKeys (r:1 w:1)
 	// Storage: Session KeyOwner (r:1 w:1)
 	fn set_keys() -> Weight {
-		Weight::from_ref_time(23_589_000 as u64)
+		Weight::from_ref_time(23_790_000 as u64)
 			.saturating_add(T::DbWeight::get().reads(2 as u64))
 			.saturating_add(T::DbWeight::get().writes(2 as u64))
 	}
 	// Storage: Session NextKeys (r:1 w:1)
 	// Storage: Session KeyOwner (r:0 w:1)
 	fn purge_keys() -> Weight {
-		Weight::from_ref_time(20_203_000 as u64)
+		Weight::from_ref_time(20_150_000 as u64)
 			.saturating_add(T::DbWeight::get().reads(1 as u64))
 			.saturating_add(T::DbWeight::get().writes(2 as u64))
 	}

--- a/runtime/common/src/weights/pallet_timestamp.rs
+++ b/runtime/common/src/weights/pallet_timestamp.rs
@@ -35,11 +35,11 @@ pub struct SubstrateWeight<T>(PhantomData<T>);
 impl<T: frame_system::Config> pallet_timestamp::WeightInfo for SubstrateWeight<T> {
 	// Storage: Timestamp Now (r:1 w:1)
 	fn set() -> Weight {
-		Weight::from_ref_time(8_922_000 as u64)
+		Weight::from_ref_time(8_693_000 as u64)
 			.saturating_add(T::DbWeight::get().reads(1 as u64))
 			.saturating_add(T::DbWeight::get().writes(1 as u64))
 	}
 	fn on_finalize() -> Weight {
-		Weight::from_ref_time(5_142_000 as u64)
+		Weight::from_ref_time(5_214_000 as u64)
 	}
 }

--- a/runtime/common/src/weights/pallet_treasury.rs
+++ b/runtime/common/src/weights/pallet_treasury.rs
@@ -34,19 +34,19 @@ use sp_std::marker::PhantomData;
 pub struct SubstrateWeight<T>(PhantomData<T>);
 impl<T: frame_system::Config> pallet_treasury::WeightInfo for SubstrateWeight<T> {
 	fn spend() -> Weight {
-		Weight::from_ref_time(177_000 as u64)
+		Weight::from_ref_time(172_000 as u64)
 	}
 	// Storage: Treasury ProposalCount (r:1 w:1)
 	// Storage: Treasury Proposals (r:0 w:1)
 	fn propose_spend() -> Weight {
-		Weight::from_ref_time(29_990_000 as u64)
+		Weight::from_ref_time(29_455_000 as u64)
 			.saturating_add(T::DbWeight::get().reads(1 as u64))
 			.saturating_add(T::DbWeight::get().writes(2 as u64))
 	}
 	// Storage: Treasury Proposals (r:1 w:1)
 	// Storage: System Account (r:1 w:1)
 	fn reject_proposal() -> Weight {
-		Weight::from_ref_time(35_907_000 as u64)
+		Weight::from_ref_time(35_960_000 as u64)
 			.saturating_add(T::DbWeight::get().reads(2 as u64))
 			.saturating_add(T::DbWeight::get().writes(2 as u64))
 	}
@@ -54,15 +54,15 @@ impl<T: frame_system::Config> pallet_treasury::WeightInfo for SubstrateWeight<T>
 	// Storage: Treasury Approvals (r:1 w:1)
 	/// The range of component `p` is `[0, 63]`.
 	fn approve_proposal(p: u32, ) -> Weight {
-		Weight::from_ref_time(13_545_000 as u64)
-			// Standard Error: 2_000
-			.saturating_add(Weight::from_ref_time(203_000 as u64).saturating_mul(p as u64))
+		Weight::from_ref_time(13_373_000 as u64)
+			// Standard Error: 1_000
+			.saturating_add(Weight::from_ref_time(219_000 as u64).saturating_mul(p as u64))
 			.saturating_add(T::DbWeight::get().reads(2 as u64))
 			.saturating_add(T::DbWeight::get().writes(1 as u64))
 	}
 	// Storage: Treasury Approvals (r:1 w:1)
 	fn remove_approval() -> Weight {
-		Weight::from_ref_time(9_633_000 as u64)
+		Weight::from_ref_time(9_632_000 as u64)
 			.saturating_add(T::DbWeight::get().reads(1 as u64))
 			.saturating_add(T::DbWeight::get().writes(1 as u64))
 	}
@@ -71,9 +71,9 @@ impl<T: frame_system::Config> pallet_treasury::WeightInfo for SubstrateWeight<T>
 	// Storage: Treasury Proposals (r:1 w:1)
 	/// The range of component `p` is `[0, 64]`.
 	fn on_initialize_proposals(p: u32, ) -> Weight {
-		Weight::from_ref_time(38_479_000 as u64)
+		Weight::from_ref_time(40_090_000 as u64)
 			// Standard Error: 20_000
-			.saturating_add(Weight::from_ref_time(29_916_000 as u64).saturating_mul(p as u64))
+			.saturating_add(Weight::from_ref_time(30_077_000 as u64).saturating_mul(p as u64))
 			.saturating_add(T::DbWeight::get().reads(2 as u64))
 			.saturating_add(T::DbWeight::get().reads((3 as u64).saturating_mul(p as u64)))
 			.saturating_add(T::DbWeight::get().writes(2 as u64))

--- a/runtime/common/src/weights/pallet_utility.rs
+++ b/runtime/common/src/weights/pallet_utility.rs
@@ -35,26 +35,26 @@ pub struct SubstrateWeight<T>(PhantomData<T>);
 impl<T: frame_system::Config> pallet_utility::WeightInfo for SubstrateWeight<T> {
 	/// The range of component `c` is `[0, 1000]`.
 	fn batch(c: u32, ) -> Weight {
-		Weight::from_ref_time(16_189_000 as u64)
+		Weight::from_ref_time(18_106_000 as u64)
 			// Standard Error: 1_000
-			.saturating_add(Weight::from_ref_time(4_029_000 as u64).saturating_mul(c as u64))
+			.saturating_add(Weight::from_ref_time(4_089_000 as u64).saturating_mul(c as u64))
 	}
 	fn as_derivative() -> Weight {
-		Weight::from_ref_time(6_394_000 as u64)
+		Weight::from_ref_time(6_634_000 as u64)
 	}
 	/// The range of component `c` is `[0, 1000]`.
 	fn batch_all(c: u32, ) -> Weight {
-		Weight::from_ref_time(15_836_000 as u64)
-			// Standard Error: 1_000
-			.saturating_add(Weight::from_ref_time(4_152_000 as u64).saturating_mul(c as u64))
+		Weight::from_ref_time(13_392_000 as u64)
+			// Standard Error: 3_000
+			.saturating_add(Weight::from_ref_time(4_180_000 as u64).saturating_mul(c as u64))
 	}
 	fn dispatch_as() -> Weight {
-		Weight::from_ref_time(14_507_000 as u64)
+		Weight::from_ref_time(14_489_000 as u64)
 	}
 	/// The range of component `c` is `[0, 1000]`.
 	fn force_batch(c: u32, ) -> Weight {
-		Weight::from_ref_time(16_469_000 as u64)
+		Weight::from_ref_time(17_245_000 as u64)
 			// Standard Error: 1_000
-			.saturating_add(Weight::from_ref_time(4_060_000 as u64).saturating_mul(c as u64))
+			.saturating_add(Weight::from_ref_time(4_071_000 as u64).saturating_mul(c as u64))
 	}
 }


### PR DESCRIPTION
# Goal
Ensure the AddKeyData struct includes the new
public-key being added. Including the public-key
in the signature prevents a provider from
being able to add any key.

Additionally, register the proof for the new
public-key to prevent replay attacks.

Update benchmarks for add-public-key-to-msa
and delete-msa-public-key.

Closes #620

