### PR TITLE
Provider -> ProviderId, Delegator -> DelegatorId

### DIFF
--- a/common/primitives/src/msa.rs
+++ b/common/primitives/src/msa.rs
@@ -16,37 +16,38 @@ pub use crate::schema::SchemaId;
 /// Message Source Id or msaId is the unique identifier for Message Source Accounts
 pub type MessageSourceId = u64;
 
-/// A Delegator is a role for an MSA to play.
+/// A DelegatorId an MSA Id serving the role of a Delegator.
 /// Delegators delegate to Providers.
 /// Encodes and Decodes as just a `u64`
-#[derive(TypeInfo, Debug, Clone, Copy, PartialEq, MaxEncodedLen, Eq)]
-pub struct Delegator(pub MessageSourceId);
+#[cfg_attr(feature = "std", derive(Serialize, Deserialize))]
+#[derive(TypeInfo, Default, Debug, Clone, Copy, PartialEq, MaxEncodedLen, Eq)]
+pub struct DelegatorId(pub MessageSourceId);
 
-impl EncodeLike for Delegator {}
+impl EncodeLike for DelegatorId {}
 
-impl Encode for Delegator {
+impl Encode for DelegatorId {
 	fn encode(&self) -> Vec<u8> {
 		self.0.encode()
 	}
 }
 
-impl Decode for Delegator {
+impl Decode for DelegatorId {
 	fn decode<I: codec::Input>(input: &mut I) -> Result<Self, codec::Error> {
 		match <u64>::decode(input) {
-			Ok(x) => Ok(Delegator(x)),
-			_ => Err(Error::from("Could not decode Delegator")),
+			Ok(x) => Ok(DelegatorId(x)),
+			_ => Err(Error::from("Could not decode DelegatorId")),
 		}
 	}
 }
 
-impl From<MessageSourceId> for Delegator {
+impl From<MessageSourceId> for DelegatorId {
 	fn from(t: MessageSourceId) -> Self {
-		Delegator(t)
+		DelegatorId(t)
 	}
 }
 
-impl From<Delegator> for MessageSourceId {
-	fn from(t: Delegator) -> MessageSourceId {
+impl From<DelegatorId> for MessageSourceId {
+	fn from(t: DelegatorId) -> MessageSourceId {
 		t.0
 	}
 }
@@ -86,34 +87,35 @@ impl<
 /// Provider is the recipient of a delegation.
 /// It is a subset of an MSA
 /// Encodes and Decodes as just a `u64`
-#[derive(TypeInfo, Debug, Clone, Copy, PartialEq, MaxEncodedLen, Eq)]
-pub struct Provider(pub MessageSourceId);
+#[cfg_attr(feature = "std", derive(Serialize, Deserialize))]
+#[derive(TypeInfo, Default, Debug, Clone, Copy, PartialEq, MaxEncodedLen, Eq)]
+pub struct ProviderId(pub MessageSourceId);
 
-impl EncodeLike for Provider {}
+impl EncodeLike for ProviderId {}
 
-impl Encode for Provider {
+impl Encode for ProviderId {
 	fn encode(&self) -> Vec<u8> {
 		self.0.encode()
 	}
 }
 
-impl Decode for Provider {
+impl Decode for ProviderId {
 	fn decode<I: codec::Input>(input: &mut I) -> Result<Self, codec::Error> {
 		match <u64>::decode(input) {
-			Ok(x) => Ok(Provider(x)),
-			_ => Err(Error::from("Could not decode Provider")),
+			Ok(x) => Ok(ProviderId(x)),
+			_ => Err(Error::from("Could not decode ProviderId")),
 		}
 	}
 }
 
-impl From<MessageSourceId> for Provider {
+impl From<MessageSourceId> for ProviderId {
 	fn from(t: MessageSourceId) -> Self {
-		Provider(t)
+		ProviderId(t)
 	}
 }
 
-impl From<Provider> for MessageSourceId {
-	fn from(t: Provider) -> MessageSourceId {
+impl From<ProviderId> for MessageSourceId {
+	fn from(t: ProviderId) -> MessageSourceId {
 		t.0
 	}
 }
@@ -160,8 +162,8 @@ pub trait ProviderLookup {
 
 	/// Gets the relationship information for this delegator, provider pair
 	fn get_delegation_of(
-		delegator: Delegator,
-		provider: Provider,
+		delegator: DelegatorId,
+		provider: ProviderId,
 	) -> Option<Delegation<Self::SchemaId, Self::BlockNumber, Self::MaxSchemaGrantsPerDelegation>>;
 }
 
@@ -176,8 +178,8 @@ pub trait DelegationValidator {
 
 	/// Validates that the delegator and provider have a relationship at this point
 	fn ensure_valid_delegation(
-		provider: Provider,
-		delegator: Delegator,
+		provider: ProviderId,
+		delegator: DelegatorId,
 		block_number: Option<Self::BlockNumber>,
 	) -> Result<
 		Delegation<Self::SchemaId, Self::BlockNumber, Self::MaxSchemaGrantsPerDelegation>,
@@ -189,8 +191,8 @@ pub trait DelegationValidator {
 pub trait SchemaGrantValidator {
 	/// Validates if the provider is allowed to use the particular schema id currently
 	fn ensure_valid_schema_grant(
-		provider: Provider,
-		delegator: Delegator,
+		provider_id: ProviderId,
+		delegator_id: DelegatorId,
 		schema_id: SchemaId,
 	) -> DispatchResult;
 }

--- a/designdocs/delegation.md
+++ b/designdocs/delegation.md
@@ -92,7 +92,7 @@ This is a signed call directly from the delegator's MSA.
 This call incurs no fees.
 
   * Parameters:
-      1. `provider_id` - id of the MSA held by the provider
+      1. `provider_msa_id` - id of the MSA held by the provider
 
   * Restrictions:  **Owner only**.
 
@@ -112,13 +112,13 @@ Validate that a provider can delegate for a list of MSA ids.
 This call is intended for validating messages in a batch, so this function would be an all-or-nothing check.
 If the permission stored for a given MSA id exceeds the parameter, the check for that MSA id passes.
 For example, if a provider has *all* permissions set, then querying for a subset of permissions will pass.
-Verify that the provided provider `provider_id` is a provider of the delegator, and has the given permission value.
+Verify that the provided provider `provider_msa_id` is a provider of the delegator, and has the given permission value.
 Returns `Ok(true)` if provider is valid, `Ok(false)` if not.
 Throws an Error enum indicating if either provider or delegator does not exist.
 
 * Parameters:
-    1. `delegator_msa_ids`: a list of MSA ids possible delegators
-    2. `provider_id`: the MSA id of the provider to verify
+    1. `delegator_msa_ids`: a list of Delegator ids possible delegators
+    2. `provider_msa_id`: the ProviderId to verify
 
 ### Storage
 * Delegations are stored as a Double-key map of Delegator MSA id --> Provider MSA id. The data stored contains the `Permission` for that relationship:

--- a/designdocs/delegation.md
+++ b/designdocs/delegation.md
@@ -92,7 +92,7 @@ This is a signed call directly from the delegator's MSA.
 This call incurs no fees.
 
   * Parameters:
-      1. `provider_msa_id` - id of the MSA held by the provider
+      1. `provider_id` - id of the MSA held by the provider
 
   * Restrictions:  **Owner only**.
 
@@ -112,13 +112,13 @@ Validate that a provider can delegate for a list of MSA ids.
 This call is intended for validating messages in a batch, so this function would be an all-or-nothing check.
 If the permission stored for a given MSA id exceeds the parameter, the check for that MSA id passes.
 For example, if a provider has *all* permissions set, then querying for a subset of permissions will pass.
-Verify that the provided provider `provider_msa_id` is a provider of the delegator, and has the given permission value.
+Verify that the provided provider `provider_id` is a provider of the delegator, and has the given permission value.
 Returns `Ok(true)` if provider is valid, `Ok(false)` if not.
 Throws an Error enum indicating if either provider or delegator does not exist.
 
 * Parameters:
     1. `delegator_msa_ids`: a list of MSA ids possible delegators
-    2. `provider_msa_id`: the MSA id of the provider to verify
+    2. `provider_id`: the MSA id of the provider to verify
 
 ### Storage
 * Delegations are stored as a Double-key map of Delegator MSA id --> Provider MSA id. The data stored contains the `Permission` for that relationship:
@@ -173,8 +173,8 @@ Including an effective block range in the provider storage data would allow prov
 Directly adding a provider, with or without a provider's permission, is not to be implemented at this time. The original use case was for a potential wallet app to support browsing and adding providers. Adding/replacing a provider for an existing account with an MSA id could still be done using the delegated methods, `add_self_as_delegate` or `replace_delegate_with_self`.  A direct add brought up concerns about potential risks of adding a provider without the provider's knowledge. For example, if the provider has removed the delegator for legitimate reasons, such as if the End User violated the provider's Terms of Service, then the provider ought to be able to prevent them from adding the provider again just by paying for it.
 
 ## Glossary
-* **Provider**: An MSA id that has been granted specific permissions by its Delegator. A company or individual operating an on-chain Provider MSA in order to post Frequency transactions on behalf of other MSAs.
-* **Delegator**: An MSA id that has granted specific permissions to a Provider.
+* **Provider**: An MSA that has been granted specific permissions by its Delegator. A company or individual operating an on-chain Provider MSA in order to post Frequency transactions on behalf of other MSAs.
+* **Delegator**: An MSA that has granted specific permissions to a Provider.
 * **MSA**: Message Source Account. A collection of key pairs which can have a specific token balance.
 * **Public Key**: A 32-byte (u256) number that is used to refer to an on-chain MSA and verify signatures. It is one of the keys of an MSA key pair
 * **MsaId**: An 8-byte (u64) number used as a lookup and storage key for delegations, among other things

--- a/designdocs/provider_registration.md
+++ b/designdocs/provider_registration.md
@@ -54,8 +54,7 @@ Please note:
   * `name`: `Vec<u8>`
 
 #### Events
-* `ProviderRegistrationEvent<T: Config>`, the resource that exists on-chain
-  * `block_number`: `BlockNumber`
+* `ProviderCreated<T: Config>`, the resource that exists on-chain
   * `provider_id`: `ProviderId`
 
 #### Storage
@@ -66,7 +65,7 @@ Please note:
 
 ### Extrinsics
 #### create_provider(origin, provider_name)
-Creates and posts a `ProviderRegistrationEvent`. The `MsaId`
+Creates and posts a `ProviderCreated`. The `MsaId`
 included in the registration must already exist.
 
 This extrinsic is responsible for storing the registered provider in the
@@ -75,7 +74,7 @@ This extrinsic is responsible for storing the registered provider in the
 * **Parameters**
   * `origin`: `Origin`  required for all extrinsics, the caller/sender.
   * `provider_name`: the name used for the provider.
-* **Event**:  `Event::<T>::ProviderRegistrationEvent(provider_id)`
+* **Event**:  `Event::<T>::ProviderCreated(provider_id)`
 * **Restrictions**:
   * `origin`'s `msa_id` must have capacity to post the transaction (including fee) during the current epoch.
 

--- a/designdocs/provider_registration.md
+++ b/designdocs/provider_registration.md
@@ -56,7 +56,7 @@ Please note:
 #### Events
 * `ProviderRegistrationEvent<T: Config>`, the resource that exists on-chain
   * `block_number`: `BlockNumber`
-  * `provider_msa_id`: `MsaId`
+  * `provider_id`: `ProviderId`
 
 #### Storage
 * `ProviderToRegistryEntry<T: Config>`: `StorageMap<MsaId, ProviderRegistryEntry>`
@@ -75,18 +75,18 @@ This extrinsic is responsible for storing the registered provider in the
 * **Parameters**
   * `origin`: `Origin`  required for all extrinsics, the caller/sender.
   * `provider_name`: the name used for the provider.
-* **Event**:  `Event::<T>::ProviderRegistrationEvent(provider_msa_id)`
+* **Event**:  `Event::<T>::ProviderRegistrationEvent(provider_id)`
 * **Restrictions**:
   * `origin`'s `msa_id` must have capacity to post the transaction (including fee) during the current epoch.
 
 
 ### Custom RPCs
-#### get_provider(provider_msa_id)
-Retrieves a single provider. The `provider_msa_id` should belong to a registered
+#### get_provider(provider_id)
+Retrieves a single provider. The `provider_id` should belong to a registered
 provider.
 
 * **Parameters**
-  * `provider_msa_id`: `MsaId` the `MsaId` of the provider in question.
+  * `provider_id`: `ProviderId` the `MsaId` of the provider in question.
 
 * **Returns**
   * `None()` if no messages meet the criteria.

--- a/js/api-augment/definitions/msa.ts
+++ b/js/api-augment/definitions/msa.ts
@@ -16,29 +16,29 @@ export default {
       params: [
         {
           name: "delegator_msa_ids",
-          type: "Vec<MessageSourceId>",
+          type: "Vec<DelegatorId>",
         },
         {
           name: "provider_msa_id",
-          type: "MessageSourceId",
+          type: "ProviderId",
         },
         {
           name: "block_number",
           type: "Option<BlockNumber>",
         },
       ],
-      type: "Vec<(MessageSourceId, bool)>",
+      type: "Vec<(DelegatorId, bool)>",
     },
     grantedSchemaIdsByMsaId: {
       description: "Fetch the list of schema ids that a delegator has granted to provider",
       params: [
         {
           name: "delegator_msa_id",
-          type: "MessageSourceId",
+          type: "DelegatorId",
         },
         {
           name: "provider_msa_id",
-          type: "MessageSourceId",
+          type: "ProviderId",
         },
       ],
       type: "Option<Vec<SchemaId>>",
@@ -46,8 +46,8 @@ export default {
   },
   types: {
     MessageSourceId: "u64",
-    Delegator: "MessageSourceId",
-    Provider: "MessageSourceId",
+    DelegatorId: "MessageSourceId",
+    ProviderId: "MessageSourceId",
     KeyInfoResponse: {
       key: "AccountId",
       msaId: "MessageSourceId",
@@ -62,12 +62,12 @@ export default {
               "Check to see if a delegation existed between the given delegator and provider at a given block",
             params: [
               {
-                name: "delegator",
-                type: "Delegator",
+                name: "delegator_id",
+                type: "DelegatorId",
               },
               {
-                name: "provider",
-                type: "Provider",
+                name: "provider_id",
+                type: "ProviderId",
               },
               {
                 name: "block_number",
@@ -81,12 +81,12 @@ export default {
               "Get the list of schema ids (if any) that exist in any delegation between the delegator and provider",
             params: [
               {
-                name: "delegator",
-                type: "Delegator",
+                name: "delegator_id",
+                type: "DelegatorId",
               },
               {
-                name: "provider",
-                type: "Provider",
+                name: "provider_id",
+                type: "ProviderId",
               },
             ],
             type: "Option<Vec<SchemaId>>",

--- a/pallets/messages/src/lib.rs
+++ b/pallets/messages/src/lib.rs
@@ -62,7 +62,9 @@ use sp_std::{collections::btree_map::BTreeMap, convert::TryInto, prelude::*};
 use codec::Encode;
 use common_primitives::{
 	messages::*,
-	msa::{ DelegatorId, MessageSourceId, MsaLookup, MsaValidator, ProviderId, SchemaGrantValidator },
+	msa::{
+		DelegatorId, MessageSourceId, MsaLookup, MsaValidator, ProviderId, SchemaGrantValidator,
+	},
 	schema::*,
 };
 pub use pallet::*;

--- a/pallets/messages/src/mock.rs
+++ b/pallets/messages/src/mock.rs
@@ -1,8 +1,8 @@
 use crate as pallet_messages;
 use common_primitives::{
 	msa::{
-		Delegation, DelegationValidator, Delegator, MessageSourceId, MsaLookup, MsaValidator,
-		Provider, ProviderLookup, SchemaGrantValidator,
+		Delegation, DelegationValidator, DelegatorId, MessageSourceId, MsaLookup, MsaValidator,
+		ProviderId, ProviderLookup, SchemaGrantValidator,
 	},
 	schema::*,
 };
@@ -153,10 +153,10 @@ impl ProviderLookup for DelegationInfoHandler {
 	type SchemaId = SchemaId;
 
 	fn get_delegation_of(
-		_delegator: Delegator,
-		provider: Provider,
+		_delegator: DelegatorId,
+		provider: ProviderId,
 	) -> Option<Delegation<SchemaId, Self::BlockNumber, MaxSchemaGrantsPerDelegation>> {
-		if provider == Provider(2000) {
+		if provider == ProviderId(2000) {
 			return None
 		};
 		Some(Delegation { revoked_at: 100, schema_permissions: Default::default() })
@@ -168,14 +168,14 @@ impl DelegationValidator for DelegationInfoHandler {
 	type SchemaId = SchemaId;
 
 	fn ensure_valid_delegation(
-		provider: Provider,
-		_delegator: Delegator,
+		provider: ProviderId,
+		_delegator: DelegatorId,
 		_block_number: Option<Self::BlockNumber>,
 	) -> Result<
 		Delegation<SchemaId, Self::BlockNumber, Self::MaxSchemaGrantsPerDelegation>,
 		DispatchError,
 	> {
-		if provider == Provider(2000) {
+		if provider == ProviderId(2000) {
 			return Err(DispatchError::Other("some delegation error"))
 		};
 
@@ -184,8 +184,8 @@ impl DelegationValidator for DelegationInfoHandler {
 }
 impl SchemaGrantValidator for SchemaGrantValidationHandler {
 	fn ensure_valid_schema_grant(
-		provider: Provider,
-		delegator: Delegator,
+		provider: ProviderId,
+		delegator: DelegatorId,
 		_schema_id: SchemaId,
 	) -> DispatchResult {
 		match DelegationInfoHandler::get_delegation_of(delegator, provider) {

--- a/pallets/msa/src/benchmarking.rs
+++ b/pallets/msa/src/benchmarking.rs
@@ -83,7 +83,7 @@ fn create_msa_account_and_keys<T: Config>() -> (T::AccountId, SignerId, MessageS
 	(account_id, key_pair, msa_id)
 }
 
-fn add_delegation<T: Config>(delegator: Delegator, provider: Provider) {
+fn add_delegation<T: Config>(delegator: DelegatorId, provider: ProviderId) {
 	let schema_ids: Vec<SchemaId> = (1..31 as u16).collect::<Vec<_>>();
 	T::SchemaValidator::set_schema_count(schema_ids.len().try_into().unwrap());
 	assert_ok!(Msa::<T>::add_provider(provider, delegator, schema_ids));
@@ -126,11 +126,11 @@ benchmarks! {
 
 		let (provider, provider_msa_id) = create_account_with_msa_id::<T>(0);
 		let (delegator, delegator_msa_id) = create_account_with_msa_id::<T>(1);
-		add_delegation::<T>(Delegator(delegator_msa_id), Provider(provider_msa_id.clone()));
+		add_delegation::<T>(DelegatorId(delegator_msa_id), ProviderId(provider_msa_id.clone()));
 
 		for j in 2 .. s {
 			let (other, other_msa_id) = create_account_with_msa_id::<T>(j);
-			add_delegation::<T>(Delegator(other_msa_id), Provider(provider_msa_id.clone()));
+			add_delegation::<T>(DelegatorId(other_msa_id), ProviderId(provider_msa_id.clone()));
 		}
 	}: _ (RawOrigin::Signed(provider), delegator_msa_id)
 
@@ -183,7 +183,7 @@ benchmarks! {
 	revoke_delegation_by_delegator {
 		let (provider, provider_msa_id) = create_account_with_msa_id::<T>(0);
 		let (delegator, delegator_msa_id) = create_account_with_msa_id::<T>(1);
-		add_delegation::<T>(Delegator(delegator_msa_id), Provider(provider_msa_id.clone()));
+		add_delegation::<T>(DelegatorId(delegator_msa_id), ProviderId(provider_msa_id.clone()));
 
 
 	}: _ (RawOrigin::Signed(delegator), provider_msa_id)
@@ -209,11 +209,11 @@ benchmarks! {
 
 		let (provider, provider_msa_id) = create_account_with_msa_id::<T>(0);
 		let (delegator, delegator_msa_id) = create_account_with_msa_id::<T>(1);
-		add_delegation::<T>(Delegator(delegator_msa_id), Provider(provider_msa_id.clone()));
+		add_delegation::<T>(DelegatorId(delegator_msa_id), ProviderId(provider_msa_id.clone()));
 
 		for j in 2 .. s {
 			let (other, other_msa_id) = create_account_with_msa_id::<T>(j);
-			add_delegation::<T>(Delegator(other_msa_id), Provider(provider_msa_id.clone()));
+			add_delegation::<T>(DelegatorId(other_msa_id), ProviderId(provider_msa_id.clone()));
 		}
 
 		let schema_ids: Vec<SchemaId> = (1..31 as u16).collect::<Vec<_>>();
@@ -226,11 +226,11 @@ benchmarks! {
 
 		let (provider, provider_msa_id) = create_account_with_msa_id::<T>(0);
 		let (delegator, delegator_msa_id) = create_account_with_msa_id::<T>(1);
-		add_delegation::<T>(Delegator(delegator_msa_id), Provider(provider_msa_id.clone()));
+		add_delegation::<T>(DelegatorId(delegator_msa_id), ProviderId(provider_msa_id.clone()));
 
 		for j in 2 .. s {
 			let (other, other_msa_id) = create_account_with_msa_id::<T>(j);
-			add_delegation::<T>(Delegator(other_msa_id), Provider(provider_msa_id.clone()));
+			add_delegation::<T>(DelegatorId(other_msa_id), ProviderId(provider_msa_id.clone()));
 		}
 
 		let schema_ids: Vec<SchemaId> = (1..31 as u16).collect::<Vec<_>>();

--- a/pallets/msa/src/lib.rs
+++ b/pallets/msa/src/lib.rs
@@ -1331,13 +1331,13 @@ impl<T: Config> DelegationValidator for Pallet<T> {
 	/// * [`Error::DelegationRevoked`]
 	///
 	fn ensure_valid_delegation(
-		provider: ProviderId,
-		delegation: DelegatorId,
+		provider_id: ProviderId,
+		delegator_id: DelegatorId,
 		block_number: Option<T::BlockNumber>,
 	) -> Result<Delegation<SchemaId, T::BlockNumber, T::MaxSchemaGrantsPerDelegation>, DispatchError>
 	{
-		let info =
-			Self::get_delegation(delegator, provider).ok_or(Error::<T>::DelegationNotFound)?;
+		let info = Self::get_delegation(delegator_id, provider_id)
+			.ok_or(Error::<T>::DelegationNotFound)?;
 		let current_block = frame_system::Pallet::<T>::block_number();
 		let requested_block = match block_number {
 			Some(block_number) => {

--- a/pallets/msa/src/lib.rs
+++ b/pallets/msa/src/lib.rs
@@ -28,7 +28,7 @@
 //! * **MSA ID:** the ID number created for a new Message Source Account and associated with one or more Public Keys.
 //! * **MSA Public Key:** the keys that control the MSA, represented by Substrate `AccountId`.
 //! * **Delegator:** a Message Source Account that has provably delegated certain actions to a Provider, typically sending a `Message`
-//! * **Provider:** the actor that a Delegator has delegated specific actions to.
+//! * **Provider:** the Message Source Account that a Delegator has delegated specific actions to.
 //! * **Delegation:** A stored Delegator-Provider association between MSAs which permits the Provider to perform specific actions on the Delegator's behalf.
 //!
 //! ## Implementations
@@ -70,7 +70,7 @@ use sp_std::prelude::*;
 pub use common_primitives::{msa::MessageSourceId, utils::wrap_binary_data};
 use common_primitives::{
 	msa::{
-		Delegation, DelegationValidator, Delegator, MsaLookup, MsaValidator, Provider,
+		Delegation, DelegationValidator, DelegatorId, MsaLookup, MsaValidator, ProviderId,
 		ProviderLookup, ProviderRegistryEntry, SchemaGrantValidator,
 	},
 	schema::{SchemaId, SchemaValidator},
@@ -116,6 +116,7 @@ pub mod pallet {
 		/// Maximum count of schemas granted for publishing data per Provider
 		#[pallet::constant]
 		type MaxSchemaGrantsPerDelegation: Get<u32> + Clone + sp_std::fmt::Debug + Eq;
+
 		/// Maximum provider name size allowed per MSA association
 		#[pallet::constant]
 		type MaxProviderNameSize: Get<u32>;
@@ -161,9 +162,9 @@ pub mod pallet {
 	pub type DelegatorAndProviderToDelegation<T: Config> = StorageDoubleMap<
 		_,
 		Twox64Concat,
-		Delegator,
+		DelegatorId,
 		Twox64Concat,
-		Provider,
+		ProviderId,
 		Delegation<SchemaId, T::BlockNumber, T::MaxSchemaGrantsPerDelegation>,
 		OptionQuery,
 	>;
@@ -176,7 +177,7 @@ pub mod pallet {
 	pub type ProviderToRegistryEntry<T: Config> = StorageMap<
 		_,
 		Twox64Concat,
-		Provider,
+		ProviderId,
 		ProviderRegistryEntry<T::MaxProviderNameSize>,
 		OptionQuery,
 	>;
@@ -220,6 +221,7 @@ pub mod pallet {
 		MsaCreated {
 			/// The MSA for the Event
 			msa_id: MessageSourceId,
+
 			/// The key added to the MSA
 			key: T::AccountId,
 		},
@@ -227,6 +229,7 @@ pub mod pallet {
 		PublicKeyAdded {
 			/// The MSA for the Event
 			msa_id: MessageSourceId,
+
 			/// The key added to the MSA
 			key: T::AccountId,
 		},
@@ -238,21 +241,23 @@ pub mod pallet {
 		/// A delegation relationship was added with the given provider and delegator
 		DelegationGranted {
 			/// The Provider MSA Id
-			provider: Provider,
+			provider_id: ProviderId,
+
 			/// The Delegator MSA Id
-			delegator: Delegator,
+			delegator_id: DelegatorId,
 		},
 		/// A Provider-MSA relationship was registered
 		ProviderCreated {
 			/// The MSA id associated with the provider
-			provider_msa_id: MessageSourceId,
+			provider_id: ProviderId,
 		},
 		/// The Delegator revoked its delegation to the Provider
 		DelegationRevoked {
 			/// The Provider MSA Id
-			provider: Provider,
+			provider_id: ProviderId,
+
 			/// The Delegator MSA Id
-			delegator: Delegator,
+			delegator_id: DelegatorId,
 		},
 		/// The MSA has been retired.
 		MsaRetired {
@@ -262,9 +267,10 @@ pub mod pallet {
 		/// A an update to the delegation occurred (ex. schema permissions where updated).
 		DelegationUpdated {
 			/// The Provider MSA Id
-			provider: Provider,
+			provider_id: ProviderId,
+
 			/// The Delegator MSA Id
-			delegator: Delegator,
+			delegator_id: DelegatorId,
 		},
 	}
 
@@ -272,62 +278,85 @@ pub mod pallet {
 	pub enum Error<T> {
 		/// Tried to add a key that was already registered to an MSA
 		KeyAlreadyRegistered,
+
 		/// MsaId values have reached the maximum
 		MsaIdOverflow,
+
 		/// Cryptographic signature verification failed for adding a key to MSA
 		MsaOwnershipInvalidSignature,
+
 		/// Ony the MSA Owner may perform the operation
 		NotMsaOwner,
+
 		/// Cryptographic signature failed verification
 		InvalidSignature,
+
 		/// Only the KeyOwner may perform the operation
 		NotKeyOwner,
+
 		/// An operation was attempted with an unknown Key
 		NoKeyExists,
+
 		/// The number of key values has reached its maximum
 		KeyLimitExceeded,
+
 		/// More than one account key exists for the MSA during retire attempt
 		MoreThanOneKeyExists,
+
 		/// Can't retire a registered provider MSA
 		RegisteredProviderCannotBeRetired,
+
 		/// A transaction's Origin (AccountId) may not remove itself
 		InvalidSelfRemoval,
+
 		/// An MSA may not be its own delegate
 		InvalidSelfProvider,
+
 		/// An invalid schema Id was provided
 		InvalidSchemaId,
+
 		/// The delegation relationship already exists for the given MSA Ids
 		DuplicateProvider,
+
 		/// Cryptographic signature verification failed for adding the Provider as delegate
 		AddProviderSignatureVerificationFailed,
+
 		/// Origin attempted to add a delegate for someone else's MSA
 		UnauthorizedDelegator,
+
 		/// Origin attempted to add a different delegate than what was in the payload
 		UnauthorizedProvider,
+
 		/// The operation was attempted with a revoked delegation
-		///
-		/// # Situations
-		/// * Had a prior delegation
-		/// * Has an active delegation, but the schema permission is revoked
 		DelegationRevoked,
+
 		/// The operation was attempted with an unknown delegation
 		DelegationNotFound,
+
 		/// The MSA id submitted for provider creation has already been associated with a provider
 		DuplicateProviderRegistryEntry,
+
 		/// The maximum length for a provider name has been exceeded
 		ExceedsMaxProviderNameSize,
+
 		/// The maximum number of schema grants has been exceeded
 		ExceedsMaxSchemaGrantsPerDelegation,
+
 		/// Provider is not permitted to publish for given schema_id
 		SchemaNotGranted,
+
 		/// The operation was attempted with a non-provider MSA
 		ProviderNotRegistered,
+
 		/// The submitted proof has expired; the current block is less the expiration block
 		ProofHasExpired,
+
 		/// The submitted proof expiration block is too far in the future
 		ProofNotYetValid,
+
 		/// Attempted to add a signature when the signature is already in the registry
 		SignatureAlreadySubmitted,
+
 		/// Cryptographic signature verification failed for proving ownership of new public-key.
 		NewKeyOwnershipInvalidSignature,
 	}
@@ -410,21 +439,16 @@ pub mod pallet {
 
 			let (_, _) =
 				Self::create_account(delegator_key.clone(), |new_msa_id| -> DispatchResult {
-					Self::add_provider(
-						provider_msa_id.into(),
-						new_msa_id.into(),
-						add_provider_payload.schema_ids,
-					)?;
+					let provider_id = ProviderId(provider_msa_id);
+					let delegator_id = DelegatorId(new_msa_id);
+					Self::add_provider(provider_id, delegator_id, add_provider_payload.schema_ids)?;
 
 					Self::deposit_event(Event::MsaCreated {
 						msa_id: new_msa_id,
 						key: delegator_key.clone(),
 					});
 
-					Self::deposit_event(Event::DelegationGranted {
-						delegator: new_msa_id.into(),
-						provider: provider_msa_id.into(),
-					});
+					Self::deposit_event(Event::DelegationGranted { delegator_id, provider_id });
 					Ok(())
 				})?;
 
@@ -450,7 +474,7 @@ pub mod pallet {
 
 			let provider_msa_id = Self::ensure_valid_msa_key(&provider_key)?;
 			ProviderToRegistryEntry::<T>::try_mutate(
-				Provider(provider_msa_id),
+				ProviderId(provider_msa_id),
 				|maybe_metadata| -> DispatchResult {
 					ensure!(
 						maybe_metadata.take().is_none(),
@@ -460,7 +484,9 @@ pub mod pallet {
 					Ok(())
 				},
 			)?;
-			Self::deposit_event(Event::ProviderCreated { provider_msa_id });
+			Self::deposit_event(Event::ProviderCreated {
+				provider_id: ProviderId(provider_msa_id),
+			});
 			Ok(())
 		}
 
@@ -498,18 +524,15 @@ pub mod pallet {
 				.map_err(|_| Error::<T>::AddProviderSignatureVerificationFailed)?;
 
 			Self::register_signature(&proof, add_provider_payload.expiration.into())?;
-
-			let (provider, delegator) =
+			let (provider_id, delegator_id) =
 				Self::ensure_valid_registered_provider(&delegator_key, &provider_key)?;
 
 			ensure!(
-				add_provider_payload.authorized_msa_id == provider.0,
+				add_provider_payload.authorized_msa_id == provider_id.0,
 				Error::<T>::UnauthorizedDelegator
 			);
-
-			Self::add_provider(provider, delegator, add_provider_payload.schema_ids)?;
-
-			Self::deposit_event(Event::DelegationGranted { delegator, provider });
+			Self::add_provider(provider_id, delegator_id, add_provider_payload.schema_ids)?;
+			Self::deposit_event(Event::DelegationGranted { delegator_id, provider_id });
 
 			Ok(())
 		}
@@ -533,14 +556,11 @@ pub mod pallet {
 			let who = ensure_signed(origin)?;
 
 			match Self::get_msa_by_public_key(&who) {
-				Some(delegator_msa) => {
-					let delegator_msa_id: Delegator = delegator_msa.into();
-					let provider_msa_id = Provider(provider_msa_id);
-					Self::revoke_provider(provider_msa_id, delegator_msa_id)?;
-					Self::deposit_event(Event::DelegationRevoked {
-						delegator: delegator_msa_id,
-						provider: provider_msa_id,
-					});
+				Some(delegator_msa_id) => {
+					let delegator_id = DelegatorId(delegator_msa_id);
+					let provider_id = ProviderId(provider_msa_id);
+					Self::revoke_provider(provider_id, delegator_id)?;
+					Self::deposit_event(Event::DelegationRevoked { delegator_id, provider_id });
 				},
 				None => {
 					error!("SignedExtension did not catch invalid MSA for account {:?}, ", who);
@@ -676,13 +696,10 @@ pub mod pallet {
 			// validity checks are in SignedExtension so in theory this should never error.
 			match Self::get_msa_by_public_key(&who) {
 				Some(msa_id) => {
-					let provider_msa_id = Provider(msa_id);
-					let delegator_msa_id = Delegator(delegator);
-					Self::revoke_provider(provider_msa_id, delegator_msa_id)?;
-					Self::deposit_event(Event::DelegationRevoked {
-						provider: provider_msa_id,
-						delegator: delegator_msa_id,
-					})
+					let provider_id = ProviderId(msa_id);
+					let delegator_id = DelegatorId(delegator);
+					Self::revoke_provider(provider_id, delegator_id)?;
+					Self::deposit_event(Event::DelegationRevoked { provider_id, delegator_id })
 				},
 				None => {
 					error!("SignedExtension did not catch invalid MSA for account {:?}, ", who);
@@ -706,21 +723,16 @@ pub mod pallet {
 		#[pallet::weight(T::WeightInfo::grant_schema_permissions(20_000))]
 		pub fn grant_schema_permissions(
 			origin: OriginFor<T>,
-			provider: MessageSourceId,
+			provider_msa_id: MessageSourceId,
 			schema_ids: Vec<SchemaId>,
 		) -> DispatchResult {
 			let delegator_key = ensure_signed(origin)?;
 			let delegator_msa_id = Self::ensure_valid_msa_key(&delegator_key)?;
+			let provider_id = ProviderId(provider_msa_id);
+			let delegator_id = DelegatorId(delegator_msa_id);
 
-			let provider_msa_id = Provider(provider);
-			let delegator_msa_id = Delegator(delegator_msa_id);
-
-			Self::grant_permissions_for_schemas(delegator_msa_id, provider_msa_id, schema_ids)?;
-
-			Self::deposit_event(Event::DelegationUpdated {
-				provider: provider_msa_id,
-				delegator: delegator_msa_id,
-			});
+			Self::grant_permissions_for_schemas(delegator_id, provider_id, schema_ids)?;
+			Self::deposit_event(Event::DelegationUpdated { provider_id, delegator_id });
 
 			Ok(())
 		}
@@ -744,16 +756,11 @@ pub mod pallet {
 		) -> DispatchResult {
 			let delegator_key = ensure_signed(origin)?;
 			let delegator_msa_id = Self::ensure_valid_msa_key(&delegator_key)?;
+			let provider_id = ProviderId(provider_msa_id);
+			let delegator_id = DelegatorId(delegator_msa_id);
 
-			let provider_msa_id = Provider(provider_msa_id);
-			let delegator_msa_id = Delegator(delegator_msa_id);
-
-			Self::revoke_permissions_for_schemas(delegator_msa_id, provider_msa_id, schema_ids)?;
-
-			Self::deposit_event(Event::DelegationUpdated {
-				provider: provider_msa_id,
-				delegator: delegator_msa_id,
-			});
+			Self::revoke_permissions_for_schemas(delegator_id, provider_id, schema_ids)?;
+			Self::deposit_event(Event::DelegationUpdated { provider_id, delegator_id });
 
 			Ok(())
 		}
@@ -783,8 +790,7 @@ pub mod pallet {
 			// check for valid MSA is in SignedExtension.
 			match Self::get_msa_by_public_key(&who) {
 				Some(msa_id) => {
-					let delegator = Delegator(msa_id);
-					Self::delete_delegation_relationship(delegator);
+					Self::delete_delegation_relationship(DelegatorId(msa_id));
 					Self::delete_key_for_msa(msa_id, &who)?;
 					Self::deposit_event(Event::PublicKeyDeleted { key: who });
 					Self::deposit_event(Event::MsaRetired { msa_id });
@@ -842,11 +848,11 @@ impl<T: Config> Pallet<T> {
 
 	/// Adds a list of schema permissions to a delegation relationship.
 	pub fn grant_permissions_for_schemas(
-		delegator: Delegator,
-		provider: Provider,
+		delegator_id: DelegatorId,
+		provider_id: ProviderId,
 		schema_ids: Vec<SchemaId>,
 	) -> DispatchResult {
-		Self::try_mutate_delegation(delegator, provider, |delegation, is_new_delegation| {
+		Self::try_mutate_delegation(delegator_id, provider_id, |delegation, is_new_delegation| {
 			ensure!(!is_new_delegation, Error::<T>::DelegationNotFound);
 			Self::ensure_all_schema_ids_are_valid(&schema_ids)?;
 
@@ -858,28 +864,24 @@ impl<T: Config> Pallet<T> {
 
 	/// Revokes a list of schema permissions from a delegation relationship.
 	pub fn revoke_permissions_for_schemas(
-		delegator_msa_id: Delegator,
-		provider_mas_id: Provider,
+		delegator_id: DelegatorId,
+		provider_id: ProviderId,
 		schema_ids: Vec<SchemaId>,
 	) -> DispatchResult {
-		Self::try_mutate_delegation(
-			delegator_msa_id,
-			provider_mas_id,
-			|delegation, is_new_delegation| {
-				ensure!(!is_new_delegation, Error::<T>::DelegationNotFound);
-				Self::ensure_all_schema_ids_are_valid(&schema_ids)?;
+		Self::try_mutate_delegation(delegator_id, provider_id, |delegation, is_new_delegation| {
+			ensure!(!is_new_delegation, Error::<T>::DelegationNotFound);
+			Self::ensure_all_schema_ids_are_valid(&schema_ids)?;
 
-				let current_block = frame_system::Pallet::<T>::block_number();
+			let current_block = frame_system::Pallet::<T>::block_number();
 
-				PermittedDelegationSchemas::<T>::try_get_mut_schemas(
-					delegation,
-					schema_ids,
-					current_block,
-				)?;
+			PermittedDelegationSchemas::<T>::try_get_mut_schemas(
+				delegation,
+				schema_ids,
+				current_block,
+			)?;
 
-				Ok(())
-			},
-		)
+			Ok(())
+		})
 	}
 
 	/// Add a new key to the MSA
@@ -932,7 +934,7 @@ impl<T: Config> Pallet<T> {
 
 	/// Returns if provider is registered by checking if the [`ProviderToRegistryEntry`] contains the MSA id
 	pub fn is_registered_provider(msa_id: MessageSourceId) -> bool {
-		ProviderToRegistryEntry::<T>::contains_key(Provider(msa_id))
+		ProviderToRegistryEntry::<T>::contains_key(ProviderId(msa_id))
 	}
 
 	/// Checks that a provider and delegator keys are valid
@@ -947,7 +949,7 @@ impl<T: Config> Pallet<T> {
 	pub fn ensure_valid_registered_provider(
 		delegator_key: &T::AccountId,
 		provider_key: &T::AccountId,
-	) -> Result<(Provider, Delegator), DispatchError> {
+	) -> Result<(ProviderId, DelegatorId), DispatchError> {
 		let provider_msa_id = Self::ensure_valid_msa_key(provider_key)?;
 		let delegator_msa_id = Self::ensure_valid_msa_key(delegator_key)?;
 
@@ -998,15 +1000,15 @@ impl<T: Config> Pallet<T> {
 	/// * [`Error::ExceedsMaxSchemaGrantsPerDelegation`]
 	///
 	pub fn add_provider(
-		provider: Provider,
-		delegator: Delegator,
-		schemas: Vec<SchemaId>,
+		provider_id: ProviderId,
+		delegator_id: DelegatorId,
+		schema_ids: Vec<SchemaId>,
 	) -> DispatchResult {
-		Self::try_mutate_delegation(delegator, provider, |delegation, is_new_delegation| {
+		Self::try_mutate_delegation(delegator_id, provider_id, |delegation, is_new_delegation| {
 			ensure!(is_new_delegation, Error::<T>::DuplicateProvider);
-			Self::ensure_all_schema_ids_are_valid(&schemas)?;
+			Self::ensure_all_schema_ids_are_valid(&schema_ids)?;
 
-			PermittedDelegationSchemas::<T>::try_insert_schemas(delegation, schemas)?;
+			PermittedDelegationSchemas::<T>::try_insert_schemas(delegation, schema_ids)?;
 
 			Ok(())
 		})
@@ -1014,16 +1016,16 @@ impl<T: Config> Pallet<T> {
 
 	/// Mutates the delegation relationship storage item only if a value OK is returned.
 	pub fn try_mutate_delegation<R, E: From<DispatchError>>(
-		delegator: Delegator,
-		provider: Provider,
+		delegator_id: DelegatorId,
+		provider_id: ProviderId,
 		f: impl FnOnce(
 			&mut Delegation<SchemaId, T::BlockNumber, T::MaxSchemaGrantsPerDelegation>,
 			bool,
 		) -> Result<R, E>,
 	) -> Result<R, E> {
 		DelegatorAndProviderToDelegation::<T>::try_mutate_exists(
-			delegator,
-			provider,
+			delegator_id,
+			provider_id,
 			|maybe_delegation_info| {
 				let is_new = maybe_delegation_info.is_none();
 				let mut delegation = maybe_delegation_info.take().unwrap_or_default();
@@ -1034,6 +1036,37 @@ impl<T: Config> Pallet<T> {
 				})
 			},
 		)
+	}
+
+	/// Check that the delegator has an active delegation to the provider.
+	/// `block_number`: Provide `None` to know if the delegation is active at the current block.
+	///                 Provide Some(N) to know if the delegation was or will be active at block N.
+	///
+	/// # Errors
+	/// * [`Error::DelegationNotFound`]
+	/// * [`Error::DelegationRevoked`]
+	///
+	pub fn ensure_valid_delegation(
+		provider: ProviderId,
+		delegator: DelegatorId,
+		block_number: Option<T::BlockNumber>,
+	) -> Result<Delegation<SchemaId, T::BlockNumber, T::MaxSchemaGrantsPerDelegation>, DispatchError>
+	{
+		let info =
+			Self::get_delegation(delegator, provider).ok_or(Error::<T>::DelegationNotFound)?;
+		let current_block = frame_system::Pallet::<T>::block_number();
+		let requested_block = match block_number {
+			Some(block_number) => {
+				ensure!(current_block >= block_number, Error::<T>::DelegationNotFound);
+				block_number
+			},
+			None => current_block,
+		};
+		if info.revoked_at == T::BlockNumber::zero() {
+			return Ok(info)
+		}
+		ensure!(info.revoked_at >= requested_block, Error::<T>::DelegationRevoked);
+		Ok(info)
 	}
 
 	/// Deletes a key associated with a given MSA
@@ -1066,13 +1099,10 @@ impl<T: Config> Pallet<T> {
 	/// * [`Error::DelegationRevoked`]
 	/// * [`Error::DelegationNotFound`]
 	///
-	pub fn revoke_provider(
-		provider_msa_id: Provider,
-		delegator_msa_id: Delegator,
-	) -> DispatchResult {
+	pub fn revoke_provider(provider_id: ProviderId, delegator_id: DelegatorId) -> DispatchResult {
 		DelegatorAndProviderToDelegation::<T>::try_mutate_exists(
-			delegator_msa_id,
-			provider_msa_id,
+			delegator_id,
+			provider_id,
 			|maybe_info| -> DispatchResult {
 				let mut info = maybe_info.take().ok_or(Error::<T>::DelegationNotFound)?;
 
@@ -1092,7 +1122,7 @@ impl<T: Config> Pallet<T> {
 	}
 
 	/// Removes all delegations from the specified delegator MSA id to providers
-	pub fn delete_delegation_relationship(delegator: Delegator) {
+	pub fn delete_delegation_relationship(delegator: DelegatorId) {
 		_ = DelegatorAndProviderToDelegation::<T>::clear_prefix(delegator, u32::max_value(), None);
 	}
 
@@ -1130,8 +1160,8 @@ impl<T: Config> Pallet<T> {
 	/// * [`Error::SchemaNotGranted`]
 	///
 	pub fn ensure_valid_schema_grant(
-		provider: Provider,
-		delegator: Delegator,
+		provider: ProviderId,
+		delegator: DelegatorId,
 		schema_id: SchemaId,
 	) -> DispatchResult {
 		let provider_info = Self::ensure_valid_delegation(provider, delegator, None)?;
@@ -1150,8 +1180,8 @@ impl<T: Config> Pallet<T> {
 	/// * [`Error::SchemaNotGranted`]
 	///
 	pub fn get_granted_schemas_by_msa_id(
-		delegator: Delegator,
-		provider: Provider,
+		delegator: DelegatorId,
+		provider: ProviderId,
 	) -> Result<Option<Vec<SchemaId>>, DispatchError> {
 		let provider_info =
 			Self::get_delegation_of(delegator, provider).ok_or(Error::<T>::DelegationNotFound)?;
@@ -1280,8 +1310,8 @@ impl<T: Config> ProviderLookup for Pallet<T> {
 	type SchemaId = SchemaId;
 
 	fn get_delegation_of(
-		delegator: Delegator,
-		provider: Provider,
+		delegator: DelegatorId,
+		provider: ProviderId,
 	) -> Option<Delegation<SchemaId, Self::BlockNumber, Self::MaxSchemaGrantsPerDelegation>> {
 		Self::get_delegation(delegator, provider)
 	}
@@ -1301,8 +1331,8 @@ impl<T: Config> DelegationValidator for Pallet<T> {
 	/// * [`Error::DelegationRevoked`]
 	///
 	fn ensure_valid_delegation(
-		provider: Provider,
-		delegator: Delegator,
+		provider: ProviderId,
+		delegation: DelegatorId,
 		block_number: Option<T::BlockNumber>,
 	) -> Result<Delegation<SchemaId, T::BlockNumber, T::MaxSchemaGrantsPerDelegation>, DispatchError>
 	{
@@ -1334,8 +1364,8 @@ impl<T: Config> SchemaGrantValidator for Pallet<T> {
 	///
 	#[cfg(not(feature = "runtime-benchmarks"))]
 	fn ensure_valid_schema_grant(
-		provider: Provider,
-		delegator: Delegator,
+		provider: ProviderId,
+		delegator: DelegatorId,
 		schema_id: SchemaId,
 	) -> DispatchResult {
 		Self::ensure_valid_schema_grant(provider, delegator, schema_id)
@@ -1350,8 +1380,8 @@ impl<T: Config> SchemaGrantValidator for Pallet<T> {
 	/// this method to return a dummy account in case it does not exist
 	#[cfg(feature = "runtime-benchmarks")]
 	fn ensure_valid_schema_grant(
-		provider: Provider,
-		delegator: Delegator,
+		provider: ProviderId,
+		delegator: DelegatorId,
 		_schema_id: SchemaId,
 	) -> DispatchResult {
 		let provider_info = Self::get_delegation_of(delegator, provider);
@@ -1386,10 +1416,10 @@ impl<T: Config + Send + Sync> CheckFreeExtrinsicUse<T> {
 		provider_msa_id: &MessageSourceId,
 	) -> TransactionValidity {
 		const TAG_PREFIX: &str = "DelegatorDelegationRevocation";
-		let delegator_msa_id: Delegator = Pallet::<T>::ensure_valid_msa_key(account_id)
+		let delegator_msa_id: DelegatorId = Pallet::<T>::ensure_valid_msa_key(account_id)
 			.map_err(|_| InvalidTransaction::Custom(ValidityError::InvalidMsaKey as u8))?
 			.into();
-		let provider_msa_id = Provider(*provider_msa_id);
+		let provider_msa_id = ProviderId(*provider_msa_id);
 
 		Pallet::<T>::ensure_valid_delegation(provider_msa_id, delegator_msa_id, None)
 			.map_err(|_| InvalidTransaction::Custom(ValidityError::InvalidDelegation as u8))?;
@@ -1412,10 +1442,10 @@ impl<T: Config + Send + Sync> CheckFreeExtrinsicUse<T> {
 	) -> TransactionValidity {
 		const TAG_PREFIX: &str = "ProviderDelegationRevocation";
 
-		let provider_msa_id: Provider = Pallet::<T>::ensure_valid_msa_key(account_id)
+		let provider_msa_id: ProviderId = Pallet::<T>::ensure_valid_msa_key(account_id)
 			.map_err(|_| InvalidTransaction::Custom(ValidityError::InvalidMsaKey as u8))?
 			.into();
-		let delegator_msa_id = Delegator(*delegator_msa_id);
+		let delegator_msa_id = DelegatorId(*delegator_msa_id);
 
 		// Verify the delegation exists and is active
 		Pallet::<T>::ensure_valid_delegation(provider_msa_id, delegator_msa_id, None)
@@ -1435,7 +1465,7 @@ impl<T: Config + Send + Sync> CheckFreeExtrinsicUse<T> {
 		key: &T::AccountId,
 	) -> TransactionValidity {
 		const TAG_PREFIX: &str = "KeyRevocation";
-		let _msa_id: Delegator = Pallet::<T>::ensure_valid_msa_key(key)
+		let _msa_id: DelegatorId = Pallet::<T>::ensure_valid_msa_key(key)
 			.map_err(|_| InvalidTransaction::Custom(ValidityError::InvalidMsaKey as u8))?
 			.into();
 		return ValidTransaction::with_tag_prefix(TAG_PREFIX).and_provides(account_id).build()

--- a/pallets/msa/src/runtime-api/src/lib.rs
+++ b/pallets/msa/src/runtime-api/src/lib.rs
@@ -31,9 +31,9 @@ sp_api::decl_runtime_apis! {
 		// fn get_msa_keys(msa_id: MessageSourceId) ->	Vec<KeyInfoResponse<AccountId>>;
 
 		/// Check to see if a delegation existed between the given delegator and provider at a given block
-		fn has_delegation(delegator: Delegator, provider: Provider, block_number: Option<BlockNumber>) -> bool;
+		fn has_delegation(delegator: DelegatorId, provider: ProviderId, block_number: Option<BlockNumber>) -> bool;
 
 		/// Get the list of schema ids (if any) that exist in any delegation between the delegator and provider
-		fn get_granted_schemas_by_msa_id(delegator: Delegator, provider: Provider) -> Option<Vec<SchemaId>>;
+		fn get_granted_schemas_by_msa_id(delegator: DelegatorId, provider: ProviderId) -> Option<Vec<SchemaId>>;
 	}
 }

--- a/pallets/msa/src/tests.rs
+++ b/pallets/msa/src/tests.rs
@@ -17,7 +17,7 @@ use crate::{
 
 use common_primitives::{
 	msa::{
-		Delegation, DelegationValidator, Delegator, MessageSourceId, Provider,
+		Delegation, DelegationValidator, DelegatorId, MessageSourceId, ProviderId,
 		ProviderRegistryEntry,
 	},
 	node::BlockNumber,
@@ -636,8 +636,8 @@ pub fn add_provider_to_msa_is_success() {
 			add_provider_payload
 		));
 
-		let provider = Provider(provider_msa);
-		let delegator = Delegator(delegator_msa);
+		let provider = ProviderId(provider_msa);
+		let delegator = DelegatorId(delegator_msa);
 
 		assert_eq!(
 			Msa::get_delegation(delegator, provider),
@@ -832,7 +832,7 @@ pub fn create_sponsored_account_with_delegation_with_valid_input_should_succeed(
 		let delegator_msa =
 			Msa::get_msa_by_public_key(&AccountId32::new(delegator_account.0)).unwrap();
 
-		let provider_info = Msa::get_delegation(Delegator(2), Provider(1));
+		let provider_info = Msa::get_delegation(DelegatorId(2), ProviderId(1));
 		assert_eq!(provider_info.is_some(), true);
 
 		let events_occured = System::events();
@@ -1102,8 +1102,8 @@ pub fn revoke_provider_is_successful() {
 		let delegator_msa =
 			Msa::ensure_valid_msa_key(&AccountId32::new(delegator_account.0)).unwrap();
 
-		let provider = Provider(provider_msa);
-		let delegator = Delegator(delegator_msa);
+		let provider = ProviderId(provider_msa);
+		let delegator = DelegatorId(delegator_msa);
 
 		assert_ok!(Msa::revoke_provider(provider, delegator));
 
@@ -1253,7 +1253,7 @@ pub fn revoke_delegation_by_provider_happy_path() {
 		assert_ok!(Msa::revoke_delegation_by_provider(Origin::signed(provider_key.into()), 2u64));
 
 		// 6. verify that the provider is revoked
-		let provider_info = Msa::get_delegation(Delegator(2), Provider(1));
+		let provider_info = Msa::get_delegation(DelegatorId(2), ProviderId(1));
 		assert_eq!(
 			provider_info,
 			Some(Delegation { revoked_at: 26, schema_permissions: Default::default() })
@@ -1261,7 +1261,8 @@ pub fn revoke_delegation_by_provider_happy_path() {
 
 		// 7. verify the event
 		System::assert_last_event(
-			Event::DelegationRevoked { provider: Provider(1), delegator: Delegator(2) }.into(),
+			Event::DelegationRevoked { provider_id: ProviderId(1), delegator_id: DelegatorId(2) }
+				.into(),
 		);
 	})
 }
@@ -1297,8 +1298,8 @@ pub fn revoke_delegation_by_provider_does_nothing_when_no_msa() {
 #[test]
 pub fn valid_delegation() {
 	new_test_ext().execute_with(|| {
-		let provider = Provider(1);
-		let delegator = Delegator(2);
+		let provider = ProviderId(1);
+		let delegator = DelegatorId(2);
 
 		assert_ok!(Msa::add_provider(provider, delegator, Vec::default()));
 
@@ -1311,8 +1312,8 @@ pub fn valid_delegation() {
 #[test]
 pub fn delegation_not_found() {
 	new_test_ext().execute_with(|| {
-		let provider = Provider(1);
-		let delegator = Delegator(2);
+		let provider = ProviderId(1);
+		let delegator = DelegatorId(2);
 
 		assert_noop!(
 			Msa::ensure_valid_delegation(provider, delegator, None),
@@ -1324,8 +1325,8 @@ pub fn delegation_not_found() {
 #[test]
 pub fn delegation_expired() {
 	new_test_ext().execute_with(|| {
-		let provider = Provider(1);
-		let delegator = Delegator(2);
+		let provider = ProviderId(1);
+		let delegator = DelegatorId(2);
 
 		assert_ok!(Msa::add_provider(provider, delegator, Vec::default()));
 
@@ -1720,8 +1721,8 @@ pub fn valid_schema_grant() {
 	new_test_ext().execute_with(|| {
 		set_schema_count::<Test>(2);
 
-		let provider = Provider(1);
-		let delegator = Delegator(2);
+		let provider = ProviderId(1);
+		let delegator = DelegatorId(2);
 		let schema_grants = vec![1, 2];
 		assert_ok!(Msa::add_provider(provider, delegator, schema_grants));
 
@@ -1740,8 +1741,8 @@ pub fn error_invalid_schema_id_table() {
 	new_test_ext().execute_with(|| {
 		set_schema_count::<Test>(12);
 
-		let provider = Provider(1);
-		let delegator = Delegator(2);
+		let provider = ProviderId(1);
+		let delegator = DelegatorId(2);
 		let test_cases: [TestCase<Error<Test>>; 3] = [
 			TestCase { schema: vec![15, 16], expected: Error::<Test>::InvalidSchemaId },
 			TestCase { schema: vec![16, 17], expected: Error::<Test>::InvalidSchemaId },
@@ -1758,8 +1759,8 @@ pub fn error_exceeding_max_schema_under_minimum_schema_grants() {
 	new_test_ext().execute_with(|| {
 		set_schema_count::<Test>(16);
 
-		let provider = Provider(1);
-		let delegator = Delegator(2);
+		let provider = ProviderId(1);
+		let delegator = DelegatorId(2);
 		assert_noop!(
 			Msa::add_provider(provider, delegator, (1..32 as u16).collect::<Vec<_>>()),
 			Error::<Test>::ExceedsMaxSchemaGrantsPerDelegation
@@ -1772,8 +1773,8 @@ pub fn error_schema_not_granted() {
 	new_test_ext().execute_with(|| {
 		set_schema_count::<Test>(2);
 
-		let provider = Provider(1);
-		let delegator = Delegator(2);
+		let provider = ProviderId(1);
+		let delegator = DelegatorId(2);
 		let schema_grants = vec![1, 2];
 		assert_ok!(Msa::add_provider(provider, delegator, schema_grants));
 
@@ -1789,8 +1790,8 @@ pub fn error_schema_not_granted() {
 #[test]
 pub fn error_not_delegated_rpc() {
 	new_test_ext().execute_with(|| {
-		let provider = Provider(1);
-		let delegator = Delegator(2);
+		let provider = ProviderId(1);
+		let delegator = DelegatorId(2);
 		assert_err!(
 			Msa::get_granted_schemas_by_msa_id(delegator, provider),
 			Error::<Test>::DelegationNotFound
@@ -1801,8 +1802,8 @@ pub fn error_not_delegated_rpc() {
 #[test]
 pub fn error_schema_not_granted_rpc() {
 	new_test_ext().execute_with(|| {
-		let provider = Provider(1);
-		let delegator = Delegator(2);
+		let provider = ProviderId(1);
+		let delegator = DelegatorId(2);
 		assert_ok!(Msa::add_provider(provider, delegator, Vec::default()));
 		assert_err!(
 			Msa::get_granted_schemas_by_msa_id(delegator, provider),
@@ -1816,8 +1817,8 @@ pub fn schema_granted_success_rpc() {
 	new_test_ext().execute_with(|| {
 		set_schema_count::<Test>(2);
 
-		let provider = Provider(1);
-		let delegator = Delegator(2);
+		let provider = ProviderId(1);
+		let delegator = DelegatorId(2);
 		let schema_grants = vec![1, 2];
 		assert_ok!(Msa::add_provider(provider, delegator, schema_grants));
 		let schemas_granted = Msa::get_granted_schemas_by_msa_id(delegator, provider);
@@ -1981,8 +1982,8 @@ pub fn add_provider_expired() {
 #[test]
 pub fn delegation_expired_long_back() {
 	new_test_ext().execute_with(|| {
-		let provider = Provider(1);
-		let delegator = Delegator(2);
+		let provider = ProviderId(1);
+		let delegator = DelegatorId(2);
 
 		assert_ok!(Msa::add_provider(provider, delegator, Vec::default()));
 
@@ -2034,7 +2035,7 @@ pub fn ensure_all_schema_ids_are_valid_success() {
 #[test]
 pub fn is_registered_provider_is_true() {
 	new_test_ext().execute_with(|| {
-		let provider = Provider(1);
+		let provider = ProviderId(1);
 		let provider_name = Vec::from("frequency".as_bytes()).try_into().unwrap();
 
 		let provider_meta = ProviderRegistryEntry { provider_name };
@@ -2267,8 +2268,8 @@ pub fn add_msa_key_replay_fails() {
 #[test]
 fn grant_permissions_for_schemas_errors_when_no_delegation() {
 	new_test_ext().execute_with(|| {
-		let delegator = Delegator(2);
-		let provider = Provider(1);
+		let delegator = DelegatorId(2);
+		let provider = ProviderId(1);
 		let schema_ids = vec![1, 2];
 		let result = Msa::grant_permissions_for_schemas(delegator, provider, schema_ids);
 
@@ -2280,8 +2281,8 @@ fn grant_permissions_for_schemas_errors_when_no_delegation() {
 fn grant_permissions_for_schemas_errors_when_invalid_schema_id() {
 	new_test_ext().execute_with(|| {
 		set_schema_count::<Test>(1);
-		let delegator = Delegator(2);
-		let provider = Provider(1);
+		let delegator = DelegatorId(2);
+		let provider = ProviderId(1);
 		let schema_grants = vec![1];
 
 		assert_ok!(Msa::add_provider(provider, delegator, schema_grants));
@@ -2298,8 +2299,8 @@ fn grant_permissions_for_schemas_errors_when_exceeds_max_schema_grants() {
 	new_test_ext().execute_with(|| {
 		set_schema_count::<Test>(31);
 
-		let delegator = Delegator(2);
-		let provider = Provider(1);
+		let delegator = DelegatorId(2);
+		let provider = ProviderId(1);
 		let schema_grants = vec![1];
 
 		assert_ok!(Msa::add_provider(provider, delegator, schema_grants));
@@ -2316,8 +2317,8 @@ fn grant_permissions_for_schema_success() {
 	new_test_ext().execute_with(|| {
 		set_schema_count::<Test>(3);
 
-		let delegator = Delegator(2);
-		let provider = Provider(1);
+		let delegator = DelegatorId(2);
+		let provider = ProviderId(1);
 		let schema_grants = vec![1];
 
 		assert_ok!(Msa::add_provider(provider, delegator, schema_grants));
@@ -2359,7 +2360,7 @@ fn grant_schema_permissions_errors_when_no_key_exists() {
 		let (delegator_pair, _) = sr25519::Pair::generate();
 		let delegator_account = delegator_pair.public();
 
-		let provider = Provider(2);
+		let provider = ProviderId(2);
 		let schema_ids: Vec<SchemaId> = vec![1];
 
 		assert_noop!(
@@ -2379,7 +2380,7 @@ fn grant_schema_permissions_errors_when_delegation_not_found_error() {
 		let (delegator_pair, _) = sr25519::Pair::generate();
 		let delegator_account = delegator_pair.public();
 
-		let provider = Provider(2);
+		let provider = ProviderId(2);
 		let schema_ids: Vec<SchemaId> = vec![1];
 
 		assert_ok!(Msa::create(Origin::signed(delegator_account.into())));
@@ -2409,8 +2410,8 @@ fn grant_schema_permissions_success() {
 		assert_ok!(Msa::create(Origin::signed(delegator_account.into())));
 		assert_ok!(Msa::create(Origin::signed(provider_account.into())));
 
-		let delegator = Delegator(1);
-		let provider = Provider(2);
+		let delegator = DelegatorId(1);
+		let provider = ProviderId(2);
 
 		assert_ok!(Msa::add_provider(provider, delegator, Default::default()));
 
@@ -2486,8 +2487,8 @@ fn schema_permissions_trait_impl_try_insert_schemas_errors_when_exceeds_max_sche
 #[test]
 fn try_mutate_delegation_success() {
 	new_test_ext().execute_with(|| {
-		let delegator = Delegator(1);
-		let provider = Provider(2);
+		let delegator = DelegatorId(1);
+		let provider = ProviderId(2);
 
 		assert_ok!(Msa::try_mutate_delegation(
 			delegator,
@@ -2510,8 +2511,8 @@ fn revoke_permissions_for_schema_success() {
 	new_test_ext().execute_with(|| {
 		set_schema_count::<Test>(3);
 
-		let delegator = Delegator(2);
-		let provider = Provider(1);
+		let delegator = DelegatorId(2);
+		let provider = ProviderId(1);
 		let schema_grants = vec![1];
 
 		assert_ok!(Msa::add_provider(provider, delegator, schema_grants));
@@ -2550,8 +2551,8 @@ fn revoke_permissions_for_schema_success() {
 #[test]
 fn revoke_permissions_for_schemas_errors_when_no_delegation() {
 	new_test_ext().execute_with(|| {
-		let delegator = Delegator(2);
-		let provider = Provider(1);
+		let delegator = DelegatorId(2);
+		let provider = ProviderId(1);
 		let schema_ids = vec![1, 2];
 		let result = Msa::revoke_permissions_for_schemas(delegator, provider, schema_ids);
 
@@ -2564,8 +2565,8 @@ fn revoke_permissions_for_schemas_errors_when_schema_does_not_exist_in_list_of_s
 	new_test_ext().execute_with(|| {
 		set_schema_count::<Test>(31);
 
-		let delegator = Delegator(2);
-		let provider = Provider(1);
+		let delegator = DelegatorId(2);
+		let provider = ProviderId(1);
 		let schema_grants = vec![1, 2];
 
 		assert_ok!(Msa::add_provider(provider, delegator, schema_grants));
@@ -2614,8 +2615,8 @@ fn revoke_schema_permissions_success() {
 		assert_ok!(Msa::create(Origin::signed(delegator_account.into())));
 		assert_ok!(Msa::create(Origin::signed(provider_account.into())));
 
-		let delegator = Delegator(1);
-		let provider = Provider(2);
+		let delegator = DelegatorId(1);
+		let provider = ProviderId(2);
 
 		assert_ok!(Msa::add_provider(provider, delegator, vec![1, 2]));
 
@@ -2637,7 +2638,7 @@ fn revoke_schema_permissions_errors_when_no_key_exists() {
 		let (delegator_pair, _) = sr25519::Pair::generate();
 		let delegator_account = delegator_pair.public();
 
-		let provider = Provider(2);
+		let provider = ProviderId(2);
 		let schema_ids: Vec<SchemaId> = vec![1];
 
 		assert_noop!(

--- a/pallets/msa/src/tests.rs
+++ b/pallets/msa/src/tests.rs
@@ -646,8 +646,8 @@ pub fn add_provider_to_msa_is_success() {
 
 		System::assert_last_event(
 			Event::DelegationGranted {
-				delegator: delegator_msa.into(),
-				provider: provider_msa.into(),
+				delegator_id: delegator_msa.into(),
+				provider_id: provider_msa.into(),
 			}
 			.into(),
 		);
@@ -845,8 +845,8 @@ pub fn create_sponsored_account_with_delegation_with_valid_input_should_succeed(
 		assert_eq!(
 			provider_event.event,
 			Event::DelegationGranted {
-				provider: provider_msa.into(),
-				delegator: delegator_msa.into()
+				provider_id: provider_msa.into(),
+				delegator_id: delegator_msa.into()
 			}
 			.into()
 		);
@@ -1066,7 +1066,7 @@ pub fn revoke_delegation_by_delegator_is_successful() {
 		));
 
 		System::assert_last_event(
-			Event::DelegationRevoked { delegator: 1.into(), provider: 2.into() }.into(),
+			Event::DelegationRevoked { delegator_id: 1.into(), provider_id: 2.into() }.into(),
 		);
 	});
 }
@@ -2410,20 +2410,20 @@ fn grant_schema_permissions_success() {
 		assert_ok!(Msa::create(Origin::signed(delegator_account.into())));
 		assert_ok!(Msa::create(Origin::signed(provider_account.into())));
 
-		let delegator = DelegatorId(1);
-		let provider = ProviderId(2);
+		let delegator_id = DelegatorId(1);
+		let provider_id = ProviderId(2);
 
-		assert_ok!(Msa::add_provider(provider, delegator, Default::default()));
+		assert_ok!(Msa::add_provider(provider_id, delegator_id, Default::default()));
 
 		let schema_ids: Vec<SchemaId> = vec![2];
 
 		assert_ok!(Msa::grant_schema_permissions(
 			Origin::signed(delegator_account.into()),
-			provider.into(),
+			provider_id.into(),
 			schema_ids,
 		));
 
-		System::assert_last_event(Event::DelegationUpdated { provider, delegator }.into());
+		System::assert_last_event(Event::DelegationUpdated { provider_id, delegator_id }.into());
 	});
 }
 
@@ -2615,20 +2615,20 @@ fn revoke_schema_permissions_success() {
 		assert_ok!(Msa::create(Origin::signed(delegator_account.into())));
 		assert_ok!(Msa::create(Origin::signed(provider_account.into())));
 
-		let delegator = DelegatorId(1);
-		let provider = ProviderId(2);
+		let delegator_id = DelegatorId(1);
+		let provider_id = ProviderId(2);
 
-		assert_ok!(Msa::add_provider(provider, delegator, vec![1, 2]));
+		assert_ok!(Msa::add_provider(provider_id, delegator_id, vec![1, 2]));
 
 		let schema_ids_to_revoke: Vec<SchemaId> = vec![2];
 
 		assert_ok!(Msa::revoke_schema_permissions(
 			Origin::signed(delegator_account.into()),
-			provider.into(),
+			provider_id.into(),
 			schema_ids_to_revoke,
 		));
 
-		System::assert_last_event(Event::DelegationUpdated { provider, delegator }.into());
+		System::assert_last_event(Event::DelegationUpdated { provider_id, delegator_id }.into());
 	});
 }
 

--- a/pallets/msa/src/tests.rs
+++ b/pallets/msa/src/tests.rs
@@ -16,10 +16,7 @@ use crate::{
 };
 
 use common_primitives::{
-	msa::{
-		Delegation, DelegationValidator, DelegatorId, MessageSourceId, ProviderId,
-		ProviderRegistryEntry,
-	},
+	msa::{Delegation, DelegatorId, MessageSourceId, ProviderId, ProviderRegistryEntry},
 	node::BlockNumber,
 	schema::{SchemaId, SchemaValidator},
 	utils::wrap_binary_data,

--- a/pallets/msa/src/types.rs
+++ b/pallets/msa/src/types.rs
@@ -7,7 +7,7 @@ use codec::{Decode, Encode};
 use core::fmt::Debug;
 
 pub use common_primitives::msa::{
-	Delegation, Delegator, KeyInfoResponse, MessageSourceId, Provider,
+	Delegation, DelegatorId, KeyInfoResponse, MessageSourceId, ProviderId,
 };
 use common_primitives::{node::BlockNumber, schema::SchemaId};
 

--- a/runtime/frequency-rococo/src/lib.rs
+++ b/runtime/frequency-rococo/src/lib.rs
@@ -812,14 +812,14 @@ impl_runtime_apis! {
 		// 	Ok(Msa::fetch_msa_keys(msa_id))
 		// }
 
-		fn has_delegation(delegator: Delegator, provider: Provider, block_number: Option<BlockNumber>) -> bool {
+		fn has_delegation(delegator: DelegatorId, provider: ProviderId, block_number: Option<BlockNumber>) -> bool {
 			match Msa::ensure_valid_delegation(provider, delegator, block_number) {
 				Ok(_) => true,
 				Err(_) => false,
 			}
 		}
 
-		fn get_granted_schemas_by_msa_id(delegator: Delegator, provider: Provider) -> Option<Vec<SchemaId>> {
+		fn get_granted_schemas_by_msa_id(delegator: DelegatorId, provider: ProviderId) -> Option<Vec<SchemaId>> {
 			match Msa::get_granted_schemas_by_msa_id(delegator, provider) {
 				Ok(x) => x,
 				Err(_) => None,

--- a/runtime/frequency/src/lib.rs
+++ b/runtime/frequency/src/lib.rs
@@ -860,14 +860,14 @@ impl_runtime_apis! {
 		// 	Ok(Msa::fetch_msa_keys(msa_id))
 		// }
 
-		fn has_delegation(delegator: Delegator, provider: Provider, block_number: Option<BlockNumber>) -> bool {
+		fn has_delegation(delegator: DelegatorId, provider: ProviderId, block_number: Option<BlockNumber>) -> bool {
 			match Msa::ensure_valid_delegation(provider, delegator, block_number) {
 				Ok(_) => true,
 				Err(_) => false,
 			}
 		}
 
-		fn get_granted_schemas_by_msa_id(delegator: Delegator, provider: Provider) -> Option<Vec<SchemaId>> {
+		fn get_granted_schemas_by_msa_id(delegator: DelegatorId, provider: ProviderId) -> Option<Vec<SchemaId>> {
 			match Msa::get_granted_schemas_by_msa_id(delegator, provider) {
 				Ok(x) => x,
 				Err(_) => None,


### PR DESCRIPTION
# Goal
The goal of this PR is to rename Provider to ProviderId and Delegator to DelegatorId

Closes #602 

# Discussion
* Performs the renames
* Also makes the RPCs consistent with each other by always using DelegatorId/ProviderId, though without renaming any parameters.

# Checklist
- [x] Custom RPC OR Runtime API added/changed? Updated js/api-augment.
- [x] Design doc(s) updated

## Not applicable
- Chain spec updated
- Benchmarks added
- Tests added
