### PR TITLE
chore(benchmarks): update msa create benchmark

### DIFF
--- a/pallets/messages/src/weights.rs
+++ b/pallets/messages/src/weights.rs
@@ -66,11 +66,11 @@ impl<T: frame_system::Config> WeightInfo for SubstrateWeight<T> {
 	// Storage: Msa DelegatorAndProviderToDelegation (r:1 w:0)
 	// Storage: Messages BlockMessages (r:1 w:1)
 	fn add_onchain_message(n: u32, m: u32, ) -> Weight {
-		Weight::from_ref_time(33_557_000 as u64)
+		Weight::from_ref_time(15_458_000 as u64)
 			// Standard Error: 0
 			.saturating_add(Weight::from_ref_time(1_000 as u64).saturating_mul(n as u64))
 			// Standard Error: 3_000
-			.saturating_add(Weight::from_ref_time(233_000 as u64).saturating_mul(m as u64))
+			.saturating_add(Weight::from_ref_time(240_000 as u64).saturating_mul(m as u64))
 			.saturating_add(T::DbWeight::get().reads(4 as u64))
 			.saturating_add(T::DbWeight::get().writes(1 as u64))
 	}
@@ -78,11 +78,11 @@ impl<T: frame_system::Config> WeightInfo for SubstrateWeight<T> {
 	// Storage: Msa PublicKeyToMsaId (r:1 w:0)
 	// Storage: Messages BlockMessages (r:1 w:1)
 	fn add_ipfs_message(n: u32, m: u32, ) -> Weight {
-		Weight::from_ref_time(18_627_000 as u64)
+		Weight::from_ref_time(18_932_000 as u64)
 			// Standard Error: 0
 			.saturating_add(Weight::from_ref_time(2_000 as u64).saturating_mul(n as u64))
-			// Standard Error: 2_000
-			.saturating_add(Weight::from_ref_time(199_000 as u64).saturating_mul(m as u64))
+			// Standard Error: 3_000
+			.saturating_add(Weight::from_ref_time(188_000 as u64).saturating_mul(m as u64))
 			.saturating_add(T::DbWeight::get().reads(3 as u64))
 			.saturating_add(T::DbWeight::get().writes(1 as u64))
 	}
@@ -91,9 +91,9 @@ impl<T: frame_system::Config> WeightInfo for SubstrateWeight<T> {
 	fn on_initialize(m: u32, s: u32, ) -> Weight {
 		Weight::from_ref_time(0 as u64)
 			// Standard Error: 14_000
-			.saturating_add(Weight::from_ref_time(404_000 as u64).saturating_mul(m as u64))
-			// Standard Error: 142_000
-			.saturating_add(Weight::from_ref_time(4_818_000 as u64).saturating_mul(s as u64))
+			.saturating_add(Weight::from_ref_time(433_000 as u64).saturating_mul(m as u64))
+			// Standard Error: 141_000
+			.saturating_add(Weight::from_ref_time(5_059_000 as u64).saturating_mul(s as u64))
 			.saturating_add(T::DbWeight::get().reads(1 as u64))
 			.saturating_add(T::DbWeight::get().writes((1 as u64).saturating_mul(s as u64)))
 	}
@@ -106,11 +106,11 @@ impl WeightInfo for () {
 	// Storage: Msa DelegatorAndProviderToDelegation (r:1 w:0)
 	// Storage: Messages BlockMessages (r:1 w:1)
 	fn add_onchain_message(n: u32, m: u32, ) -> Weight {
-		Weight::from_ref_time(33_557_000 as u64)
+		Weight::from_ref_time(15_458_000 as u64)
 			// Standard Error: 0
 			.saturating_add(Weight::from_ref_time(1_000 as u64).saturating_mul(n as u64))
 			// Standard Error: 3_000
-			.saturating_add(Weight::from_ref_time(233_000 as u64).saturating_mul(m as u64))
+			.saturating_add(Weight::from_ref_time(240_000 as u64).saturating_mul(m as u64))
 			.saturating_add(RocksDbWeight::get().reads(4 as u64))
 			.saturating_add(RocksDbWeight::get().writes(1 as u64))
 	}
@@ -118,11 +118,11 @@ impl WeightInfo for () {
 	// Storage: Msa PublicKeyToMsaId (r:1 w:0)
 	// Storage: Messages BlockMessages (r:1 w:1)
 	fn add_ipfs_message(n: u32, m: u32, ) -> Weight {
-		Weight::from_ref_time(18_627_000 as u64)
+		Weight::from_ref_time(18_932_000 as u64)
 			// Standard Error: 0
 			.saturating_add(Weight::from_ref_time(2_000 as u64).saturating_mul(n as u64))
-			// Standard Error: 2_000
-			.saturating_add(Weight::from_ref_time(199_000 as u64).saturating_mul(m as u64))
+			// Standard Error: 3_000
+			.saturating_add(Weight::from_ref_time(188_000 as u64).saturating_mul(m as u64))
 			.saturating_add(RocksDbWeight::get().reads(3 as u64))
 			.saturating_add(RocksDbWeight::get().writes(1 as u64))
 	}
@@ -131,9 +131,9 @@ impl WeightInfo for () {
 	fn on_initialize(m: u32, s: u32, ) -> Weight {
 		Weight::from_ref_time(0 as u64)
 			// Standard Error: 14_000
-			.saturating_add(Weight::from_ref_time(404_000 as u64).saturating_mul(m as u64))
-			// Standard Error: 142_000
-			.saturating_add(Weight::from_ref_time(4_818_000 as u64).saturating_mul(s as u64))
+			.saturating_add(Weight::from_ref_time(433_000 as u64).saturating_mul(m as u64))
+			// Standard Error: 141_000
+			.saturating_add(Weight::from_ref_time(5_059_000 as u64).saturating_mul(s as u64))
 			.saturating_add(RocksDbWeight::get().reads(1 as u64))
 			.saturating_add(RocksDbWeight::get().writes((1 as u64).saturating_mul(s as u64)))
 	}

--- a/pallets/msa/src/benchmarking.rs
+++ b/pallets/msa/src/benchmarking.rs
@@ -26,11 +26,6 @@ fn create_account<T: Config>(name: &'static str, index: u32) -> T::AccountId {
 	account(name, index, SEED)
 }
 
-fn create_msa<T: Config>(n: u32) -> DispatchResult {
-	let acc = create_account::<T>("account", n);
-	Msa::<T>::create(RawOrigin::Signed(acc.clone()).into())
-}
-
 fn create_payload_and_signature<T: Config>() -> (AddProvider, MultiSignature, T::AccountId) {
 	let delegator_account = SignerId::generate_pair(None);
 	let schemas: Vec<SchemaId> = vec![1, 2];
@@ -101,13 +96,12 @@ fn register_signature<T: Config>(mortality_block: u32) {
 
 benchmarks! {
 	create {
-		let s in 1 .. 1000;
 		let caller: T::AccountId = whitelisted_caller();
 
-		for j in 0 .. s {
-			assert_ok!(create_msa::<T>(j));
-		}
-	}: _ (RawOrigin::Signed(caller))
+	}: _ (RawOrigin::Signed(caller.clone()))
+	verify {
+		assert!(Msa::<T>::get_msa_by_public_key(caller).is_some());
+	}
 
 	create_sponsored_account_with_delegation {
 

--- a/pallets/msa/src/lib.rs
+++ b/pallets/msa/src/lib.rs
@@ -381,14 +381,14 @@ pub mod pallet {
 		///
 		/// * [`Error::KeyAlreadyRegistered`] - MSA is already registered to the Origin.
 		///
-		#[pallet::weight(T::WeightInfo::create(10_000))]
+		#[pallet::weight(T::WeightInfo::create())]
 		pub fn create(origin: OriginFor<T>) -> DispatchResult {
-			let who = ensure_signed(origin)?;
+			let public_key = ensure_signed(origin)?;
 
-			let (_, _) = Self::create_account(who.clone(), |new_msa_id| -> DispatchResult {
-				Self::deposit_event(Event::MsaCreated { msa_id: new_msa_id, key: who });
-				Ok(())
-			})?;
+			let (new_msa_id, new_public_key) =
+				Self::create_account(public_key, |_| -> DispatchResult { Ok(()) })?;
+
+			Self::deposit_event(Event::MsaCreated { msa_id: new_msa_id, key: new_public_key });
 
 			Ok(())
 		}

--- a/pallets/msa/src/weights.rs
+++ b/pallets/msa/src/weights.rs
@@ -53,7 +53,7 @@ use sp_std::marker::PhantomData;
 
 /// Weight functions needed for pallet_msa.
 pub trait WeightInfo {
-	fn create(s: u32, ) -> Weight;
+	fn create() -> Weight;
 	fn create_sponsored_account_with_delegation() -> Weight;
 	fn revoke_delegation_by_provider(s: u32, ) -> Weight;
 	fn add_public_key_to_msa() -> Weight;
@@ -73,10 +73,8 @@ impl<T: frame_system::Config> WeightInfo for SubstrateWeight<T> {
 	// Storage: Msa CurrentMsaIdentifierMaximum (r:1 w:1)
 	// Storage: Msa PublicKeyToMsaId (r:1 w:1)
 	// Storage: Msa PublicKeyCountForMsaId (r:1 w:1)
-	fn create(s: u32, ) -> Weight {
-		Weight::from_ref_time(51_257_000 as u64)
-			// Standard Error: 4_000
-			.saturating_add(Weight::from_ref_time(44_000 as u64).saturating_mul(s as u64))
+	fn create() -> Weight {
+		Weight::from_ref_time(20_353_000 as u64)
 			.saturating_add(T::DbWeight::get().reads(3 as u64))
 			.saturating_add(T::DbWeight::get().writes(3 as u64))
 	}
@@ -88,16 +86,16 @@ impl<T: frame_system::Config> WeightInfo for SubstrateWeight<T> {
 	// Storage: Msa DelegatorAndProviderToDelegation (r:1 w:1)
 	// Storage: Schemas CurrentSchemaIdentifierMaximum (r:1 w:0)
 	fn create_sponsored_account_with_delegation() -> Weight {
-		Weight::from_ref_time(101_498_000 as u64)
+		Weight::from_ref_time(102_894_000 as u64)
 			.saturating_add(T::DbWeight::get().reads(8 as u64))
 			.saturating_add(T::DbWeight::get().writes(5 as u64))
 	}
 	// Storage: Msa PublicKeyToMsaId (r:1 w:0)
 	// Storage: Msa DelegatorAndProviderToDelegation (r:1 w:1)
 	fn revoke_delegation_by_provider(s: u32, ) -> Weight {
-		Weight::from_ref_time(50_649_000 as u64)
+		Weight::from_ref_time(46_822_000 as u64)
 			// Standard Error: 3_000
-			.saturating_add(Weight::from_ref_time(82_000 as u64).saturating_mul(s as u64))
+			.saturating_add(Weight::from_ref_time(85_000 as u64).saturating_mul(s as u64))
 			.saturating_add(T::DbWeight::get().reads(2 as u64))
 			.saturating_add(T::DbWeight::get().writes(1 as u64))
 	}
@@ -105,14 +103,14 @@ impl<T: frame_system::Config> WeightInfo for SubstrateWeight<T> {
 	// Storage: Msa PublicKeyToMsaId (r:2 w:1)
 	// Storage: Msa PublicKeyCountForMsaId (r:1 w:1)
 	fn add_public_key_to_msa() -> Weight {
-		Weight::from_ref_time(148_503_000 as u64)
+		Weight::from_ref_time(147_127_000 as u64)
 			.saturating_add(T::DbWeight::get().reads(5 as u64))
 			.saturating_add(T::DbWeight::get().writes(4 as u64))
 	}
 	// Storage: Msa PublicKeyToMsaId (r:2 w:1)
 	// Storage: Msa PublicKeyCountForMsaId (r:1 w:1)
 	fn delete_msa_public_key() -> Weight {
-		Weight::from_ref_time(29_361_000 as u64)
+		Weight::from_ref_time(29_182_000 as u64)
 			.saturating_add(T::DbWeight::get().reads(3 as u64))
 			.saturating_add(T::DbWeight::get().writes(2 as u64))
 	}
@@ -120,9 +118,9 @@ impl<T: frame_system::Config> WeightInfo for SubstrateWeight<T> {
 	// Storage: Msa PublicKeyCountForMsaId (r:1 w:1)
 	// Storage: Msa DelegatorAndProviderToDelegation (r:0 w:3)
 	fn retire_msa(s: u32, ) -> Weight {
-		Weight::from_ref_time(27_080_000 as u64)
-			// Standard Error: 6_000
-			.saturating_add(Weight::from_ref_time(1_225_000 as u64).saturating_mul(s as u64))
+		Weight::from_ref_time(27_174_000 as u64)
+			// Standard Error: 5_000
+			.saturating_add(Weight::from_ref_time(1_223_000 as u64).saturating_mul(s as u64))
 			.saturating_add(T::DbWeight::get().reads(2 as u64))
 			.saturating_add(T::DbWeight::get().writes((1 as u64).saturating_mul(s as u64)))
 	}
@@ -132,36 +130,36 @@ impl<T: frame_system::Config> WeightInfo for SubstrateWeight<T> {
 	// Storage: Msa DelegatorAndProviderToDelegation (r:1 w:1)
 	// Storage: Schemas CurrentSchemaIdentifierMaximum (r:1 w:0)
 	fn grant_delegation() -> Weight {
-		Weight::from_ref_time(92_909_000 as u64)
+		Weight::from_ref_time(93_337_000 as u64)
 			.saturating_add(T::DbWeight::get().reads(6 as u64))
 			.saturating_add(T::DbWeight::get().writes(2 as u64))
 	}
 	// Storage: Msa PublicKeyToMsaId (r:1 w:0)
 	// Storage: Msa DelegatorAndProviderToDelegation (r:1 w:1)
 	fn revoke_delegation_by_delegator() -> Weight {
-		Weight::from_ref_time(26_684_000 as u64)
+		Weight::from_ref_time(27_141_000 as u64)
 			.saturating_add(T::DbWeight::get().reads(2 as u64))
 			.saturating_add(T::DbWeight::get().writes(1 as u64))
 	}
 	// Storage: Msa PublicKeyToMsaId (r:1 w:0)
 	// Storage: Msa ProviderToRegistryEntry (r:1 w:1)
 	fn create_provider() -> Weight {
-		Weight::from_ref_time(21_019_000 as u64)
+		Weight::from_ref_time(20_871_000 as u64)
 			.saturating_add(T::DbWeight::get().reads(2 as u64))
 			.saturating_add(T::DbWeight::get().writes(1 as u64))
 	}
 	fn on_initialize(m: u32, ) -> Weight {
-		Weight::from_ref_time(12_307_000 as u64)
+		Weight::from_ref_time(12_705_000 as u64)
 			// Standard Error: 0
-			.saturating_add(Weight::from_ref_time(2_000 as u64).saturating_mul(m as u64))
+			.saturating_add(Weight::from_ref_time(3_000 as u64).saturating_mul(m as u64))
 	}
 	// Storage: Msa PublicKeyToMsaId (r:1 w:0)
 	// Storage: Msa DelegatorAndProviderToDelegation (r:1 w:1)
 	// Storage: Schemas CurrentSchemaIdentifierMaximum (r:1 w:0)
 	fn grant_schema_permissions(s: u32, ) -> Weight {
-		Weight::from_ref_time(57_575_000 as u64)
+		Weight::from_ref_time(57_644_000 as u64)
 			// Standard Error: 3_000
-			.saturating_add(Weight::from_ref_time(96_000 as u64).saturating_mul(s as u64))
+			.saturating_add(Weight::from_ref_time(86_000 as u64).saturating_mul(s as u64))
 			.saturating_add(T::DbWeight::get().reads(3 as u64))
 			.saturating_add(T::DbWeight::get().writes(1 as u64))
 	}
@@ -169,9 +167,9 @@ impl<T: frame_system::Config> WeightInfo for SubstrateWeight<T> {
 	// Storage: Msa DelegatorAndProviderToDelegation (r:1 w:1)
 	// Storage: Schemas CurrentSchemaIdentifierMaximum (r:1 w:0)
 	fn revoke_schema_permissions(s: u32, ) -> Weight {
-		Weight::from_ref_time(59_886_000 as u64)
+		Weight::from_ref_time(57_453_000 as u64)
 			// Standard Error: 3_000
-			.saturating_add(Weight::from_ref_time(95_000 as u64).saturating_mul(s as u64))
+			.saturating_add(Weight::from_ref_time(88_000 as u64).saturating_mul(s as u64))
 			.saturating_add(T::DbWeight::get().reads(3 as u64))
 			.saturating_add(T::DbWeight::get().writes(1 as u64))
 	}
@@ -182,10 +180,8 @@ impl WeightInfo for () {
 	// Storage: Msa CurrentMsaIdentifierMaximum (r:1 w:1)
 	// Storage: Msa PublicKeyToMsaId (r:1 w:1)
 	// Storage: Msa PublicKeyCountForMsaId (r:1 w:1)
-	fn create(s: u32, ) -> Weight {
-		Weight::from_ref_time(51_257_000 as u64)
-			// Standard Error: 4_000
-			.saturating_add(Weight::from_ref_time(44_000 as u64).saturating_mul(s as u64))
+	fn create() -> Weight {
+		Weight::from_ref_time(20_353_000 as u64)
 			.saturating_add(RocksDbWeight::get().reads(3 as u64))
 			.saturating_add(RocksDbWeight::get().writes(3 as u64))
 	}
@@ -197,16 +193,16 @@ impl WeightInfo for () {
 	// Storage: Msa DelegatorAndProviderToDelegation (r:1 w:1)
 	// Storage: Schemas CurrentSchemaIdentifierMaximum (r:1 w:0)
 	fn create_sponsored_account_with_delegation() -> Weight {
-		Weight::from_ref_time(101_498_000 as u64)
+		Weight::from_ref_time(102_894_000 as u64)
 			.saturating_add(RocksDbWeight::get().reads(8 as u64))
 			.saturating_add(RocksDbWeight::get().writes(5 as u64))
 	}
 	// Storage: Msa PublicKeyToMsaId (r:1 w:0)
 	// Storage: Msa DelegatorAndProviderToDelegation (r:1 w:1)
 	fn revoke_delegation_by_provider(s: u32, ) -> Weight {
-		Weight::from_ref_time(50_649_000 as u64)
+		Weight::from_ref_time(46_822_000 as u64)
 			// Standard Error: 3_000
-			.saturating_add(Weight::from_ref_time(82_000 as u64).saturating_mul(s as u64))
+			.saturating_add(Weight::from_ref_time(85_000 as u64).saturating_mul(s as u64))
 			.saturating_add(RocksDbWeight::get().reads(2 as u64))
 			.saturating_add(RocksDbWeight::get().writes(1 as u64))
 	}
@@ -214,14 +210,14 @@ impl WeightInfo for () {
 	// Storage: Msa PublicKeyToMsaId (r:2 w:1)
 	// Storage: Msa PublicKeyCountForMsaId (r:1 w:1)
 	fn add_public_key_to_msa() -> Weight {
-		Weight::from_ref_time(148_503_000 as u64)
+		Weight::from_ref_time(147_127_000 as u64)
 			.saturating_add(RocksDbWeight::get().reads(5 as u64))
 			.saturating_add(RocksDbWeight::get().writes(4 as u64))
 	}
 	// Storage: Msa PublicKeyToMsaId (r:2 w:1)
 	// Storage: Msa PublicKeyCountForMsaId (r:1 w:1)
 	fn delete_msa_public_key() -> Weight {
-		Weight::from_ref_time(29_361_000 as u64)
+		Weight::from_ref_time(29_182_000 as u64)
 			.saturating_add(RocksDbWeight::get().reads(3 as u64))
 			.saturating_add(RocksDbWeight::get().writes(2 as u64))
 	}
@@ -229,9 +225,9 @@ impl WeightInfo for () {
 	// Storage: Msa PublicKeyCountForMsaId (r:1 w:1)
 	// Storage: Msa DelegatorAndProviderToDelegation (r:0 w:3)
 	fn retire_msa(s: u32, ) -> Weight {
-		Weight::from_ref_time(27_080_000 as u64)
-			// Standard Error: 6_000
-			.saturating_add(Weight::from_ref_time(1_225_000 as u64).saturating_mul(s as u64))
+		Weight::from_ref_time(27_174_000 as u64)
+			// Standard Error: 5_000
+			.saturating_add(Weight::from_ref_time(1_223_000 as u64).saturating_mul(s as u64))
 			.saturating_add(RocksDbWeight::get().reads(2 as u64))
 			.saturating_add(RocksDbWeight::get().writes((1 as u64).saturating_mul(s as u64)))
 	}
@@ -241,36 +237,36 @@ impl WeightInfo for () {
 	// Storage: Msa DelegatorAndProviderToDelegation (r:1 w:1)
 	// Storage: Schemas CurrentSchemaIdentifierMaximum (r:1 w:0)
 	fn grant_delegation() -> Weight {
-		Weight::from_ref_time(92_909_000 as u64)
+		Weight::from_ref_time(93_337_000 as u64)
 			.saturating_add(RocksDbWeight::get().reads(6 as u64))
 			.saturating_add(RocksDbWeight::get().writes(2 as u64))
 	}
 	// Storage: Msa PublicKeyToMsaId (r:1 w:0)
 	// Storage: Msa DelegatorAndProviderToDelegation (r:1 w:1)
 	fn revoke_delegation_by_delegator() -> Weight {
-		Weight::from_ref_time(26_684_000 as u64)
+		Weight::from_ref_time(27_141_000 as u64)
 			.saturating_add(RocksDbWeight::get().reads(2 as u64))
 			.saturating_add(RocksDbWeight::get().writes(1 as u64))
 	}
 	// Storage: Msa PublicKeyToMsaId (r:1 w:0)
 	// Storage: Msa ProviderToRegistryEntry (r:1 w:1)
 	fn create_provider() -> Weight {
-		Weight::from_ref_time(21_019_000 as u64)
+		Weight::from_ref_time(20_871_000 as u64)
 			.saturating_add(RocksDbWeight::get().reads(2 as u64))
 			.saturating_add(RocksDbWeight::get().writes(1 as u64))
 	}
 	fn on_initialize(m: u32, ) -> Weight {
-		Weight::from_ref_time(12_307_000 as u64)
+		Weight::from_ref_time(12_705_000 as u64)
 			// Standard Error: 0
-			.saturating_add(Weight::from_ref_time(2_000 as u64).saturating_mul(m as u64))
+			.saturating_add(Weight::from_ref_time(3_000 as u64).saturating_mul(m as u64))
 	}
 	// Storage: Msa PublicKeyToMsaId (r:1 w:0)
 	// Storage: Msa DelegatorAndProviderToDelegation (r:1 w:1)
 	// Storage: Schemas CurrentSchemaIdentifierMaximum (r:1 w:0)
 	fn grant_schema_permissions(s: u32, ) -> Weight {
-		Weight::from_ref_time(57_575_000 as u64)
+		Weight::from_ref_time(57_644_000 as u64)
 			// Standard Error: 3_000
-			.saturating_add(Weight::from_ref_time(96_000 as u64).saturating_mul(s as u64))
+			.saturating_add(Weight::from_ref_time(86_000 as u64).saturating_mul(s as u64))
 			.saturating_add(RocksDbWeight::get().reads(3 as u64))
 			.saturating_add(RocksDbWeight::get().writes(1 as u64))
 	}
@@ -278,9 +274,9 @@ impl WeightInfo for () {
 	// Storage: Msa DelegatorAndProviderToDelegation (r:1 w:1)
 	// Storage: Schemas CurrentSchemaIdentifierMaximum (r:1 w:0)
 	fn revoke_schema_permissions(s: u32, ) -> Weight {
-		Weight::from_ref_time(59_886_000 as u64)
+		Weight::from_ref_time(57_453_000 as u64)
 			// Standard Error: 3_000
-			.saturating_add(Weight::from_ref_time(95_000 as u64).saturating_mul(s as u64))
+			.saturating_add(Weight::from_ref_time(88_000 as u64).saturating_mul(s as u64))
 			.saturating_add(RocksDbWeight::get().reads(3 as u64))
 			.saturating_add(RocksDbWeight::get().writes(1 as u64))
 	}

--- a/pallets/schemas/src/weights.rs
+++ b/pallets/schemas/src/weights.rs
@@ -65,9 +65,9 @@ impl<T: frame_system::Config> WeightInfo for SubstrateWeight<T> {
 	fn create_schema(m: u32, n: u32, ) -> Weight {
 		Weight::from_ref_time(0 as u64)
 			// Standard Error: 0
-			.saturating_add(Weight::from_ref_time(31_000 as u64).saturating_mul(m as u64))
-			// Standard Error: 7_000
-			.saturating_add(Weight::from_ref_time(144_000 as u64).saturating_mul(n as u64))
+			.saturating_add(Weight::from_ref_time(33_000 as u64).saturating_mul(m as u64))
+			// Standard Error: 8_000
+			.saturating_add(Weight::from_ref_time(124_000 as u64).saturating_mul(n as u64))
 			.saturating_add(T::DbWeight::get().reads(2 as u64))
 			.saturating_add(T::DbWeight::get().writes(2 as u64))
 	}
@@ -81,9 +81,9 @@ impl WeightInfo for () {
 	fn create_schema(m: u32, n: u32, ) -> Weight {
 		Weight::from_ref_time(0 as u64)
 			// Standard Error: 0
-			.saturating_add(Weight::from_ref_time(31_000 as u64).saturating_mul(m as u64))
-			// Standard Error: 7_000
-			.saturating_add(Weight::from_ref_time(144_000 as u64).saturating_mul(n as u64))
+			.saturating_add(Weight::from_ref_time(33_000 as u64).saturating_mul(m as u64))
+			// Standard Error: 8_000
+			.saturating_add(Weight::from_ref_time(124_000 as u64).saturating_mul(n as u64))
 			.saturating_add(RocksDbWeight::get().reads(2 as u64))
 			.saturating_add(RocksDbWeight::get().writes(2 as u64))
 	}

--- a/runtime/common/src/weights/orml_vesting.rs
+++ b/runtime/common/src/weights/orml_vesting.rs
@@ -38,7 +38,7 @@ impl<T: frame_system::Config> orml_vesting::WeightInfo for SubstrateWeight<T> {
 	// Storage: System Account (r:2 w:2)
 	// Storage: Balances Locks (r:1 w:1)
 	fn vested_transfer() -> Weight {
-		Weight::from_ref_time(59_471_000 as u64)
+		Weight::from_ref_time(60_467_000 as u64)
 			.saturating_add(T::DbWeight::get().reads(5 as u64))
 			.saturating_add(T::DbWeight::get().writes(4 as u64))
 	}
@@ -47,9 +47,9 @@ impl<T: frame_system::Config> orml_vesting::WeightInfo for SubstrateWeight<T> {
 	// Storage: Balances Locks (r:1 w:1)
 	/// The range of component `i` is `[1, 50]`.
 	fn claim(i: u32, ) -> Weight {
-		Weight::from_ref_time(38_282_000 as u64)
+		Weight::from_ref_time(38_502_000 as u64)
 			// Standard Error: 1_000
-			.saturating_add(Weight::from_ref_time(75_000 as u64).saturating_mul(i as u64))
+			.saturating_add(Weight::from_ref_time(78_000 as u64).saturating_mul(i as u64))
 			.saturating_add(T::DbWeight::get().reads(3 as u64))
 			.saturating_add(T::DbWeight::get().writes(2 as u64))
 	}
@@ -58,9 +58,9 @@ impl<T: frame_system::Config> orml_vesting::WeightInfo for SubstrateWeight<T> {
 	// Storage: Vesting VestingSchedules (r:0 w:1)
 	/// The range of component `i` is `[1, 50]`.
 	fn update_vesting_schedules(i: u32, ) -> Weight {
-		Weight::from_ref_time(32_684_000 as u64)
+		Weight::from_ref_time(32_538_000 as u64)
 			// Standard Error: 1_000
-			.saturating_add(Weight::from_ref_time(55_000 as u64).saturating_mul(i as u64))
+			.saturating_add(Weight::from_ref_time(52_000 as u64).saturating_mul(i as u64))
 			.saturating_add(T::DbWeight::get().reads(2 as u64))
 			.saturating_add(T::DbWeight::get().writes(3 as u64))
 	}

--- a/runtime/common/src/weights/pallet_balances.rs
+++ b/runtime/common/src/weights/pallet_balances.rs
@@ -35,43 +35,43 @@ pub struct SubstrateWeight<T>(PhantomData<T>);
 impl<T: frame_system::Config> pallet_balances::WeightInfo for SubstrateWeight<T> {
 	// Storage: System Account (r:1 w:1)
 	fn transfer() -> Weight {
-		Weight::from_ref_time(46_980_000 as u64)
+		Weight::from_ref_time(46_228_000 as u64)
 			.saturating_add(T::DbWeight::get().reads(1 as u64))
 			.saturating_add(T::DbWeight::get().writes(1 as u64))
 	}
 	// Storage: System Account (r:1 w:1)
 	fn transfer_keep_alive() -> Weight {
-		Weight::from_ref_time(35_044_000 as u64)
+		Weight::from_ref_time(34_763_000 as u64)
 			.saturating_add(T::DbWeight::get().reads(1 as u64))
 			.saturating_add(T::DbWeight::get().writes(1 as u64))
 	}
 	// Storage: System Account (r:1 w:1)
 	fn set_balance_creating() -> Weight {
-		Weight::from_ref_time(25_645_000 as u64)
+		Weight::from_ref_time(25_185_000 as u64)
 			.saturating_add(T::DbWeight::get().reads(1 as u64))
 			.saturating_add(T::DbWeight::get().writes(1 as u64))
 	}
 	// Storage: System Account (r:1 w:1)
 	fn set_balance_killing() -> Weight {
-		Weight::from_ref_time(28_922_000 as u64)
+		Weight::from_ref_time(28_407_000 as u64)
 			.saturating_add(T::DbWeight::get().reads(1 as u64))
 			.saturating_add(T::DbWeight::get().writes(1 as u64))
 	}
 	// Storage: System Account (r:2 w:2)
 	fn force_transfer() -> Weight {
-		Weight::from_ref_time(46_896_000 as u64)
+		Weight::from_ref_time(45_807_000 as u64)
 			.saturating_add(T::DbWeight::get().reads(2 as u64))
 			.saturating_add(T::DbWeight::get().writes(2 as u64))
 	}
 	// Storage: System Account (r:1 w:1)
 	fn transfer_all() -> Weight {
-		Weight::from_ref_time(40_764_000 as u64)
+		Weight::from_ref_time(39_607_000 as u64)
 			.saturating_add(T::DbWeight::get().reads(1 as u64))
 			.saturating_add(T::DbWeight::get().writes(1 as u64))
 	}
 	// Storage: System Account (r:1 w:1)
 	fn force_unreserve() -> Weight {
-		Weight::from_ref_time(21_610_000 as u64)
+		Weight::from_ref_time(21_479_000 as u64)
 			.saturating_add(T::DbWeight::get().reads(1 as u64))
 			.saturating_add(T::DbWeight::get().writes(1 as u64))
 	}

--- a/runtime/common/src/weights/pallet_democracy.rs
+++ b/runtime/common/src/weights/pallet_democracy.rs
@@ -38,16 +38,16 @@ impl<T: frame_system::Config> pallet_democracy::WeightInfo for SubstrateWeight<T
 	// Storage: Democracy Blacklist (r:1 w:0)
 	// Storage: Democracy DepositOf (r:0 w:1)
 	fn propose() -> Weight {
-		Weight::from_ref_time(64_652_000 as u64)
+		Weight::from_ref_time(65_181_000 as u64)
 			.saturating_add(T::DbWeight::get().reads(3 as u64))
 			.saturating_add(T::DbWeight::get().writes(3 as u64))
 	}
 	// Storage: Democracy DepositOf (r:1 w:1)
 	/// The range of component `s` is `[0, 100]`.
 	fn second(s: u32, ) -> Weight {
-		Weight::from_ref_time(36_940_000 as u64)
+		Weight::from_ref_time(36_833_000 as u64)
 			// Standard Error: 1_000
-			.saturating_add(Weight::from_ref_time(165_000 as u64).saturating_mul(s as u64))
+			.saturating_add(Weight::from_ref_time(178_000 as u64).saturating_mul(s as u64))
 			.saturating_add(T::DbWeight::get().reads(1 as u64))
 			.saturating_add(T::DbWeight::get().writes(1 as u64))
 	}
@@ -56,9 +56,9 @@ impl<T: frame_system::Config> pallet_democracy::WeightInfo for SubstrateWeight<T
 	// Storage: Balances Locks (r:1 w:1)
 	/// The range of component `r` is `[1, 99]`.
 	fn vote_new(r: u32, ) -> Weight {
-		Weight::from_ref_time(49_272_000 as u64)
-			// Standard Error: 2_000
-			.saturating_add(Weight::from_ref_time(268_000 as u64).saturating_mul(r as u64))
+		Weight::from_ref_time(49_570_000 as u64)
+			// Standard Error: 3_000
+			.saturating_add(Weight::from_ref_time(273_000 as u64).saturating_mul(r as u64))
 			.saturating_add(T::DbWeight::get().reads(3 as u64))
 			.saturating_add(T::DbWeight::get().writes(3 as u64))
 	}
@@ -67,16 +67,16 @@ impl<T: frame_system::Config> pallet_democracy::WeightInfo for SubstrateWeight<T
 	// Storage: Balances Locks (r:1 w:1)
 	/// The range of component `r` is `[1, 99]`.
 	fn vote_existing(r: u32, ) -> Weight {
-		Weight::from_ref_time(48_261_000 as u64)
-			// Standard Error: 1_000
-			.saturating_add(Weight::from_ref_time(301_000 as u64).saturating_mul(r as u64))
+		Weight::from_ref_time(49_944_000 as u64)
+			// Standard Error: 3_000
+			.saturating_add(Weight::from_ref_time(271_000 as u64).saturating_mul(r as u64))
 			.saturating_add(T::DbWeight::get().reads(3 as u64))
 			.saturating_add(T::DbWeight::get().writes(3 as u64))
 	}
 	// Storage: Democracy ReferendumInfoOf (r:1 w:1)
 	// Storage: Democracy Cancellations (r:1 w:1)
 	fn emergency_cancel() -> Weight {
-		Weight::from_ref_time(23_408_000 as u64)
+		Weight::from_ref_time(23_501_000 as u64)
 			.saturating_add(T::DbWeight::get().reads(2 as u64))
 			.saturating_add(T::DbWeight::get().writes(2 as u64))
 	}
@@ -88,9 +88,9 @@ impl<T: frame_system::Config> pallet_democracy::WeightInfo for SubstrateWeight<T
 	// Storage: System Account (r:1 w:1)
 	/// The range of component `p` is `[1, 100]`.
 	fn blacklist(p: u32, ) -> Weight {
-		Weight::from_ref_time(58_031_000 as u64)
-			// Standard Error: 7_000
-			.saturating_add(Weight::from_ref_time(331_000 as u64).saturating_mul(p as u64))
+		Weight::from_ref_time(58_014_000 as u64)
+			// Standard Error: 6_000
+			.saturating_add(Weight::from_ref_time(350_000 as u64).saturating_mul(p as u64))
 			.saturating_add(T::DbWeight::get().reads(5 as u64))
 			.saturating_add(T::DbWeight::get().writes(6 as u64))
 	}
@@ -98,27 +98,27 @@ impl<T: frame_system::Config> pallet_democracy::WeightInfo for SubstrateWeight<T
 	// Storage: Democracy Blacklist (r:1 w:0)
 	/// The range of component `v` is `[1, 100]`.
 	fn external_propose(v: u32, ) -> Weight {
-		Weight::from_ref_time(16_860_000 as u64)
-			// Standard Error: 0
-			.saturating_add(Weight::from_ref_time(14_000 as u64).saturating_mul(v as u64))
+		Weight::from_ref_time(16_961_000 as u64)
+			// Standard Error: 2_000
+			.saturating_add(Weight::from_ref_time(19_000 as u64).saturating_mul(v as u64))
 			.saturating_add(T::DbWeight::get().reads(2 as u64))
 			.saturating_add(T::DbWeight::get().writes(1 as u64))
 	}
 	// Storage: Democracy NextExternal (r:0 w:1)
 	fn external_propose_majority() -> Weight {
-		Weight::from_ref_time(5_141_000 as u64)
+		Weight::from_ref_time(5_202_000 as u64)
 			.saturating_add(T::DbWeight::get().writes(1 as u64))
 	}
 	// Storage: Democracy NextExternal (r:0 w:1)
 	fn external_propose_default() -> Weight {
-		Weight::from_ref_time(5_333_000 as u64)
+		Weight::from_ref_time(5_283_000 as u64)
 			.saturating_add(T::DbWeight::get().writes(1 as u64))
 	}
 	// Storage: Democracy NextExternal (r:1 w:1)
 	// Storage: Democracy ReferendumCount (r:1 w:1)
 	// Storage: Democracy ReferendumInfoOf (r:0 w:1)
 	fn fast_track() -> Weight {
-		Weight::from_ref_time(23_659_000 as u64)
+		Weight::from_ref_time(24_043_000 as u64)
 			.saturating_add(T::DbWeight::get().reads(2 as u64))
 			.saturating_add(T::DbWeight::get().writes(3 as u64))
 	}
@@ -126,7 +126,7 @@ impl<T: frame_system::Config> pallet_democracy::WeightInfo for SubstrateWeight<T
 	// Storage: Democracy Blacklist (r:1 w:1)
 	/// The range of component `v` is `[0, 100]`.
 	fn veto_external(v: u32, ) -> Weight {
-		Weight::from_ref_time(25_550_000 as u64)
+		Weight::from_ref_time(25_666_000 as u64)
 			// Standard Error: 0
 			.saturating_add(Weight::from_ref_time(33_000 as u64).saturating_mul(v as u64))
 			.saturating_add(T::DbWeight::get().reads(2 as u64))
@@ -137,24 +137,24 @@ impl<T: frame_system::Config> pallet_democracy::WeightInfo for SubstrateWeight<T
 	// Storage: System Account (r:1 w:1)
 	/// The range of component `p` is `[1, 100]`.
 	fn cancel_proposal(p: u32, ) -> Weight {
-		Weight::from_ref_time(46_696_000 as u64)
+		Weight::from_ref_time(46_558_000 as u64)
 			// Standard Error: 3_000
-			.saturating_add(Weight::from_ref_time(301_000 as u64).saturating_mul(p as u64))
+			.saturating_add(Weight::from_ref_time(325_000 as u64).saturating_mul(p as u64))
 			.saturating_add(T::DbWeight::get().reads(3 as u64))
 			.saturating_add(T::DbWeight::get().writes(3 as u64))
 	}
 	// Storage: Democracy ReferendumInfoOf (r:0 w:1)
 	fn cancel_referendum() -> Weight {
-		Weight::from_ref_time(15_288_000 as u64)
+		Weight::from_ref_time(15_305_000 as u64)
 			.saturating_add(T::DbWeight::get().writes(1 as u64))
 	}
 	// Storage: Scheduler Lookup (r:1 w:1)
 	// Storage: Scheduler Agenda (r:1 w:1)
 	/// The range of component `r` is `[1, 99]`.
 	fn cancel_queued(r: u32, ) -> Weight {
-		Weight::from_ref_time(28_153_000 as u64)
+		Weight::from_ref_time(28_147_000 as u64)
 			// Standard Error: 3_000
-			.saturating_add(Weight::from_ref_time(625_000 as u64).saturating_mul(r as u64))
+			.saturating_add(Weight::from_ref_time(633_000 as u64).saturating_mul(r as u64))
 			.saturating_add(T::DbWeight::get().reads(2 as u64))
 			.saturating_add(T::DbWeight::get().writes(2 as u64))
 	}
@@ -163,9 +163,9 @@ impl<T: frame_system::Config> pallet_democracy::WeightInfo for SubstrateWeight<T
 	// Storage: Democracy ReferendumInfoOf (r:1 w:0)
 	/// The range of component `r` is `[1, 99]`.
 	fn on_initialize_base(r: u32, ) -> Weight {
-		Weight::from_ref_time(8_753_000 as u64)
-			// Standard Error: 3_000
-			.saturating_add(Weight::from_ref_time(2_595_000 as u64).saturating_mul(r as u64))
+		Weight::from_ref_time(8_873_000 as u64)
+			// Standard Error: 4_000
+			.saturating_add(Weight::from_ref_time(2_586_000 as u64).saturating_mul(r as u64))
 			.saturating_add(T::DbWeight::get().reads(2 as u64))
 			.saturating_add(T::DbWeight::get().reads((1 as u64).saturating_mul(r as u64)))
 			.saturating_add(T::DbWeight::get().writes(1 as u64))
@@ -178,9 +178,9 @@ impl<T: frame_system::Config> pallet_democracy::WeightInfo for SubstrateWeight<T
 	// Storage: Democracy ReferendumInfoOf (r:1 w:0)
 	/// The range of component `r` is `[1, 99]`.
 	fn on_initialize_base_with_launch_period(r: u32, ) -> Weight {
-		Weight::from_ref_time(11_263_000 as u64)
-			// Standard Error: 3_000
-			.saturating_add(Weight::from_ref_time(2_599_000 as u64).saturating_mul(r as u64))
+		Weight::from_ref_time(11_265_000 as u64)
+			// Standard Error: 4_000
+			.saturating_add(Weight::from_ref_time(2_614_000 as u64).saturating_mul(r as u64))
 			.saturating_add(T::DbWeight::get().reads(5 as u64))
 			.saturating_add(T::DbWeight::get().reads((1 as u64).saturating_mul(r as u64)))
 			.saturating_add(T::DbWeight::get().writes(1 as u64))
@@ -190,9 +190,9 @@ impl<T: frame_system::Config> pallet_democracy::WeightInfo for SubstrateWeight<T
 	// Storage: Balances Locks (r:1 w:1)
 	/// The range of component `r` is `[1, 99]`.
 	fn delegate(r: u32, ) -> Weight {
-		Weight::from_ref_time(52_185_000 as u64)
-			// Standard Error: 4_000
-			.saturating_add(Weight::from_ref_time(3_932_000 as u64).saturating_mul(r as u64))
+		Weight::from_ref_time(52_839_000 as u64)
+			// Standard Error: 6_000
+			.saturating_add(Weight::from_ref_time(3_927_000 as u64).saturating_mul(r as u64))
 			.saturating_add(T::DbWeight::get().reads(4 as u64))
 			.saturating_add(T::DbWeight::get().reads((1 as u64).saturating_mul(r as u64)))
 			.saturating_add(T::DbWeight::get().writes(4 as u64))
@@ -202,9 +202,9 @@ impl<T: frame_system::Config> pallet_democracy::WeightInfo for SubstrateWeight<T
 	// Storage: Democracy ReferendumInfoOf (r:1 w:1)
 	/// The range of component `r` is `[1, 99]`.
 	fn undelegate(r: u32, ) -> Weight {
-		Weight::from_ref_time(29_917_000 as u64)
-			// Standard Error: 4_000
-			.saturating_add(Weight::from_ref_time(3_871_000 as u64).saturating_mul(r as u64))
+		Weight::from_ref_time(28_800_000 as u64)
+			// Standard Error: 6_000
+			.saturating_add(Weight::from_ref_time(3_957_000 as u64).saturating_mul(r as u64))
 			.saturating_add(T::DbWeight::get().reads(2 as u64))
 			.saturating_add(T::DbWeight::get().reads((1 as u64).saturating_mul(r as u64)))
 			.saturating_add(T::DbWeight::get().writes(2 as u64))
@@ -212,13 +212,13 @@ impl<T: frame_system::Config> pallet_democracy::WeightInfo for SubstrateWeight<T
 	}
 	// Storage: Democracy PublicProps (r:0 w:1)
 	fn clear_public_proposals() -> Weight {
-		Weight::from_ref_time(6_616_000 as u64)
+		Weight::from_ref_time(6_551_000 as u64)
 			.saturating_add(T::DbWeight::get().writes(1 as u64))
 	}
 	// Storage: Democracy Preimages (r:1 w:1)
 	/// The range of component `b` is `[0, 16384]`.
 	fn note_preimage(b: u32, ) -> Weight {
-		Weight::from_ref_time(33_585_000 as u64)
+		Weight::from_ref_time(33_481_000 as u64)
 			// Standard Error: 0
 			.saturating_add(Weight::from_ref_time(2_000 as u64).saturating_mul(b as u64))
 			.saturating_add(T::DbWeight::get().reads(1 as u64))
@@ -227,7 +227,7 @@ impl<T: frame_system::Config> pallet_democracy::WeightInfo for SubstrateWeight<T
 	// Storage: Democracy Preimages (r:1 w:1)
 	/// The range of component `b` is `[0, 16384]`.
 	fn note_imminent_preimage(b: u32, ) -> Weight {
-		Weight::from_ref_time(24_761_000 as u64)
+		Weight::from_ref_time(24_918_000 as u64)
 			// Standard Error: 0
 			.saturating_add(Weight::from_ref_time(2_000 as u64).saturating_mul(b as u64))
 			.saturating_add(T::DbWeight::get().reads(1 as u64))
@@ -237,7 +237,7 @@ impl<T: frame_system::Config> pallet_democracy::WeightInfo for SubstrateWeight<T
 	// Storage: System Account (r:1 w:1)
 	/// The range of component `b` is `[0, 16384]`.
 	fn reap_preimage(b: u32, ) -> Weight {
-		Weight::from_ref_time(43_297_000 as u64)
+		Weight::from_ref_time(43_538_000 as u64)
 			// Standard Error: 0
 			.saturating_add(Weight::from_ref_time(1_000 as u64).saturating_mul(b as u64))
 			.saturating_add(T::DbWeight::get().reads(2 as u64))
@@ -248,9 +248,9 @@ impl<T: frame_system::Config> pallet_democracy::WeightInfo for SubstrateWeight<T
 	// Storage: System Account (r:1 w:1)
 	/// The range of component `r` is `[1, 99]`.
 	fn unlock_remove(r: u32, ) -> Weight {
-		Weight::from_ref_time(36_477_000 as u64)
+		Weight::from_ref_time(35_963_000 as u64)
 			// Standard Error: 1_000
-			.saturating_add(Weight::from_ref_time(201_000 as u64).saturating_mul(r as u64))
+			.saturating_add(Weight::from_ref_time(216_000 as u64).saturating_mul(r as u64))
 			.saturating_add(T::DbWeight::get().reads(3 as u64))
 			.saturating_add(T::DbWeight::get().writes(3 as u64))
 	}
@@ -259,9 +259,9 @@ impl<T: frame_system::Config> pallet_democracy::WeightInfo for SubstrateWeight<T
 	// Storage: System Account (r:1 w:1)
 	/// The range of component `r` is `[1, 99]`.
 	fn unlock_set(r: u32, ) -> Weight {
-		Weight::from_ref_time(35_326_000 as u64)
+		Weight::from_ref_time(35_274_000 as u64)
 			// Standard Error: 1_000
-			.saturating_add(Weight::from_ref_time(248_000 as u64).saturating_mul(r as u64))
+			.saturating_add(Weight::from_ref_time(266_000 as u64).saturating_mul(r as u64))
 			.saturating_add(T::DbWeight::get().reads(3 as u64))
 			.saturating_add(T::DbWeight::get().writes(3 as u64))
 	}
@@ -269,9 +269,9 @@ impl<T: frame_system::Config> pallet_democracy::WeightInfo for SubstrateWeight<T
 	// Storage: Democracy VotingOf (r:1 w:1)
 	/// The range of component `r` is `[1, 99]`.
 	fn remove_vote(r: u32, ) -> Weight {
-		Weight::from_ref_time(20_876_000 as u64)
-			// Standard Error: 2_000
-			.saturating_add(Weight::from_ref_time(241_000 as u64).saturating_mul(r as u64))
+		Weight::from_ref_time(20_513_000 as u64)
+			// Standard Error: 1_000
+			.saturating_add(Weight::from_ref_time(260_000 as u64).saturating_mul(r as u64))
 			.saturating_add(T::DbWeight::get().reads(2 as u64))
 			.saturating_add(T::DbWeight::get().writes(2 as u64))
 	}
@@ -279,9 +279,9 @@ impl<T: frame_system::Config> pallet_democracy::WeightInfo for SubstrateWeight<T
 	// Storage: Democracy VotingOf (r:1 w:1)
 	/// The range of component `r` is `[1, 99]`.
 	fn remove_other_vote(r: u32, ) -> Weight {
-		Weight::from_ref_time(20_559_000 as u64)
+		Weight::from_ref_time(20_587_000 as u64)
 			// Standard Error: 1_000
-			.saturating_add(Weight::from_ref_time(252_000 as u64).saturating_mul(r as u64))
+			.saturating_add(Weight::from_ref_time(257_000 as u64).saturating_mul(r as u64))
 			.saturating_add(T::DbWeight::get().reads(2 as u64))
 			.saturating_add(T::DbWeight::get().writes(2 as u64))
 	}

--- a/runtime/common/src/weights/pallet_preimage.rs
+++ b/runtime/common/src/weights/pallet_preimage.rs
@@ -66,58 +66,58 @@ impl<T: frame_system::Config> pallet_preimage::WeightInfo for SubstrateWeight<T>
 	// Storage: Preimage StatusFor (r:1 w:1)
 	// Storage: Preimage PreimageFor (r:0 w:1)
 	fn unnote_preimage() -> Weight {
-		Weight::from_ref_time(55_158_000 as u64)
+		Weight::from_ref_time(46_973_000 as u64)
 			.saturating_add(T::DbWeight::get().reads(1 as u64))
 			.saturating_add(T::DbWeight::get().writes(2 as u64))
 	}
 	// Storage: Preimage StatusFor (r:1 w:1)
 	// Storage: Preimage PreimageFor (r:0 w:1)
 	fn unnote_no_deposit_preimage() -> Weight {
-		Weight::from_ref_time(38_893_000 as u64)
+		Weight::from_ref_time(36_633_000 as u64)
 			.saturating_add(T::DbWeight::get().reads(1 as u64))
 			.saturating_add(T::DbWeight::get().writes(2 as u64))
 	}
 	// Storage: Preimage StatusFor (r:1 w:1)
 	fn request_preimage() -> Weight {
-		Weight::from_ref_time(55_072_000 as u64)
+		Weight::from_ref_time(47_064_000 as u64)
 			.saturating_add(T::DbWeight::get().reads(1 as u64))
 			.saturating_add(T::DbWeight::get().writes(1 as u64))
 	}
 	// Storage: Preimage StatusFor (r:1 w:1)
 	fn request_no_deposit_preimage() -> Weight {
-		Weight::from_ref_time(38_453_000 as u64)
+		Weight::from_ref_time(31_325_000 as u64)
 			.saturating_add(T::DbWeight::get().reads(1 as u64))
 			.saturating_add(T::DbWeight::get().writes(1 as u64))
 	}
 	// Storage: Preimage StatusFor (r:1 w:1)
 	fn request_unnoted_preimage() -> Weight {
-		Weight::from_ref_time(25_176_000 as u64)
+		Weight::from_ref_time(23_659_000 as u64)
 			.saturating_add(T::DbWeight::get().reads(1 as u64))
 			.saturating_add(T::DbWeight::get().writes(1 as u64))
 	}
 	// Storage: Preimage StatusFor (r:1 w:1)
 	fn request_requested_preimage() -> Weight {
-		Weight::from_ref_time(12_875_000 as u64)
+		Weight::from_ref_time(12_996_000 as u64)
 			.saturating_add(T::DbWeight::get().reads(1 as u64))
 			.saturating_add(T::DbWeight::get().writes(1 as u64))
 	}
 	// Storage: Preimage StatusFor (r:1 w:1)
 	// Storage: Preimage PreimageFor (r:0 w:1)
 	fn unrequest_preimage() -> Weight {
-		Weight::from_ref_time(36_098_000 as u64)
+		Weight::from_ref_time(30_238_000 as u64)
 			.saturating_add(T::DbWeight::get().reads(1 as u64))
 			.saturating_add(T::DbWeight::get().writes(2 as u64))
 	}
 	// Storage: Preimage StatusFor (r:1 w:1)
 	// Storage: Preimage PreimageFor (r:0 w:1)
 	fn unrequest_unnoted_preimage() -> Weight {
-		Weight::from_ref_time(26_766_000 as u64)
+		Weight::from_ref_time(26_700_000 as u64)
 			.saturating_add(T::DbWeight::get().reads(1 as u64))
 			.saturating_add(T::DbWeight::get().writes(2 as u64))
 	}
 	// Storage: Preimage StatusFor (r:1 w:1)
 	fn unrequest_multi_referenced_preimage() -> Weight {
-		Weight::from_ref_time(12_497_000 as u64)
+		Weight::from_ref_time(13_137_000 as u64)
 			.saturating_add(T::DbWeight::get().reads(1 as u64))
 			.saturating_add(T::DbWeight::get().writes(1 as u64))
 	}

--- a/runtime/common/src/weights/pallet_scheduler.rs
+++ b/runtime/common/src/weights/pallet_scheduler.rs
@@ -39,9 +39,9 @@ impl<T: frame_system::Config> pallet_scheduler::WeightInfo for SubstrateWeight<T
 	// Storage: Scheduler Lookup (r:0 w:1)
 	/// The range of component `s` is `[1, 50]`.
 	fn on_initialize_periodic_named_resolved(s: u32, ) -> Weight {
-		Weight::from_ref_time(16_328_000 as u64)
-			// Standard Error: 15_000
-			.saturating_add(Weight::from_ref_time(20_401_000 as u64).saturating_mul(s as u64))
+		Weight::from_ref_time(15_866_000 as u64)
+			// Standard Error: 13_000
+			.saturating_add(Weight::from_ref_time(20_831_000 as u64).saturating_mul(s as u64))
 			.saturating_add(T::DbWeight::get().reads(1 as u64))
 			.saturating_add(T::DbWeight::get().reads((3 as u64).saturating_mul(s as u64)))
 			.saturating_add(T::DbWeight::get().writes(1 as u64))
@@ -53,9 +53,9 @@ impl<T: frame_system::Config> pallet_scheduler::WeightInfo for SubstrateWeight<T
 	// Storage: Scheduler Lookup (r:0 w:1)
 	/// The range of component `s` is `[1, 50]`.
 	fn on_initialize_named_resolved(s: u32, ) -> Weight {
-		Weight::from_ref_time(15_129_000 as u64)
-			// Standard Error: 13_000
-			.saturating_add(Weight::from_ref_time(16_289_000 as u64).saturating_mul(s as u64))
+		Weight::from_ref_time(15_442_000 as u64)
+			// Standard Error: 14_000
+			.saturating_add(Weight::from_ref_time(16_482_000 as u64).saturating_mul(s as u64))
 			.saturating_add(T::DbWeight::get().reads(1 as u64))
 			.saturating_add(T::DbWeight::get().reads((2 as u64).saturating_mul(s as u64)))
 			.saturating_add(T::DbWeight::get().writes(1 as u64))
@@ -66,9 +66,9 @@ impl<T: frame_system::Config> pallet_scheduler::WeightInfo for SubstrateWeight<T
 	// Storage: Preimage StatusFor (r:1 w:1)
 	/// The range of component `s` is `[1, 50]`.
 	fn on_initialize_periodic_resolved(s: u32, ) -> Weight {
-		Weight::from_ref_time(15_036_000 as u64)
-			// Standard Error: 17_000
-			.saturating_add(Weight::from_ref_time(17_224_000 as u64).saturating_mul(s as u64))
+		Weight::from_ref_time(15_043_000 as u64)
+			// Standard Error: 15_000
+			.saturating_add(Weight::from_ref_time(17_537_000 as u64).saturating_mul(s as u64))
 			.saturating_add(T::DbWeight::get().reads(1 as u64))
 			.saturating_add(T::DbWeight::get().reads((3 as u64).saturating_mul(s as u64)))
 			.saturating_add(T::DbWeight::get().writes(1 as u64))
@@ -79,9 +79,9 @@ impl<T: frame_system::Config> pallet_scheduler::WeightInfo for SubstrateWeight<T
 	// Storage: Preimage StatusFor (r:1 w:1)
 	/// The range of component `s` is `[1, 50]`.
 	fn on_initialize_resolved(s: u32, ) -> Weight {
-		Weight::from_ref_time(15_368_000 as u64)
-			// Standard Error: 11_000
-			.saturating_add(Weight::from_ref_time(14_870_000 as u64).saturating_mul(s as u64))
+		Weight::from_ref_time(15_847_000 as u64)
+			// Standard Error: 13_000
+			.saturating_add(Weight::from_ref_time(15_045_000 as u64).saturating_mul(s as u64))
 			.saturating_add(T::DbWeight::get().reads(1 as u64))
 			.saturating_add(T::DbWeight::get().reads((2 as u64).saturating_mul(s as u64)))
 			.saturating_add(T::DbWeight::get().writes(1 as u64))
@@ -92,9 +92,9 @@ impl<T: frame_system::Config> pallet_scheduler::WeightInfo for SubstrateWeight<T
 	// Storage: Scheduler Lookup (r:0 w:1)
 	/// The range of component `s` is `[1, 50]`.
 	fn on_initialize_named_aborted(s: u32, ) -> Weight {
-		Weight::from_ref_time(7_789_000 as u64)
-			// Standard Error: 5_000
-			.saturating_add(Weight::from_ref_time(5_523_000 as u64).saturating_mul(s as u64))
+		Weight::from_ref_time(7_225_000 as u64)
+			// Standard Error: 6_000
+			.saturating_add(Weight::from_ref_time(5_575_000 as u64).saturating_mul(s as u64))
 			.saturating_add(T::DbWeight::get().reads(2 as u64))
 			.saturating_add(T::DbWeight::get().reads((1 as u64).saturating_mul(s as u64)))
 			.saturating_add(T::DbWeight::get().writes(2 as u64))
@@ -104,9 +104,9 @@ impl<T: frame_system::Config> pallet_scheduler::WeightInfo for SubstrateWeight<T
 	// Storage: Preimage PreimageFor (r:1 w:0)
 	/// The range of component `s` is `[1, 50]`.
 	fn on_initialize_aborted(s: u32, ) -> Weight {
-		Weight::from_ref_time(10_201_000 as u64)
-			// Standard Error: 2_000
-			.saturating_add(Weight::from_ref_time(2_588_000 as u64).saturating_mul(s as u64))
+		Weight::from_ref_time(10_380_000 as u64)
+			// Standard Error: 5_000
+			.saturating_add(Weight::from_ref_time(2_687_000 as u64).saturating_mul(s as u64))
 			.saturating_add(T::DbWeight::get().reads(2 as u64))
 			.saturating_add(T::DbWeight::get().reads((1 as u64).saturating_mul(s as u64)))
 			.saturating_add(T::DbWeight::get().writes(2 as u64))
@@ -115,9 +115,9 @@ impl<T: frame_system::Config> pallet_scheduler::WeightInfo for SubstrateWeight<T
 	// Storage: Scheduler Lookup (r:0 w:1)
 	/// The range of component `s` is `[1, 50]`.
 	fn on_initialize_periodic_named(s: u32, ) -> Weight {
-		Weight::from_ref_time(17_020_000 as u64)
-			// Standard Error: 7_000
-			.saturating_add(Weight::from_ref_time(9_757_000 as u64).saturating_mul(s as u64))
+		Weight::from_ref_time(16_968_000 as u64)
+			// Standard Error: 8_000
+			.saturating_add(Weight::from_ref_time(9_959_000 as u64).saturating_mul(s as u64))
 			.saturating_add(T::DbWeight::get().reads(1 as u64))
 			.saturating_add(T::DbWeight::get().reads((1 as u64).saturating_mul(s as u64)))
 			.saturating_add(T::DbWeight::get().writes(1 as u64))
@@ -126,9 +126,9 @@ impl<T: frame_system::Config> pallet_scheduler::WeightInfo for SubstrateWeight<T
 	// Storage: Scheduler Agenda (r:2 w:2)
 	/// The range of component `s` is `[1, 50]`.
 	fn on_initialize_periodic(s: u32, ) -> Weight {
-		Weight::from_ref_time(15_164_000 as u64)
-			// Standard Error: 4_000
-			.saturating_add(Weight::from_ref_time(6_867_000 as u64).saturating_mul(s as u64))
+		Weight::from_ref_time(14_792_000 as u64)
+			// Standard Error: 7_000
+			.saturating_add(Weight::from_ref_time(6_980_000 as u64).saturating_mul(s as u64))
 			.saturating_add(T::DbWeight::get().reads(1 as u64))
 			.saturating_add(T::DbWeight::get().reads((1 as u64).saturating_mul(s as u64)))
 			.saturating_add(T::DbWeight::get().writes(1 as u64))
@@ -138,9 +138,9 @@ impl<T: frame_system::Config> pallet_scheduler::WeightInfo for SubstrateWeight<T
 	// Storage: Scheduler Lookup (r:0 w:1)
 	/// The range of component `s` is `[1, 50]`.
 	fn on_initialize_named(s: u32, ) -> Weight {
-		Weight::from_ref_time(16_040_000 as u64)
-			// Standard Error: 4_000
-			.saturating_add(Weight::from_ref_time(6_031_000 as u64).saturating_mul(s as u64))
+		Weight::from_ref_time(17_052_000 as u64)
+			// Standard Error: 5_000
+			.saturating_add(Weight::from_ref_time(6_099_000 as u64).saturating_mul(s as u64))
 			.saturating_add(T::DbWeight::get().reads(1 as u64))
 			.saturating_add(T::DbWeight::get().writes(1 as u64))
 			.saturating_add(T::DbWeight::get().writes((1 as u64).saturating_mul(s as u64)))
@@ -148,18 +148,18 @@ impl<T: frame_system::Config> pallet_scheduler::WeightInfo for SubstrateWeight<T
 	// Storage: Scheduler Agenda (r:1 w:1)
 	/// The range of component `s` is `[1, 50]`.
 	fn on_initialize(s: u32, ) -> Weight {
-		Weight::from_ref_time(15_919_000 as u64)
-			// Standard Error: 3_000
-			.saturating_add(Weight::from_ref_time(4_772_000 as u64).saturating_mul(s as u64))
+		Weight::from_ref_time(16_189_000 as u64)
+			// Standard Error: 4_000
+			.saturating_add(Weight::from_ref_time(4_847_000 as u64).saturating_mul(s as u64))
 			.saturating_add(T::DbWeight::get().reads(1 as u64))
 			.saturating_add(T::DbWeight::get().writes(1 as u64))
 	}
 	// Storage: Scheduler Agenda (r:1 w:1)
 	/// The range of component `s` is `[0, 50]`.
 	fn schedule(s: u32, ) -> Weight {
-		Weight::from_ref_time(19_821_000 as u64)
+		Weight::from_ref_time(19_915_000 as u64)
 			// Standard Error: 1_000
-			.saturating_add(Weight::from_ref_time(110_000 as u64).saturating_mul(s as u64))
+			.saturating_add(Weight::from_ref_time(126_000 as u64).saturating_mul(s as u64))
 			.saturating_add(T::DbWeight::get().reads(1 as u64))
 			.saturating_add(T::DbWeight::get().writes(1 as u64))
 	}
@@ -167,9 +167,9 @@ impl<T: frame_system::Config> pallet_scheduler::WeightInfo for SubstrateWeight<T
 	// Storage: Scheduler Lookup (r:0 w:1)
 	/// The range of component `s` is `[1, 50]`.
 	fn cancel(s: u32, ) -> Weight {
-		Weight::from_ref_time(20_415_000 as u64)
+		Weight::from_ref_time(20_430_000 as u64)
 			// Standard Error: 1_000
-			.saturating_add(Weight::from_ref_time(545_000 as u64).saturating_mul(s as u64))
+			.saturating_add(Weight::from_ref_time(556_000 as u64).saturating_mul(s as u64))
 			.saturating_add(T::DbWeight::get().reads(1 as u64))
 			.saturating_add(T::DbWeight::get().writes(2 as u64))
 	}
@@ -177,9 +177,9 @@ impl<T: frame_system::Config> pallet_scheduler::WeightInfo for SubstrateWeight<T
 	// Storage: Scheduler Agenda (r:1 w:1)
 	/// The range of component `s` is `[0, 50]`.
 	fn schedule_named(s: u32, ) -> Weight {
-		Weight::from_ref_time(24_466_000 as u64)
+		Weight::from_ref_time(24_587_000 as u64)
 			// Standard Error: 3_000
-			.saturating_add(Weight::from_ref_time(174_000 as u64).saturating_mul(s as u64))
+			.saturating_add(Weight::from_ref_time(178_000 as u64).saturating_mul(s as u64))
 			.saturating_add(T::DbWeight::get().reads(2 as u64))
 			.saturating_add(T::DbWeight::get().writes(2 as u64))
 	}
@@ -187,9 +187,9 @@ impl<T: frame_system::Config> pallet_scheduler::WeightInfo for SubstrateWeight<T
 	// Storage: Scheduler Agenda (r:1 w:1)
 	/// The range of component `s` is `[1, 50]`.
 	fn cancel_named(s: u32, ) -> Weight {
-		Weight::from_ref_time(24_028_000 as u64)
+		Weight::from_ref_time(24_256_000 as u64)
 			// Standard Error: 3_000
-			.saturating_add(Weight::from_ref_time(599_000 as u64).saturating_mul(s as u64))
+			.saturating_add(Weight::from_ref_time(612_000 as u64).saturating_mul(s as u64))
 			.saturating_add(T::DbWeight::get().reads(2 as u64))
 			.saturating_add(T::DbWeight::get().writes(2 as u64))
 	}

--- a/runtime/common/src/weights/pallet_session.rs
+++ b/runtime/common/src/weights/pallet_session.rs
@@ -36,14 +36,14 @@ impl<T: frame_system::Config> pallet_session::WeightInfo for SubstrateWeight<T> 
 	// Storage: Session NextKeys (r:1 w:1)
 	// Storage: Session KeyOwner (r:1 w:1)
 	fn set_keys() -> Weight {
-		Weight::from_ref_time(23_057_000 as u64)
+		Weight::from_ref_time(23_001_000 as u64)
 			.saturating_add(T::DbWeight::get().reads(2 as u64))
 			.saturating_add(T::DbWeight::get().writes(2 as u64))
 	}
 	// Storage: Session NextKeys (r:1 w:1)
 	// Storage: Session KeyOwner (r:0 w:1)
 	fn purge_keys() -> Weight {
-		Weight::from_ref_time(20_092_000 as u64)
+		Weight::from_ref_time(20_407_000 as u64)
 			.saturating_add(T::DbWeight::get().reads(1 as u64))
 			.saturating_add(T::DbWeight::get().writes(2 as u64))
 	}

--- a/runtime/common/src/weights/pallet_timestamp.rs
+++ b/runtime/common/src/weights/pallet_timestamp.rs
@@ -35,11 +35,11 @@ pub struct SubstrateWeight<T>(PhantomData<T>);
 impl<T: frame_system::Config> pallet_timestamp::WeightInfo for SubstrateWeight<T> {
 	// Storage: Timestamp Now (r:1 w:1)
 	fn set() -> Weight {
-		Weight::from_ref_time(9_060_000 as u64)
+		Weight::from_ref_time(8_911_000 as u64)
 			.saturating_add(T::DbWeight::get().reads(1 as u64))
 			.saturating_add(T::DbWeight::get().writes(1 as u64))
 	}
 	fn on_finalize() -> Weight {
-		Weight::from_ref_time(5_370_000 as u64)
+		Weight::from_ref_time(5_189_000 as u64)
 	}
 }

--- a/runtime/common/src/weights/pallet_treasury.rs
+++ b/runtime/common/src/weights/pallet_treasury.rs
@@ -34,19 +34,19 @@ use sp_std::marker::PhantomData;
 pub struct SubstrateWeight<T>(PhantomData<T>);
 impl<T: frame_system::Config> pallet_treasury::WeightInfo for SubstrateWeight<T> {
 	fn spend() -> Weight {
-		Weight::from_ref_time(158_000 as u64)
+		Weight::from_ref_time(176_000 as u64)
 	}
 	// Storage: Treasury ProposalCount (r:1 w:1)
 	// Storage: Treasury Proposals (r:0 w:1)
 	fn propose_spend() -> Weight {
-		Weight::from_ref_time(30_137_000 as u64)
+		Weight::from_ref_time(30_543_000 as u64)
 			.saturating_add(T::DbWeight::get().reads(1 as u64))
 			.saturating_add(T::DbWeight::get().writes(2 as u64))
 	}
 	// Storage: Treasury Proposals (r:1 w:1)
 	// Storage: System Account (r:1 w:1)
 	fn reject_proposal() -> Weight {
-		Weight::from_ref_time(36_573_000 as u64)
+		Weight::from_ref_time(36_747_000 as u64)
 			.saturating_add(T::DbWeight::get().reads(2 as u64))
 			.saturating_add(T::DbWeight::get().writes(2 as u64))
 	}
@@ -54,15 +54,15 @@ impl<T: frame_system::Config> pallet_treasury::WeightInfo for SubstrateWeight<T>
 	// Storage: Treasury Approvals (r:1 w:1)
 	/// The range of component `p` is `[0, 63]`.
 	fn approve_proposal(p: u32, ) -> Weight {
-		Weight::from_ref_time(12_962_000 as u64)
+		Weight::from_ref_time(12_925_000 as u64)
 			// Standard Error: 1_000
-			.saturating_add(Weight::from_ref_time(246_000 as u64).saturating_mul(p as u64))
+			.saturating_add(Weight::from_ref_time(257_000 as u64).saturating_mul(p as u64))
 			.saturating_add(T::DbWeight::get().reads(2 as u64))
 			.saturating_add(T::DbWeight::get().writes(1 as u64))
 	}
 	// Storage: Treasury Approvals (r:1 w:1)
 	fn remove_approval() -> Weight {
-		Weight::from_ref_time(9_673_000 as u64)
+		Weight::from_ref_time(9_994_000 as u64)
 			.saturating_add(T::DbWeight::get().reads(1 as u64))
 			.saturating_add(T::DbWeight::get().writes(1 as u64))
 	}
@@ -71,9 +71,9 @@ impl<T: frame_system::Config> pallet_treasury::WeightInfo for SubstrateWeight<T>
 	// Storage: Treasury Proposals (r:1 w:1)
 	/// The range of component `p` is `[0, 64]`.
 	fn on_initialize_proposals(p: u32, ) -> Weight {
-		Weight::from_ref_time(42_101_000 as u64)
-			// Standard Error: 19_000
-			.saturating_add(Weight::from_ref_time(30_480_000 as u64).saturating_mul(p as u64))
+		Weight::from_ref_time(44_560_000 as u64)
+			// Standard Error: 17_000
+			.saturating_add(Weight::from_ref_time(30_292_000 as u64).saturating_mul(p as u64))
 			.saturating_add(T::DbWeight::get().reads(2 as u64))
 			.saturating_add(T::DbWeight::get().reads((3 as u64).saturating_mul(p as u64)))
 			.saturating_add(T::DbWeight::get().writes(2 as u64))

--- a/runtime/common/src/weights/pallet_utility.rs
+++ b/runtime/common/src/weights/pallet_utility.rs
@@ -35,26 +35,26 @@ pub struct SubstrateWeight<T>(PhantomData<T>);
 impl<T: frame_system::Config> pallet_utility::WeightInfo for SubstrateWeight<T> {
 	/// The range of component `c` is `[0, 1000]`.
 	fn batch(c: u32, ) -> Weight {
-		Weight::from_ref_time(31_867_000 as u64)
-			// Standard Error: 3_000
-			.saturating_add(Weight::from_ref_time(4_108_000 as u64).saturating_mul(c as u64))
+		Weight::from_ref_time(13_123_000 as u64)
+			// Standard Error: 1_000
+			.saturating_add(Weight::from_ref_time(4_277_000 as u64).saturating_mul(c as u64))
 	}
 	fn as_derivative() -> Weight {
-		Weight::from_ref_time(6_760_000 as u64)
+		Weight::from_ref_time(6_476_000 as u64)
 	}
 	/// The range of component `c` is `[0, 1000]`.
 	fn batch_all(c: u32, ) -> Weight {
-		Weight::from_ref_time(18_323_000 as u64)
+		Weight::from_ref_time(16_463_000 as u64)
 			// Standard Error: 1_000
-			.saturating_add(Weight::from_ref_time(4_165_000 as u64).saturating_mul(c as u64))
+			.saturating_add(Weight::from_ref_time(4_382_000 as u64).saturating_mul(c as u64))
 	}
 	fn dispatch_as() -> Weight {
-		Weight::from_ref_time(14_900_000 as u64)
+		Weight::from_ref_time(14_957_000 as u64)
 	}
 	/// The range of component `c` is `[0, 1000]`.
 	fn force_batch(c: u32, ) -> Weight {
-		Weight::from_ref_time(27_461_000 as u64)
-			// Standard Error: 3_000
-			.saturating_add(Weight::from_ref_time(4_114_000 as u64).saturating_mul(c as u64))
+		Weight::from_ref_time(14_976_000 as u64)
+			// Standard Error: 1_000
+			.saturating_add(Weight::from_ref_time(4_276_000 as u64).saturating_mul(c as u64))
 	}
 }


### PR DESCRIPTION
# Goal
Update Msa pallet "create" extrinsic benchmark.
Remove the complexity parameter since it has no
parameters that can affect weights. Additionally,
there are no bounds to the number of Msa accounts
that can be created.

Update benchmark files.

References #668