### PR TITLE
fix docker image run permission error

### DIFF
--- a/docker/instant-seal-node.dockerfile
+++ b/docker/instant-seal-node.dockerfile
@@ -23,6 +23,7 @@ COPY --from=base /etc/ssl/certs/ca-certificates.crt /etc/ssl/certs/ca-certificat
 # For local testing only
 # COPY --chown=frequency target/release/frequency.amd64 ./frequency/frequency
 COPY --chown=frequency target/release/frequency ./frequency/
+RUN chmod +x ./frequency/frequency
 
 # 9933 P2P port
 # 9944 for RPC call

--- a/docker/parachain-node.dockerfile
+++ b/docker/parachain-node.dockerfile
@@ -24,6 +24,7 @@ COPY --from=base /etc/ssl/certs/ca-certificates.crt /etc/ssl/certs/ca-certificat
 # For local testing only
 # COPY --chown=frequency target/production/frequency.amd64 ./frequency/frequency
 COPY --chown=frequency target/production/frequency ./frequency/
+RUN chmod +x ./frequency/frequency
 
 # 9933 for RPC call
 # 9944 for Websocket


### PR DESCRIPTION
# Goal
The goal of this PR is to fix the docker image run permission error. The permissions were lost once we stopped using tar and will need to be set explicitly now.

Closes #631