### PR TITLE
Cleanup before Mainnet

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,31 +1,3 @@
 # CONTRIBUTING
 
 For contributing guidelines see the [Project Liberty Contributing Guidelines](https://github.com/LibertyDSNP/meta/blob/main/CONTRIBUTING.md).
-
-
-# Path to Beta
-
-While we are trying to get Frequency off the ground, the work is slightly different than with a stable project.
-Here are our rules of thumb
-How we work while trying to get off the ground.
-Expect this to change as we stabilize.
-
-- Issues should often be MORE than one PR
-  - Smaller PRs are easier to review
-  - Great if your story is blocking others and a part of your story complete can unblock them
-  - Consider breaking up into:
-    - Core Logic
-    - Addition PR Feedback
-    - Benchmarks
-    - Smaller side logic
-    - Etc...
-- PR Reviews
-  - We want to get them through fast.
-  -  Prefix Blocking Comments with "Blocking:" (or other indication that it is important)
-  - Types of Comments:
-    - Something that MUST be changed before being merged. (Mark PR review as "Request Changes")
-    - Something that needs to be done before the Issue is closed, but the PR can be merged. PR Author should add it to a TODO list in the Issue.
-    - Something that should be in a SEPARATE issue. PR Author creates a new issue.
-    - Suggestions. Things that could be done differently, but only if the PR Author wants to.
-- Internals can change much easier than externals
-  - Example: Extrinsic interface changes should be vetted MORE than internal code (for now).

--- a/Makefile
+++ b/Makefile
@@ -43,12 +43,6 @@ offboard:
 specs-rococo-2000:
 	./scripts/generate_specs.sh 2000 rococo-2000 release
 
-specs-rococo-4044:
-	./scripts/generate_specs.sh 4044 rococo-4044 release
-
-specs-mainnet:
-	./scripts/generate_specs.sh 999 mainnet release
-
 specs-rococo-local:
 	./scripts/generate_relay_specs.sh
 

--- a/README.md
+++ b/README.md
@@ -235,27 +235,6 @@ cargo test --all-features --workspace --release
 make benchmarks
 ```
 
-## Generate Specs
-
-To build spec against specific chain config specify chain name in the command above.
-
-1. Update `node/**/chain_spec.rs` with required spec config, defaults to `para_id:2000`
-   and relay chain to be `rococo_local.json` with `protocol_id:frequency-local`
-1. Export the chain spec
-    ```sh
-    cargo run --release build-spec --disable-default-bootnode > ./res/genesis/local/frequency-spec-rococo.json
-    ```
-1. Export the raw chain spec
-    ```sh
-    cargo run --release build-spec --raw --disable-default-bootnode --chain ./res/genesis/local/frequency-spec-rococo.json > ./res/genesis/local/rococo-local-frequency-2000-raw.json
-    ```
-
-Alternatively, run the following to generate plain and raw frequency spec along with
-genesis state and WASM:
-
--   `make specs-rococo-2000` for Rococo local testnet
--   `make specs-rococo-4044` for Rococo public testnet
-
 # Format, Lint and Audit Source Code
 
 -   Format code with `make format` according to style guidelines and configurations in `rustfmt.toml`.
@@ -281,7 +260,7 @@ make upgrade-local
 
 The current scripts follow this process for upgrading locally:
 
-1. Build new runtime and generate the compressed wasm
+1. Build new runtime and generate the compressed wasm: `make specs-rococo-2000`
 2. Call `authorizeUpgrade` extrinsic from parachain system to initiate the upgrade.
 3. Call `enactAuthorizedUpgrade` extrinsic from parachain system to enact the upgrade.
 4. For testnet and mainnet, the upgrade is done slightly differently using `scheduler` and enactment is scheduled for a specific block number in the future.

--- a/README.md
+++ b/README.md
@@ -1,3 +1,16 @@
+<!-- PROJECT SHIELDS -->
+<!--
+*** I'm using markdown "reference style" links for readability.
+*** Reference links are enclosed in brackets [ ] instead of parentheses ( ).
+*** See the bottom of this document for the declaration of the reference variables
+*** for contributors-url, forks-url, etc. This is an optional, concise syntax you may use.
+*** https://www.markdownguide.org/basic-syntax/#reference-style-links
+-->
+[![Release][release-shield]][release-url]
+[![Docker][docker-shield]][docker-url]
+[![Issues][issues-shield]][issues-url]
+[![Codecov][codecov-shield]][codecov-url]
+
 Frequency is a Polkadot parachain designed to run Decentralized Social Network Protocol (DSNP), but it could run other things.
 
 # Table of Contents
@@ -289,3 +302,15 @@ lsof -i -P | grep -i "listen"
 # View ports Frequency node is listening on
 lsof -i -P | grep -i "listen" | grep frequency
 ```
+
+<!-- MARKDOWN LINKS & IMAGES -->
+<!-- https://www.markdownguide.org/basic-syntax/#reference-style-links -->
+[issues-shield]: https://img.shields.io/github/issues/LibertyDSNP/frequency.svg?style=for-the-badge
+[issues-url]: https://github.com/LibertyDSNP/frequency/issues
+[codecov-shield]: https://img.shields.io/codecov/c/github/LibertyDSNP/frequency?style=for-the-badge
+[codecov-url]: https://app.codecov.io/gh/LibertyDSNP/frequency
+[release-shield]: https://img.shields.io/github/v/release/LibertyDSNP/frequency?style=for-the-badge
+[release-url]: https://github.com/LibertyDSNP/frequency/releases
+[docker-shield]: https://img.shields.io/docker/v/frequencychain/parachain-node-mainnet/latest?color=1c90ed&label=Docker&style=for-the-badge
+[docker-url]: https://hub.docker.com/u/frequencychain
+

--- a/js/api-augment/definitions/schemas.ts
+++ b/js/api-augment/definitions/schemas.ts
@@ -36,7 +36,7 @@ export default {
       payload_location: "PayloadLocation",
     },
     ModelType: {
-      _enum: ["AvroBinary"],
+      _enum: ["AvroBinary", "Parquet"],
     },
     PayloadLocation: {
       _enum: ["OnChain", "IPFS"],

--- a/node/service/src/chain_spec/frequency.rs
+++ b/node/service/src/chain_spec/frequency.rs
@@ -23,8 +23,6 @@ pub mod frequency_mainnet_keys {
 	pub const MAINNET_FRQ_SUDO: &str =
 		"0xd64279ee49fc11521ab7272190f8c11fdff7ab554d5490254f292613b36dab30";
 
-	//TODO: update collator key naming convention
-
 	// Unfinished Collator 1 public key (sr25519) and session key
 	pub const UNFINISHED_COLLATOR_1_SR25519: &str =
 		"0x40c0cf083ba1d081fce7c1f38f5344a4eba4ee5c13e1dddcb9cc6acf74559710";

--- a/node/service/src/chain_spec/frequency.rs
+++ b/node/service/src/chain_spec/frequency.rs
@@ -219,14 +219,13 @@ pub fn frequency() -> ChainSpec {
 				),
 				//candidacy bond
 				100_000 * UNITS,
-				// TODO: include council/democracy/staking related inputs
 				para_id,
 			)
 		},
 		// Bootnodes
 		vec![
-			"/dns/0.boot.frequency.xyz/tcp/30333/p2p/12D3KooWBd4aEArNvXECtt2JHQACBdFmeafpyfre3q81iM1xCcpP".parse().unwrap(),
-			"/dns/1.boot.frequency.xyz/tcp/30333/p2p/12D3KooWCW8d7Yz2d3Jcb49rWcNppRNEs1K2NZitCpPtrHSQb6dw".parse().unwrap(),
+			"/dns4/0.boot.frequency.xyz/tcp/30333/ws/p2p/12D3KooWBd4aEArNvXECtt2JHQACBdFmeafpyfre3q81iM1xCcpP".parse().unwrap(),
+			"/dns4/1.boot.frequency.xyz/tcp/30333/ws/p2p/12D3KooWCW8d7Yz2d3Jcb49rWcNppRNEs1K2NZitCpPtrHSQb6dw".parse().unwrap(),
 		],
 		// Telemetry
 		TelemetryEndpoints::new(vec![("wss://telemetry.polkadot.io/submit/".into(), 0), ("wss://telemetry.frequency.xyz/submit/".into(), 0)]).ok(),

--- a/runtime/frequency-rococo/src/lib.rs
+++ b/runtime/frequency-rococo/src/lib.rs
@@ -364,7 +364,7 @@ impl pallet_collective::Config<CouncilCollective> for Runtime {
 	type MaxProposals = CouncilMaxProposals;
 	type MaxMembers = ConstU32<5>;
 	type DefaultVote = pallet_collective::PrimeDefaultVote;
-	// TODO: this uses default but we don't have weights yet
+	// TODO: this uses default but we don't have weights yet. Issue: #608
 	type WeightInfo = pallet_collective::weights::SubstrateWeight<Runtime>;
 }
 
@@ -377,7 +377,7 @@ impl pallet_collective::Config<TechnicalCommitteeInstance> for Runtime {
 	type MaxProposals = TCMaxProposals;
 	type MaxMembers = TCMaxMembers;
 	type DefaultVote = pallet_collective::PrimeDefaultVote;
-	// TODO: this uses default but we don't have weights yet
+	// TODO: this uses default but we don't have weights yet. Issue: #608
 	type WeightInfo = pallet_collective::weights::SubstrateWeight<Runtime>;
 }
 

--- a/runtime/frequency/src/lib.rs
+++ b/runtime/frequency/src/lib.rs
@@ -398,7 +398,7 @@ impl pallet_collective::Config<TechnicalCommitteeInstance> for Runtime {
 	type MaxProposals = TCMaxProposals;
 	type MaxMembers = TCMaxMembers;
 	type DefaultVote = pallet_collective::PrimeDefaultVote;
-	// TODO: this uses default but we don't have weights yet
+	// TODO: this uses default but we don't have weights yet. Issue: #608
 	type WeightInfo = pallet_collective::weights::SubstrateWeight<Runtime>;
 }
 

--- a/scripts/generate_specs.sh
+++ b/scripts/generate_specs.sh
@@ -29,33 +29,6 @@ case $build_step in
     $PWD/target/$profile/frequency export-genesis-state --chain ./res/genesis/local/rococo-local-frequency-2000-raw.json > ./res/genesis/local/frequency-rococo-genesis-state
     $PWD/target/$profile/frequency export-genesis-wasm --chain ./res/genesis/local/rococo-local-frequency-2000-raw.json > ./res/genesis/local/frequency-rococo-genesis-wasm
     ;;
-  rococo-4044)
-    mkdir -p ./res/genesis/testnet
-    echo "Building Spec for for frequency rococo testnet paraid=4044"
-    $PWD/target/$profile/frequency build-spec --chain=frequency-rococo --disable-default-bootnode > ./res/genesis/testnet/frequency-spec-rococo-testnet.json
-    sed -i.bu "s/\"parachainId\": 4044/\"parachainId\": $parachain_id/g" ./res/genesis/testnet/frequency-spec-rococo-testnet.json
-    sed -i.bu "s/\"para_id\": 4044/\"para_id\": $parachain_id/g" ./res/genesis/testnet/frequency-spec-rococo-testnet.json
-    $PWD/target/$profile/frequency build-spec --raw --disable-default-bootnode --chain ./res/genesis/testnet/frequency-spec-rococo-testnet.json > ./res/genesis/testnet/rococo-testnet-frequency-raw.json
-    rm ./res/genesis/testnet/frequency-spec-rococo-testnet.json.bu
-
-    echo "Exporting state and wasm for frequency rococo testnet paraid=4044"
-    $PWD/target/$profile/frequency export-genesis-state --chain ./res/genesis/testnet/rococo-testnet-frequency-raw.json > ./res/genesis/testnet/frequency-rococo-testnet-genesis-state
-    $PWD/target/$profile/frequency export-genesis-wasm --chain ./res/genesis/testnet/rococo-testnet-frequency-raw.json > ./res/genesis/testnet/frequency-rococo-testnet-genesis-wasm
-    ;;
-
-  mainnet)
-    mkdir -p ./res/genesis/mainnet
-    echo "Building Spec for frequency mainnet"
-    $PWD/target/$profile/frequency build-spec --chain=frequency --disable-default-bootnode > ./res/genesis/mainnet/frequency.json
-    sed -i.bu "s/\"parachainId\": 999/\"parachainId\": $parachain_id/g" ./res/genesis/mainnet/frequency.json
-    sed -i.bu "s/\"para_id\": 999/\"para_id\": $parachain_id/g" ./res/genesis/mainnet/frequency.json
-    $PWD/target/$profile/frequency build-spec --raw --disable-default-bootnode --chain ./res/genesis/mainnet/frequency.json > ./res/genesis/mainnet/frequency-raw.json
-    rm ./res/genesis/mainnet/frequency.json.bu
-
-    echo "Exporting state and wasm for frequency mainnet"
-    $PWD/target/$profile/frequency export-genesis-state --chain ./res/genesis/mainnet/frequency-raw.json > ./res/genesis/mainnet/frequency-state
-    $PWD/target/$profile/frequency export-genesis-wasm --chain ./res/genesis/mainnet/frequency-raw.json > ./res/genesis/mainnet/frequency-wasm
-    ;;
   *)
     echo "Unknown build step: $build_step"
     exit 1

--- a/scripts/js/democracy/README.md
+++ b/scripts/js/democracy/README.md
@@ -18,7 +18,7 @@ To accomplish the above workflow, you will need to take the following steps:
 
 ```
 make build
-make specs-rococo-4044
+make specs-rococo-2000
 ```
 
 This will place a WASM in the `res/genesis/testnet` folder.


### PR DESCRIPTION
# Goal
The goal of this PR is cleanup some small bits of things before release.


# Discussion
- ONLY CODE CHANGE: Mainnet bootnodes updated to the correct format
- js/api-augment change: Added missing enum value
- Readme/etc... updates
- Remove spec generation code for rococo and mainnet
- Update todo lines