### PR TITLE
[Part1] Remove generic ```BlockNumber``` types to concrete types for client side 

### DIFF
--- a/js/api-augment/definitions/messages.ts
+++ b/js/api-augment/definitions/messages.ts
@@ -58,7 +58,7 @@ export default {
                 type: "BlockNumber",
               },
             ],
-            type: "Vec<MessageResponse<BlockNumber>>",
+            type: "Vec<MessageResponse>",
           },
           get_schema_by_id: {
             description: "Retrieve a schema by id",

--- a/pallets/messages/src/lib.rs
+++ b/pallets/messages/src/lib.rs
@@ -350,11 +350,12 @@ impl<T: Config> Pallet<T> {
 		schema_id: SchemaId,
 		schema_payload_location: PayloadLocation,
 		block_number: T::BlockNumber,
-	) -> Vec<MessageResponse<T::BlockNumber>> {
+	) -> Vec<MessageResponse> {
+		let block_number_value: u32 = block_number.try_into().unwrap_or_default();
 		<Messages<T>>::get(block_number, schema_id)
 			.into_inner()
 			.iter()
-			.map(|msg| msg.map_to_response(block_number, schema_payload_location))
+			.map(|msg| msg.map_to_response(block_number_value, schema_payload_location))
 			.collect()
 	}
 

--- a/pallets/messages/src/rpc/src/lib.rs
+++ b/pallets/messages/src/rpc/src/lib.rs
@@ -37,8 +37,8 @@ pub trait MessagesApi<BlockNumber> {
 	fn get_messages_by_schema_id(
 		&self,
 		schema_id: SchemaId,
-		pagination: BlockPaginationRequest<BlockNumber>,
-	) -> RpcResult<BlockPaginationResponse<BlockNumber, MessageResponse<BlockNumber>>>;
+		pagination: BlockPaginationRequest,
+	) -> RpcResult<BlockPaginationResponse<MessageResponse>>;
 }
 
 /// The client handler for the API used by Frequency Service RPC with `jsonrpsee`
@@ -82,8 +82,8 @@ where
 	fn get_messages_by_schema_id(
 		&self,
 		schema_id: SchemaId,
-		pagination: BlockPaginationRequest<BlockNumber>,
-	) -> RpcResult<BlockPaginationResponse<BlockNumber, MessageResponse<BlockNumber>>> {
+		pagination: BlockPaginationRequest,
+	) -> RpcResult<BlockPaginationResponse<MessageResponse>> {
 		// Request Validation
 		ensure!(pagination.validate(), MessageRpcError::InvalidPaginationRequest);
 
@@ -110,7 +110,7 @@ where
 
 		'loops: for bid in from..to {
 			let block_number: BlockNumber = bid.into();
-			let list: Vec<MessageResponse<BlockNumber>> = api
+			let list: Vec<MessageResponse> = api
 				.get_messages_by_schema_and_block(
 					&at,
 					schema.schema_id,
@@ -125,7 +125,7 @@ where
 				response.content.push(list[i as usize].clone());
 
 				if response.check_end_condition_and_set_next_pagination(
-					block_number,
+					block_number.try_into().unwrap_or_default(),
 					i,
 					list_size,
 					&pagination,

--- a/pallets/messages/src/rpc/src/tests/mod.rs
+++ b/pallets/messages/src/rpc/src/tests/mod.rs
@@ -11,7 +11,7 @@ use substrate_test_runtime_client::runtime::Block;
 const SCHEMA_ID_EMPTY: u16 = 1;
 const SCHEMA_ID_HAS_MESSAGES: u16 = 2;
 
-fn test_messages() -> Vec<MessageResponse<BlockNumber>> {
+fn test_messages() -> Vec<MessageResponse> {
 	vec![
 		MessageResponse {
 			payload: None,
@@ -49,7 +49,7 @@ sp_api::mock_impl_runtime_apis! {
 		}
 
 		fn get_messages_by_schema_and_block(schema_id: SchemaId, _schema_payload_location: PayloadLocation, _block_number: BlockNumber) ->
-			Vec<MessageResponse<BlockNumber>> {
+			Vec<MessageResponse> {
 				match schema_id {
 					SCHEMA_ID_HAS_MESSAGES => test_messages(),
 					_ => vec![]

--- a/pallets/messages/src/runtime-api/src/lib.rs
+++ b/pallets/messages/src/runtime-api/src/lib.rs
@@ -30,7 +30,7 @@ sp_api::decl_runtime_apis! {
 	{
 		/// Retrieve the messages for a particular schema and block number
 		fn get_messages_by_schema_and_block(schema_id: SchemaId, schema_payload_location: PayloadLocation, block_number: BlockNumber) ->
-			Vec<MessageResponse<BlockNumber>>;
+			Vec<MessageResponse>;
 
 		/// Retrieve a schema by id
 		fn get_schema_by_id(schema_id: SchemaId) -> Option<SchemaResponse>;

--- a/pallets/messages/src/types.rs
+++ b/pallets/messages/src/types.rs
@@ -1,5 +1,7 @@
 use codec::{Decode, Encode};
-use common_primitives::{messages::MessageResponse, msa::MessageSourceId, schema::PayloadLocation};
+use common_primitives::{
+	messages::MessageResponse, msa::MessageSourceId, node::BlockNumber, schema::PayloadLocation,
+};
 use frame_support::{traits::Get, BoundedVec};
 use scale_info::TypeInfo;
 use sp_std::prelude::*;
@@ -32,11 +34,11 @@ where
 	MaxDataSize: Get<u32> + Clone,
 {
 	/// Helper function to handle response type [`MessageResponse`] depending on the Payload Location (on chain or IPFS)
-	pub fn map_to_response<BlockNumber>(
+	pub fn map_to_response(
 		&self,
 		block_number: BlockNumber,
 		payload_location: PayloadLocation,
-	) -> MessageResponse<BlockNumber> {
+	) -> MessageResponse {
 		match payload_location {
 			PayloadLocation::OnChain => MessageResponse {
 				provider_msa_id: self.provider_msa_id,

--- a/runtime/frequency-rococo/src/lib.rs
+++ b/runtime/frequency-rococo/src/lib.rs
@@ -791,7 +791,7 @@ impl_runtime_apis! {
 	// Unfinished runtime APIs
 	impl pallet_messages_runtime_api::MessagesRuntimeApi<Block, BlockNumber> for Runtime {
 		fn get_messages_by_schema_and_block(schema_id: SchemaId, schema_payload_location: PayloadLocation, block_number: BlockNumber) ->
-			Vec<MessageResponse<BlockNumber>> {
+			Vec<MessageResponse> {
 			Messages::get_messages_by_schema_and_block(schema_id, schema_payload_location, block_number)
 		}
 

--- a/runtime/frequency/src/lib.rs
+++ b/runtime/frequency/src/lib.rs
@@ -839,7 +839,7 @@ impl_runtime_apis! {
 	// Unfinished runtime APIs
 	impl pallet_messages_runtime_api::MessagesRuntimeApi<Block, BlockNumber> for Runtime {
 		fn get_messages_by_schema_and_block(schema_id: SchemaId, schema_payload_location: PayloadLocation, block_number: BlockNumber,) ->
-			Vec<MessageResponse<BlockNumber>> {
+			Vec<MessageResponse> {
 			Messages::get_messages_by_schema_and_block(schema_id, schema_payload_location, block_number)
 		}
 


### PR DESCRIPTION
# Goal
The goal of this PR is to Remove generic ```BlockNumber``` types to concrete types for client side 

Part of: 

# Checklist
- [ ] Chain spec updated
- [ ] Custom RPC OR Runtime API added/changed? Updated js/api-augment.
- [ ] Design doc(s) updated
- [ ] Tests added
- [ ] Benchmarks added
- [ ] Weights updated
