### PR TITLE
chore(messages): remove config dependency

### DIFF
--- a/pallets/messages/src/lib.rs
+++ b/pallets/messages/src/lib.rs
@@ -62,10 +62,7 @@ use sp_std::{collections::btree_map::BTreeMap, convert::TryInto, prelude::*};
 use codec::Encode;
 use common_primitives::{
 	messages::*,
-	msa::{
-		DelegationValidator, Delegator, MessageSourceId, MsaLookup, MsaValidator, Provider,
-		ProviderLookup, SchemaGrantValidator,
-	},
+	msa::{Delegator, MessageSourceId, MsaLookup, MsaValidator, Provider, SchemaGrantValidator},
 	schema::*,
 };
 pub use pallet::*;
@@ -88,9 +85,6 @@ pub mod pallet {
 
 		/// A type that will supply MSA related information
 		type MsaInfoProvider: MsaLookup + MsaValidator<AccountId = Self::AccountId>;
-
-		/// A type that will supply delegation related information
-		type DelegationInfoProvider: ProviderLookup + DelegationValidator;
 
 		/// A type that will validate schema grants
 		type SchemaGrantValidator: SchemaGrantValidator;

--- a/pallets/messages/src/mock.rs
+++ b/pallets/messages/src/mock.rs
@@ -222,7 +222,6 @@ impl SchemaProvider<u16> for SchemaHandler {
 impl pallet_messages::Config for Test {
 	type Event = Event;
 	type MsaInfoProvider = MsaInfoHandler;
-	type DelegationInfoProvider = DelegationInfoHandler;
 	type SchemaGrantValidator = SchemaGrantValidationHandler;
 	type SchemaProvider = SchemaHandler;
 	type WeightInfo = ();

--- a/pallets/msa/src/tests.rs
+++ b/pallets/msa/src/tests.rs
@@ -16,7 +16,10 @@ use crate::{
 };
 
 use common_primitives::{
-	msa::{Delegation, Delegator, MessageSourceId, Provider, ProviderRegistryEntry},
+	msa::{
+		Delegation, DelegationValidator, Delegator, MessageSourceId, Provider,
+		ProviderRegistryEntry,
+	},
 	node::BlockNumber,
 	schema::{SchemaId, SchemaValidator},
 	utils::wrap_binary_data,
@@ -1451,7 +1454,7 @@ fn signed_extension_revoke_delegation_by_provider_fails_when_no_provider_msa() {
 		let (provider_pair, _) = sr25519::Pair::generate();
 		let provider_account = provider_pair.public();
 
-		let (delegator_msa, delegator_pair) = create_account();
+		let (delegator_msa, _) = create_account();
 
 		let expected_err = InvalidTransaction::Custom(ValidityError::InvalidMsaKey as u8);
 		assert_revoke_delegation_by_provider_err(expected_err, provider_account, delegator_msa);
@@ -1463,8 +1466,7 @@ fn signed_extension_revoke_delegation_by_provider_fails_when_no_delegation() {
 	new_test_ext().execute_with(|| {
 		let (_, provider_pair) = create_account();
 		let provider_account = provider_pair.public();
-		let (delegator_msa, delegator_pair) = create_account();
-		let delegator_account = delegator_pair.public();
+		let (delegator_msa, _) = create_account();
 
 		let expected_err = InvalidTransaction::Custom(ValidityError::InvalidDelegation as u8);
 		assert_revoke_delegation_by_provider_err(expected_err, provider_account, delegator_msa);

--- a/runtime/frequency-rococo/src/lib.rs
+++ b/runtime/frequency-rococo/src/lib.rs
@@ -587,7 +587,6 @@ impl pallet_messages::Config for Runtime {
 	type Event = Event;
 	type WeightInfo = pallet_messages::weights::SubstrateWeight<Runtime>;
 	type MsaInfoProvider = Msa;
-	type DelegationInfoProvider = Msa;
 	type SchemaGrantValidator = Msa;
 	type SchemaProvider = Schemas;
 	type MaxMessagesPerBlock = MessagesMaxPerBlock;

--- a/runtime/frequency/src/lib.rs
+++ b/runtime/frequency/src/lib.rs
@@ -635,7 +635,6 @@ impl pallet_messages::Config for Runtime {
 	type Event = Event;
 	type WeightInfo = pallet_messages::weights::SubstrateWeight<Runtime>;
 	type MsaInfoProvider = Msa;
-	type DelegationInfoProvider = Msa;
 	type SchemaGrantValidator = Msa;
 	type SchemaProvider = Schemas;
 	type MaxMessagesPerBlock = MessagesMaxPerBlock;


### PR DESCRIPTION
# Goal
Remove the `DelegationInfoProvider` config dependency. `SchemaGrantValidator` is used to check the validity of a schema and delegation relationship.

Closes #650 
