### PR TITLE
fix failing docker build in CI

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -302,6 +302,7 @@ jobs:
         run: |
           mkdir -p ${{env.BIN_DIR}}
           mv ${{env.RELEASE_BIN_FILENAME}} ${{env.BIN_DIR}}/${{env.BUILT_BIN_FILENAME}}
+          chmod +x ${{env.BIN_DIR}}/${{env.BUILT_BIN_FILENAME}}
       - name: Set up QEMU
         uses: docker/setup-qemu-action@v2
         with:
@@ -365,6 +366,7 @@ jobs:
         run: |
           mkdir -p ${{env.BIN_DIR}}
           mv ${{env.RELEASE_BIN_FILENAME}} ${{env.BIN_DIR}}/${{env.BUILT_BIN_FILENAME}}
+          chmod +x ${{env.BIN_DIR}}/${{env.BUILT_BIN_FILENAME}}
       - name: Set up QEMU
         uses: docker/setup-qemu-action@v2
         with:

--- a/docker/parachain-node.dockerfile
+++ b/docker/parachain-node.dockerfile
@@ -3,7 +3,6 @@
 # the binary in the build folder.
 # This is the build stage for Polkadot. Here we create the binary in a temporary image.
 FROM --platform=linux/amd64 ubuntu:focal AS base
-
 LABEL maintainer="Frequency Team"
 LABEL description="Frequency parachain node for Rococo testnet and Mainnet"
 
@@ -24,7 +23,6 @@ COPY --from=base /etc/ssl/certs/ca-certificates.crt /etc/ssl/certs/ca-certificat
 # For local testing only
 # COPY --chown=frequency target/production/frequency.amd64 ./frequency/frequency
 COPY --chown=frequency target/production/frequency ./frequency/
-RUN chmod +x ./frequency/frequency
 
 # 9933 for RPC call
 # 9944 for Websocket


### PR DESCRIPTION
# Goal
The goal of this PR is to set execution bits on frequency binaries in `parachain-node-<network>` images. This was lost once we moved away from tar.
