### PR TITLE
```prod_or_testnet_or_local_or_env``` requires wasm be built with flags

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -3,11 +3,11 @@ concurrency:
   group: ${{github.workflow}}-${{github.ref}}
   cancel-in-progress: true
 on:
-  push:
-    tags:
-      - "v[0-9]+.[0-9]+.[0-9]+" # ex. v0.29.9
-      - "v[0-9]+.[0-9]+.[0-9]+-[0-9]+" # ex. v0.29.9-1
-      - "v[0-9]+.[0-9]+.[0-9]+-rc[0-9]+" # ex. v0.29.9-1-rc1
+  pull_request:
+    # tags:
+    #   - "v[0-9]+.[0-9]+.[0-9]+" # ex. v0.29.9
+    #   - "v[0-9]+.[0-9]+.[0-9]+-[0-9]+" # ex. v0.29.9-1
+    #   - "v[0-9]+.[0-9]+.[0-9]+-rc[0-9]+" # ex. v0.29.9-1-rc1
 env:
   RUST_TOOLCHAIN: nightly-2022-09-22 # Update this when updating the Rust toolchain
   NEW_RELEASE_VERSION: ${{github.ref_name}}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -3,11 +3,11 @@ concurrency:
   group: ${{github.workflow}}-${{github.ref}}
   cancel-in-progress: true
 on:
-  pull_request:
-    # tags:
-    #   - "v[0-9]+.[0-9]+.[0-9]+" # ex. v0.29.9
-    #   - "v[0-9]+.[0-9]+.[0-9]+-[0-9]+" # ex. v0.29.9-1
-    #   - "v[0-9]+.[0-9]+.[0-9]+-rc[0-9]+" # ex. v0.29.9-1-rc1
+  push:
+    tags:
+      - "v[0-9]+.[0-9]+.[0-9]+" # ex. v0.29.9
+      - "v[0-9]+.[0-9]+.[0-9]+-[0-9]+" # ex. v0.29.9-1
+      - "v[0-9]+.[0-9]+.[0-9]+-rc[0-9]+" # ex. v0.29.9-1-rc1
 env:
   RUST_TOOLCHAIN: nightly-2022-09-22 # Update this when updating the Rust toolchain
   NEW_RELEASE_VERSION: ${{github.ref_name}}
@@ -117,7 +117,7 @@ jobs:
             build-profile: production
             package: frequency-runtime
             runtime-dir: runtime/frequency
-            built-wasm-file-name-prefix: frequency_rococo_runtime
+            built-wasm-file-name-prefix: frequency_runtime
             release-wasm-file-name-prefix: frequency-rococo_runtime
             features: frequency-rococo-testnet
           - network: mainnet

--- a/runtime/common/Cargo.toml
+++ b/runtime/common/Cargo.toml
@@ -43,6 +43,8 @@ orml-vesting = {git = "https://github.com/open-web3-stack/open-runtime-module-li
 
 [features]
 default = ["std"]
+frequency = []
+frequency-rococo-testnet = []
 frequency-rococo-local = []
 std = ["frame-support/std"]
 try-runtime = [

--- a/runtime/common/src/constants.rs
+++ b/runtime/common/src/constants.rs
@@ -1,4 +1,4 @@
-use crate::prod_or_testnet_or_local_or_env;
+use crate::prod_or_testnet_or_local;
 use common_primitives::{
 	node::{Balance, BlockNumber},
 	schema::SchemaId,
@@ -182,13 +182,13 @@ parameter_types! {
 // Config from
 // https://github.com/paritytech/substrate/blob/367dab0d4bd7fd7b6c222dd15c753169c057dd42/bin/node/runtime/src/lib.rs#L880
 parameter_types! {
-	pub LaunchPeriod: BlockNumber = prod_or_testnet_or_local_or_env!(7 * DAYS, 1 * DAYS, 5 * MINUTES);
-	pub VotingPeriod: BlockNumber = prod_or_testnet_or_local_or_env!(7 * DAYS, 1 * DAYS, 5 * MINUTES);
-	pub FastTrackVotingPeriod: BlockNumber = prod_or_testnet_or_local_or_env!(3 * HOURS, 30 * MINUTES, 5 * MINUTES);
-	pub EnactmentPeriod: BlockNumber = prod_or_testnet_or_local_or_env!(8 * DAYS, 30 * HOURS, 10 * MINUTES);
-	pub CooloffPeriod: BlockNumber = prod_or_testnet_or_local_or_env!(7 * DAYS, 1 * DAYS, 5 * MINUTES);
-	pub MinimumDeposit: Balance = prod_or_testnet_or_local_or_env!(currency::deposit(5, 0), 100 * currency::deposit(5, 0), 100 * currency::deposit(5, 0));
-	pub SpendPeriod: BlockNumber = prod_or_testnet_or_local_or_env!(7 * DAYS, 10 * MINUTES, 10 * MINUTES);
+	pub LaunchPeriod: BlockNumber = prod_or_testnet_or_local!(7 * DAYS, 1 * DAYS, 5 * MINUTES);
+	pub VotingPeriod: BlockNumber = prod_or_testnet_or_local!(7 * DAYS, 1 * DAYS, 5 * MINUTES);
+	pub FastTrackVotingPeriod: BlockNumber = prod_or_testnet_or_local!(3 * HOURS, 30 * MINUTES, 5 * MINUTES);
+	pub EnactmentPeriod: BlockNumber = prod_or_testnet_or_local!(8 * DAYS, 30 * HOURS, 10 * MINUTES);
+	pub CooloffPeriod: BlockNumber = prod_or_testnet_or_local!(7 * DAYS, 1 * DAYS, 5 * MINUTES);
+	pub MinimumDeposit: Balance = prod_or_testnet_or_local!(currency::deposit(5, 0), 100 * currency::deposit(5, 0), 100 * currency::deposit(5, 0));
+	pub SpendPeriod: BlockNumber = prod_or_testnet_or_local!(7 * DAYS, 10 * MINUTES, 10 * MINUTES);
 }
 pub type DemocracyMaxVotes = ConstU32<100>;
 pub type DemocracyMaxProposals = HUNDRED;
@@ -249,10 +249,10 @@ pub type AuraMaxAuthorities = ConstU32<100_000>;
 // Example CollatorMaxInvulnerables are 16 in production(mainnet),
 // 5 in rococo testnet and 5 in rococo local
 parameter_types! {
-	pub CollatorMaxCandidates: u32 = prod_or_testnet_or_local_or_env!(0, 0, 0);
-	pub CollatorMinCandidates: u32 = prod_or_testnet_or_local_or_env!(0, 0, 0);
-	pub CollatorMaxInvulnerables: u32 = prod_or_testnet_or_local_or_env!(16, 5, 5);
-	pub CollatorKickThreshold: BlockNumber = prod_or_testnet_or_local_or_env!(
+	pub CollatorMaxCandidates: u32 = prod_or_testnet_or_local!(0, 0, 0);
+	pub CollatorMinCandidates: u32 = prod_or_testnet_or_local!(0, 0, 0);
+	pub CollatorMaxInvulnerables: u32 = prod_or_testnet_or_local!(16, 5, 5);
+	pub CollatorKickThreshold: BlockNumber = prod_or_testnet_or_local!(
 		6 * HOURS,
 		6 * HOURS,
 		6 * HOURS
@@ -280,5 +280,5 @@ parameter_types! {
 	/// SS58 Prefix for the for Frequency Network
 	/// 90 is the prefix for the Frequency Network on Polkadot
 	/// 42 is the prefix for the Frequency Network on Rococo
-	pub const Ss58Prefix: u16 = prod_or_testnet_or_local_or_env!(90, 42, 42);
+	pub const Ss58Prefix: u16 = prod_or_testnet_or_local!(90, 42, 42);
 }

--- a/runtime/common/src/constants.rs
+++ b/runtime/common/src/constants.rs
@@ -182,13 +182,13 @@ parameter_types! {
 // Config from
 // https://github.com/paritytech/substrate/blob/367dab0d4bd7fd7b6c222dd15c753169c057dd42/bin/node/runtime/src/lib.rs#L880
 parameter_types! {
-	pub LaunchPeriod: BlockNumber = prod_or_testnet_or_local_or_env!(7 * DAYS, 1 * DAYS, 5 * MINUTES, "FRQCY_LAUNCH_PERIOD");
-	pub VotingPeriod: BlockNumber = prod_or_testnet_or_local_or_env!(7 * DAYS, 1 * DAYS, 5 * MINUTES, "FRQCY_VOTING_PERIOD");
-	pub FastTrackVotingPeriod: BlockNumber = prod_or_testnet_or_local_or_env!(3 * HOURS, 30 * MINUTES, 5 * MINUTES, "FRQCY_FAST_TRACK_VOTING_PERIOD");
-	pub EnactmentPeriod: BlockNumber = prod_or_testnet_or_local_or_env!(8 * DAYS, 30 * HOURS, 10 * MINUTES, "FRQCY_ENACTMENT_PERIOD");
-	pub CooloffPeriod: BlockNumber = prod_or_testnet_or_local_or_env!(7 * DAYS, 1 * DAYS, 5 * MINUTES, "FRQCY_COOLOFF_PERIOD");
-	pub MinimumDeposit: Balance = prod_or_testnet_or_local_or_env!(currency::deposit(5, 0), 100 * currency::deposit(5, 0), 100 * currency::deposit(5, 0), "FRQCY_MINIMUM_DEPOSIT");
-	pub SpendPeriod: BlockNumber = prod_or_testnet_or_local_or_env!(7 * DAYS, 10 * MINUTES, 10 * MINUTES, "FRQCY_SPEND_PERIOD");
+	pub LaunchPeriod: BlockNumber = prod_or_testnet_or_local_or_env!(7 * DAYS, 1 * DAYS, 5 * MINUTES);
+	pub VotingPeriod: BlockNumber = prod_or_testnet_or_local_or_env!(7 * DAYS, 1 * DAYS, 5 * MINUTES);
+	pub FastTrackVotingPeriod: BlockNumber = prod_or_testnet_or_local_or_env!(3 * HOURS, 30 * MINUTES, 5 * MINUTES);
+	pub EnactmentPeriod: BlockNumber = prod_or_testnet_or_local_or_env!(8 * DAYS, 30 * HOURS, 10 * MINUTES);
+	pub CooloffPeriod: BlockNumber = prod_or_testnet_or_local_or_env!(7 * DAYS, 1 * DAYS, 5 * MINUTES);
+	pub MinimumDeposit: Balance = prod_or_testnet_or_local_or_env!(currency::deposit(5, 0), 100 * currency::deposit(5, 0), 100 * currency::deposit(5, 0));
+	pub SpendPeriod: BlockNumber = prod_or_testnet_or_local_or_env!(7 * DAYS, 10 * MINUTES, 10 * MINUTES);
 }
 pub type DemocracyMaxVotes = ConstU32<100>;
 pub type DemocracyMaxProposals = HUNDRED;

--- a/runtime/common/src/lib.rs
+++ b/runtime/common/src/lib.rs
@@ -13,7 +13,7 @@ pub mod weights;
 /// ```Rust
 /// parameter_types! {
 /// 	// Note that the env variable version parameter cannot be const.
-/// 	pub LaunchPeriod: BlockNumber = prod_or_testnet_or_local_or_env!(7 * DAYS, 28 * DAYS, 1 * MINUTES, "FRQCY_LAUNCH_PERIOD");
+/// 	pub LaunchPeriod: BlockNumber = prod_or_testnet_or_local_or_env!(7 * DAYS, 28 * DAYS, 1 * MINUTES);
 /// 	pub const VotingPeriod: BlockNumber = prod_or_testnet_or_local_or_env!(7 * DAYS, 28 * DAYS, 1 * MINUTES);
 /// }
 /// ```
@@ -22,15 +22,6 @@ macro_rules! prod_or_testnet_or_local_or_env {
 	($prod:expr, $test:expr, $local:expr) => {
 		if cfg!(feature = "frequency-rococo-local") {
 			$local
-		} else if cfg!(feature = "frequency-rococo-testnet") {
-			$test
-		} else {
-			$prod
-		}
-	};
-	($prod:expr, $test:expr, $local:expr, $env:expr) => {
-		if cfg!(feature = "frequency-rococo-local") {
-			core::option_env!($env).map(|s| s.parse().ok()).flatten().unwrap_or($local)
 		} else if cfg!(feature = "frequency-rococo-testnet") {
 			$test
 		} else {

--- a/runtime/common/src/lib.rs
+++ b/runtime/common/src/lib.rs
@@ -13,12 +13,12 @@ pub mod weights;
 /// ```Rust
 /// parameter_types! {
 /// 	// Note that the env variable version parameter cannot be const.
-/// 	pub LaunchPeriod: BlockNumber = prod_or_testnet_or_local_or_env!(7 * DAYS, 28 * DAYS, 1 * MINUTES);
-/// 	pub const VotingPeriod: BlockNumber = prod_or_testnet_or_local_or_env!(7 * DAYS, 28 * DAYS, 1 * MINUTES);
+/// 	pub LaunchPeriod: BlockNumber = prod_or_testnet_or_local!(7 * DAYS, 28 * DAYS, 1 * MINUTES);
+/// 	pub const VotingPeriod: BlockNumber = prod_or_testnet_or_local!(7 * DAYS, 28 * DAYS, 1 * MINUTES);
 /// }
 /// ```
 #[macro_export]
-macro_rules! prod_or_testnet_or_local_or_env {
+macro_rules! prod_or_testnet_or_local {
 	($prod:expr, $test:expr, $local:expr) => {
 		if cfg!(feature = "frequency-rococo-local") {
 			$local

--- a/runtime/frequency/Cargo.toml
+++ b/runtime/frequency/Cargo.toml
@@ -191,6 +191,8 @@ try-runtime = [
   "pallet-democracy/try-runtime",
   "pallet-utility/try-runtime",
 ]
+frequency = ["common-runtime/frequency"]
+frequency-rococo-testnet = ["common-runtime/frequency-rococo-testnet"]
 frequency-rococo-local = ["common-runtime/frequency-rococo-local"]
 # Following features are used in generating lean wasms
 no-metadata-docs = ["frame-support/no-metadata-docs"]


### PR DESCRIPTION
# Goal
The goal of this PR is to fix a bug discovered by @shannonwells that wasm based constants such as LaunchPeriod that are derived from ```prod_or_testnet_or_local_or_env``` defaults to prod values for rococo

This just makes our wasm to have prod values in all such constants because SRTool wasm is generated with default features and it overrides what value chain sees in metadata 

# Resolution:

* Generate wasm artifacts for rococo and mainnet enabling their respective feature flags i.e. ```frequency-rococo-testnet``` and ```frequency``` (mainnet) and update CI job to build feature based wasms
* The latter part got covered when unifying runtime #714 

Closes #732 

# Checklist
- [ ] Chain spec updated
- [ ] Custom RPC OR Runtime API added/changed? Updated js/api-augment.
- [ ] Design doc(s) updated
- [ ] Tests added
- [ ] Benchmarks added
- [ ] Weights updated
