### PR TITLE
pin globally to ubuntu-20.04 in CI

### DIFF
--- a/.github/workflows/merge-pr.yml
+++ b/.github/workflows/merge-pr.yml
@@ -18,7 +18,7 @@ env:
 jobs:
   changes:
     name: Determine Changed Files
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     outputs:
       js-api-augment: ${{steps.filter.outputs.js-api-augment}}
       rust: ${{steps.filter.outputs.rust}}
@@ -39,7 +39,7 @@ jobs:
 
   publish-js-api-augment-rc:
     name: Merge - Publish JS API Augment Release Candidate
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     steps:
       - name: Check Out Repo
         uses: actions/checkout@v3
@@ -87,7 +87,7 @@ jobs:
 
   calc-code-coverage-main:
     name: Merge - Calculate Code Coverage
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     steps:
       - name: Check Out Repo
         uses: actions/checkout@v3
@@ -116,7 +116,7 @@ jobs:
 
   save-encoded-metadata:
     name: Save Encoded Metadata
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     env:
       NETWORK: mainnet
     steps:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -17,7 +17,7 @@ jobs:
     name: Build ${{matrix.arch}} Binary for ${{matrix.network}}
     strategy:
       matrix:
-        os: [ubuntu-latest, macOS-latest]
+        os: [ubuntu-20.04, macOS-latest]
         network: [local, rococo, mainnet]
         include:
           - network: local
@@ -29,7 +29,7 @@ jobs:
           - network: mainnet
             spec: frequency
             build-profile: production
-          - os: ubuntu-latest
+          - os: ubuntu-20.04
             arch: amd64
           - os: macOS-latest
             arch: arm64
@@ -127,7 +127,7 @@ jobs:
             release-wasm-file-name-prefix: frequency-mainnet_runtime
     env:
       SRT_TOOL_VERSION: "1.62.0"
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     steps:
       - name: Check Out Repo
         uses: actions/checkout@v3
@@ -176,7 +176,7 @@ jobs:
 
   build-rust-developer-docs:
     name: Build Rust Developer Docs
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     steps:
       - name: Check Out Repo
         uses: actions/checkout@v3
@@ -206,13 +206,13 @@ jobs:
     name: Build JS API Augment
     strategy:
       matrix:
-        os: [ubuntu-latest]
+        os: [ubuntu-20.04]
         network: [mainnet]
         include:
           - network: mainnet
             spec: frequency
             build-profile: production
-          - os: ubuntu-latest
+          - os: ubuntu-20.04
             arch: amd64
     runs-on: ${{matrix.os}}
     steps:
@@ -258,7 +258,7 @@ jobs:
   wait-for-all-builds:
     needs: [build-binaries, build-runtimes, build-rust-developer-docs, build-js-api-augment]
     name: Wait for All Builds to Finish
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     steps:
       - name: Proceed Forward
         run: echo "All build jobs have finished, proceeding with the release"
@@ -266,7 +266,7 @@ jobs:
   release-artifacts:
     needs: wait-for-all-builds
     name: Release Built Artifacts
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     steps:
       - name: Check Out Repo
         uses: actions/checkout@v3
@@ -362,7 +362,7 @@ jobs:
     env:
       DOCKER_HUB_PROFILE: frequencychain
       IMAGE_NAME: parachain-node
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     steps:
       - name: Set Env Vars
         run: |
@@ -426,7 +426,7 @@ jobs:
             docker-platform: linux/amd64
     env:
       DOCKER_HUB_PROFILE: frequencychain
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     steps:
       - name: Set Env Vars
         run: |
@@ -478,7 +478,7 @@ jobs:
   release-rust-developer-docs:
     needs: wait-for-all-builds
     name: Release Rust Developer Docs
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     steps:
       - name: Check Out Repo
         uses: actions/checkout@v3
@@ -497,7 +497,7 @@ jobs:
   release-js-api-augment:
     needs: wait-for-all-builds
     name: Release JS API Augment
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     steps:
       - name: Check Out Repo
         uses: actions/checkout@v3


### PR DESCRIPTION
The goal of this PR is to use ubuntu-20.04 across all CI jobs for consistency.
