### PR TITLE
messages: seed schema for benchmarks

### DIFF
--- a/common/primitives/src/benchmarks.rs
+++ b/common/primitives/src/benchmarks.rs
@@ -3,7 +3,7 @@ use sp_std::vec::Vec;
 
 use crate::{
 	msa::{DelegatorId, MessageSourceId, ProviderId},
-	schema::SchemaId,
+	schema::{ModelType, PayloadLocation, SchemaId},
 };
 
 /// A trait for helping setup state for running benchmarks.
@@ -13,7 +13,7 @@ use crate::{
 /// Implementing this trait and adding the runtime-benchmarks feature flag
 /// makes it possible for the messages pallet to access functions that allow
 /// one to set up the necessary state for running benchmarks for messages.
-pub trait BenchmarkHelper<AccountId> {
+pub trait MsaBenchmarkHelper<AccountId> {
 	/// Sets the delegation relationship of between Provider and Delegator.
 	fn set_delegation_relationship(
 		provider: ProviderId,
@@ -21,14 +21,11 @@ pub trait BenchmarkHelper<AccountId> {
 		schemas: Vec<SchemaId>,
 	) -> DispatchResult;
 
-	/// Sets a publickey to an MSA.
+	/// Sets a public key to an MSA.
 	fn add_key(msa_id: MessageSourceId, key: AccountId) -> DispatchResult;
-
-	/// Sets the schema count.
-	fn set_schema_count(schema_id: SchemaId);
 }
 
-impl<AccountId> BenchmarkHelper<AccountId> for () {
+impl<AccountId> MsaBenchmarkHelper<AccountId> for () {
 	/// Sets the delegation relationship of between Provider and Delegator.
 	fn set_delegation_relationship(
 		_provider: ProviderId,
@@ -42,7 +39,31 @@ impl<AccountId> BenchmarkHelper<AccountId> for () {
 	fn add_key(_msa_id: MessageSourceId, _key: AccountId) -> DispatchResult {
 		Ok(())
 	}
+}
 
+/// A trait for Schema pallet helping setup state for running benchmarks.
+pub trait SchemaBenchmarkHelper {
+	/// Sets the schema count.
+	fn set_schema_count(schema_id: SchemaId);
+
+	/// Creates a new schema.
+	fn create_schema(
+		model: Vec<u8>,
+		model_type: ModelType,
+		payload_location: PayloadLocation,
+	) -> DispatchResult;
+}
+
+impl SchemaBenchmarkHelper for () {
 	/// Sets the schema count.
 	fn set_schema_count(_schema_id: SchemaId) {}
+
+	/// Adds a new schema.
+	fn create_schema(
+		_model: Vec<u8>,
+		_model_type: ModelType,
+		_payload_location: PayloadLocation,
+	) -> DispatchResult {
+		Ok(())
+	}
 }

--- a/pallets/messages/src/lib.rs
+++ b/pallets/messages/src/lib.rs
@@ -69,7 +69,7 @@ use common_primitives::{
 };
 
 #[cfg(feature = "runtime-benchmarks")]
-use common_primitives::benchmarks::BenchmarkHelper;
+use common_primitives::benchmarks::{MsaBenchmarkHelper, SchemaBenchmarkHelper};
 
 pub use pallet::*;
 pub use types::*;
@@ -108,7 +108,11 @@ pub mod pallet {
 
 		#[cfg(feature = "runtime-benchmarks")]
 		/// A set of helper functions for benchmarking.
-		type Helper: BenchmarkHelper<Self::AccountId>;
+		type MsaBenchmarkHelper: MsaBenchmarkHelper<Self::AccountId>;
+
+		#[cfg(feature = "runtime-benchmarks")]
+		/// A set of helper functions for benchmarking.
+		type SchemaBenchmarkHelper: SchemaBenchmarkHelper;
 	}
 
 	#[pallet::pallet]

--- a/pallets/messages/src/mock.rs
+++ b/pallets/messages/src/mock.rs
@@ -25,7 +25,7 @@ type UncheckedExtrinsic = frame_system::mocking::MockUncheckedExtrinsic<Test>;
 type Block = frame_system::mocking::MockBlock<Test>;
 
 pub const INVALID_SCHEMA_ID: SchemaId = 65534;
-pub const IPFS_SCHEMA_ID: SchemaId = 65535;
+pub const IPFS_SCHEMA_ID: SchemaId = 50;
 
 pub const IPFS_PAYLOAD_LENGTH: u32 = 1200;
 
@@ -229,9 +229,11 @@ impl pallet_messages::Config for Test {
 	type MaxMessagesPerBlock = MaxMessagesPerBlock;
 	type MaxMessagePayloadSizeBytes = MaxMessagePayloadSizeBytes;
 
-	#[cfg(feature = "runtime-benchmarks")]
 	/// A set of helper functions for benchmarking.
-	type Helper = ();
+	#[cfg(feature = "runtime-benchmarks")]
+	type MsaBenchmarkHelper = ();
+	#[cfg(feature = "runtime-benchmarks")]
+	type SchemaBenchmarkHelper = ();
 }
 
 pub fn new_test_ext() -> sp_io::TestExternalities {

--- a/pallets/messages/src/weights.rs
+++ b/pallets/messages/src/weights.rs
@@ -66,11 +66,11 @@ impl<T: frame_system::Config> WeightInfo for SubstrateWeight<T> {
 	// Storage: Msa DelegatorAndProviderToDelegation (r:1 w:0)
 	// Storage: Messages BlockMessages (r:1 w:1)
 	fn add_onchain_message(n: u32, m: u32, ) -> Weight {
-		Weight::from_ref_time(15_422_000 as u64)
+		Weight::from_ref_time(9_248_000 as u64)
 			// Standard Error: 0
 			.saturating_add(Weight::from_ref_time(1_000 as u64).saturating_mul(n as u64))
 			// Standard Error: 2_000
-			.saturating_add(Weight::from_ref_time(224_000 as u64).saturating_mul(m as u64))
+			.saturating_add(Weight::from_ref_time(179_000 as u64).saturating_mul(m as u64))
 			.saturating_add(T::DbWeight::get().reads(4 as u64))
 			.saturating_add(T::DbWeight::get().writes(1 as u64))
 	}
@@ -78,11 +78,11 @@ impl<T: frame_system::Config> WeightInfo for SubstrateWeight<T> {
 	// Storage: Msa PublicKeyToMsaId (r:1 w:0)
 	// Storage: Messages BlockMessages (r:1 w:1)
 	fn add_ipfs_message(n: u32, m: u32, ) -> Weight {
-		Weight::from_ref_time(16_686_000 as u64)
+		Weight::from_ref_time(16_047_000 as u64)
 			// Standard Error: 0
-			.saturating_add(Weight::from_ref_time(2_000 as u64).saturating_mul(n as u64))
-			// Standard Error: 3_000
-			.saturating_add(Weight::from_ref_time(173_000 as u64).saturating_mul(m as u64))
+			.saturating_add(Weight::from_ref_time(1_000 as u64).saturating_mul(n as u64))
+			// Standard Error: 2_000
+			.saturating_add(Weight::from_ref_time(141_000 as u64).saturating_mul(m as u64))
 			.saturating_add(T::DbWeight::get().reads(3 as u64))
 			.saturating_add(T::DbWeight::get().writes(1 as u64))
 	}
@@ -90,10 +90,10 @@ impl<T: frame_system::Config> WeightInfo for SubstrateWeight<T> {
 	// Storage: Messages Messages (r:0 w:1)
 	fn on_initialize(m: u32, s: u32, ) -> Weight {
 		Weight::from_ref_time(0 as u64)
-			// Standard Error: 13_000
-			.saturating_add(Weight::from_ref_time(383_000 as u64).saturating_mul(m as u64))
-			// Standard Error: 140_000
-			.saturating_add(Weight::from_ref_time(4_703_000 as u64).saturating_mul(s as u64))
+			// Standard Error: 9_000
+			.saturating_add(Weight::from_ref_time(293_000 as u64).saturating_mul(m as u64))
+			// Standard Error: 94_000
+			.saturating_add(Weight::from_ref_time(3_310_000 as u64).saturating_mul(s as u64))
 			.saturating_add(T::DbWeight::get().reads(1 as u64))
 			.saturating_add(T::DbWeight::get().writes((1 as u64).saturating_mul(s as u64)))
 	}
@@ -106,11 +106,11 @@ impl WeightInfo for () {
 	// Storage: Msa DelegatorAndProviderToDelegation (r:1 w:0)
 	// Storage: Messages BlockMessages (r:1 w:1)
 	fn add_onchain_message(n: u32, m: u32, ) -> Weight {
-		Weight::from_ref_time(15_422_000 as u64)
+		Weight::from_ref_time(9_248_000 as u64)
 			// Standard Error: 0
 			.saturating_add(Weight::from_ref_time(1_000 as u64).saturating_mul(n as u64))
 			// Standard Error: 2_000
-			.saturating_add(Weight::from_ref_time(224_000 as u64).saturating_mul(m as u64))
+			.saturating_add(Weight::from_ref_time(179_000 as u64).saturating_mul(m as u64))
 			.saturating_add(RocksDbWeight::get().reads(4 as u64))
 			.saturating_add(RocksDbWeight::get().writes(1 as u64))
 	}
@@ -118,11 +118,11 @@ impl WeightInfo for () {
 	// Storage: Msa PublicKeyToMsaId (r:1 w:0)
 	// Storage: Messages BlockMessages (r:1 w:1)
 	fn add_ipfs_message(n: u32, m: u32, ) -> Weight {
-		Weight::from_ref_time(16_686_000 as u64)
+		Weight::from_ref_time(16_047_000 as u64)
 			// Standard Error: 0
-			.saturating_add(Weight::from_ref_time(2_000 as u64).saturating_mul(n as u64))
-			// Standard Error: 3_000
-			.saturating_add(Weight::from_ref_time(173_000 as u64).saturating_mul(m as u64))
+			.saturating_add(Weight::from_ref_time(1_000 as u64).saturating_mul(n as u64))
+			// Standard Error: 2_000
+			.saturating_add(Weight::from_ref_time(141_000 as u64).saturating_mul(m as u64))
 			.saturating_add(RocksDbWeight::get().reads(3 as u64))
 			.saturating_add(RocksDbWeight::get().writes(1 as u64))
 	}
@@ -130,10 +130,10 @@ impl WeightInfo for () {
 	// Storage: Messages Messages (r:0 w:1)
 	fn on_initialize(m: u32, s: u32, ) -> Weight {
 		Weight::from_ref_time(0 as u64)
-			// Standard Error: 13_000
-			.saturating_add(Weight::from_ref_time(383_000 as u64).saturating_mul(m as u64))
-			// Standard Error: 140_000
-			.saturating_add(Weight::from_ref_time(4_703_000 as u64).saturating_mul(s as u64))
+			// Standard Error: 9_000
+			.saturating_add(Weight::from_ref_time(293_000 as u64).saturating_mul(m as u64))
+			// Standard Error: 94_000
+			.saturating_add(Weight::from_ref_time(3_310_000 as u64).saturating_mul(s as u64))
 			.saturating_add(RocksDbWeight::get().reads(1 as u64))
 			.saturating_add(RocksDbWeight::get().writes((1 as u64).saturating_mul(s as u64)))
 	}

--- a/pallets/msa/src/lib.rs
+++ b/pallets/msa/src/lib.rs
@@ -60,7 +60,7 @@ use frame_support::{
 };
 
 #[cfg(feature = "runtime-benchmarks")]
-use common_primitives::benchmarks::BenchmarkHelper;
+use common_primitives::benchmarks::MsaBenchmarkHelper;
 
 use frame_system::pallet_prelude::*;
 use scale_info::TypeInfo;
@@ -1228,7 +1228,7 @@ impl<T: Config> Pallet<T> {
 }
 
 #[cfg(feature = "runtime-benchmarks")]
-impl<T: Config> BenchmarkHelper<T::AccountId> for Pallet<T> {
+impl<T: Config> MsaBenchmarkHelper<T::AccountId> for Pallet<T> {
 	/// Some docs
 	fn set_delegation_relationship(
 		provider: ProviderId,
@@ -1243,10 +1243,6 @@ impl<T: Config> BenchmarkHelper<T::AccountId> for Pallet<T> {
 	fn add_key(msa_id: MessageSourceId, key: T::AccountId) -> DispatchResult {
 		Self::add_key(msa_id, &key, EMPTY_FUNCTION)?;
 		Ok(())
-	}
-
-	fn set_schema_count(schema_id: SchemaId) {
-		T::SchemaValidator::set_schema_count(schema_id)
 	}
 }
 

--- a/pallets/msa/src/lib.rs
+++ b/pallets/msa/src/lib.rs
@@ -1229,7 +1229,7 @@ impl<T: Config> Pallet<T> {
 
 #[cfg(feature = "runtime-benchmarks")]
 impl<T: Config> MsaBenchmarkHelper<T::AccountId> for Pallet<T> {
-	/// Some docs
+	/// adds delegation relationship with permitted schema ids
 	fn set_delegation_relationship(
 		provider: ProviderId,
 		delegator: DelegatorId,
@@ -1239,7 +1239,7 @@ impl<T: Config> MsaBenchmarkHelper<T::AccountId> for Pallet<T> {
 		Ok(())
 	}
 
-	/// Some docs
+	/// adds a new key to specified msa
 	fn add_key(msa_id: MessageSourceId, key: T::AccountId) -> DispatchResult {
 		Self::add_key(msa_id, &key, EMPTY_FUNCTION)?;
 		Ok(())

--- a/pallets/schemas/src/lib.rs
+++ b/pallets/schemas/src/lib.rs
@@ -56,6 +56,7 @@ use common_primitives::{
 	},
 };
 use frame_support::{dispatch::DispatchResult, ensure, traits::Get};
+use sp_runtime::BoundedVec;
 use sp_std::vec::Vec;
 
 #[cfg(test)]
@@ -66,6 +67,8 @@ mod mock;
 
 #[cfg(feature = "runtime-benchmarks")]
 mod benchmarking;
+#[cfg(feature = "runtime-benchmarks")]
+use common_primitives::benchmarks::SchemaBenchmarkHelper;
 
 mod types;
 
@@ -260,7 +263,7 @@ pub mod pallet {
 
 		/// Build the [`Schema`] and insert it into storage
 		/// Updates the [`CurrentSchemaIdentifierMaximum`] storage
-		fn add_schema(
+		pub fn add_schema(
 			model: BoundedVec<u8, T::SchemaModelMaxBytesBoundedVecLimit>,
 			model_type: ModelType,
 			payload_location: PayloadLocation,
@@ -324,6 +327,27 @@ pub mod pallet {
 	}
 }
 
+#[cfg(feature = "runtime-benchmarks")]
+impl<T: Config> SchemaBenchmarkHelper for Pallet<T> {
+	/// Sets schema count.
+	fn set_schema_count(schema_id: SchemaId) {
+		Self::set_schema_count(schema_id);
+	}
+
+	/// Creates a schema.
+	fn create_schema(
+		model: Vec<u8>,
+		model_type: ModelType,
+		payload_location: PayloadLocation,
+	) -> DispatchResult {
+		let model: BoundedVec<u8, T::SchemaModelMaxBytesBoundedVecLimit> =
+			model.try_into().unwrap();
+		Self::ensure_valid_model(&model_type, &model)?;
+		Self::add_schema(model, model_type, payload_location)?;
+		Ok(())
+	}
+}
+
 impl<T: Config> SchemaValidator<SchemaId> for Pallet<T> {
 	fn are_all_schema_ids_valid(schema_ids: &Vec<SchemaId>) -> bool {
 		let latest_issue_schema_id = Self::get_current_schema_identifier_maximum();
@@ -337,37 +361,7 @@ impl<T: Config> SchemaValidator<SchemaId> for Pallet<T> {
 }
 
 impl<T: Config> SchemaProvider<SchemaId> for Pallet<T> {
-	#[cfg(not(feature = "runtime-benchmarks"))]
 	fn get_schema_by_id(schema_id: SchemaId) -> Option<SchemaResponse> {
 		Self::get_schema_by_id(schema_id)
-	}
-
-	/// Since benchmarks are using regular runtime, we can not use mocking for this loosely bounded
-	/// pallet trait implementation. To be able to run benchmarks successfully for any other pallet
-	/// that has dependencies on this one, we would need to define msa accounts on those pallets'
-	/// benchmarks, but this will introduce direct dependencies between these pallets, which we
-	/// would like to avoid.
-	/// To successfully run benchmarks without adding dependencies between pallets we re-defined
-	/// this method to return schema checks requested by the benchmark to also be some.
-	#[cfg(feature = "runtime-benchmarks")]
-	fn get_schema_by_id(schema_id: SchemaId) -> Option<SchemaResponse> {
-		// To account for db read
-		Self::get_schema_by_id(schema_id);
-
-		// This method allows the benchmarks to cover both payload location types
-		// used by the messages pallets. Maybe one day we can replace this with a
-		// common "benchmarking" crate.
-		const IPFS_SCHEMA_ID: u16 = 65535;
-		let location: PayloadLocation = if schema_id == IPFS_SCHEMA_ID {
-			PayloadLocation::IPFS
-		} else {
-			PayloadLocation::OnChain
-		};
-		Some(SchemaResponse {
-			schema_id,
-			model: "{}".as_bytes().to_vec(),
-			model_type: ModelType::default(),
-			payload_location: location,
-		})
 	}
 }

--- a/runtime/frequency-rococo/src/lib.rs
+++ b/runtime/frequency-rococo/src/lib.rs
@@ -594,7 +594,9 @@ impl pallet_messages::Config for Runtime {
 
 	/// A set of helper functions for benchmarking.
 	#[cfg(feature = "runtime-benchmarks")]
-	type Helper = Msa;
+	type MsaBenchmarkHelper = Msa;
+	#[cfg(feature = "runtime-benchmarks")]
+	type SchemaBenchmarkHelper = Schemas;
 }
 
 impl pallet_sudo::Config for Runtime {

--- a/runtime/frequency/src/lib.rs
+++ b/runtime/frequency/src/lib.rs
@@ -644,7 +644,9 @@ impl pallet_messages::Config for Runtime {
 
 	/// A set of helper functions for benchmarking.
 	#[cfg(feature = "runtime-benchmarks")]
-	type Helper = Msa;
+	type MsaBenchmarkHelper = Msa;
+	#[cfg(feature = "runtime-benchmarks")]
+	type SchemaBenchmarkHelper = Schemas;
 }
 
 impl pallet_sudo::Config for Runtime {


### PR DESCRIPTION
# Goal
The goal of this PR is remove `#[cfg(not(feature = "runtime-benchmarks"))]` and seeds schema related storage for benchmarks

Closes #657 

# Discussion

- removes `#[cfg(not(feature = "runtime-benchmarks"))]`
- modify benchmarks on messages to use seeding utility

# Checklist
- [x] Benchmarks added
- [x] Weights updated
