### PR TITLE
Replaced deprecated alias

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -136,4 +136,4 @@ build-mainnet-release:
 
 PHONY: test
 test:
-	cargo test --all --locked --features all-frequency-features
+	cargo test --workspace --locked --features all-frequency-features


### PR DESCRIPTION
From Cargo documentation:

```
--workspace
Test all members in the workspace.
--all
Deprecated alias for --workspace.
```