### PR TITLE
install protobuf package

### DIFF
--- a/.github/workflows/merge-pr.yml
+++ b/.github/workflows/merge-pr.yml
@@ -94,6 +94,10 @@ jobs:
     steps:
       - name: Check Out Repo
         uses: actions/checkout@v3
+      - name: Install Required Packages
+        run: |
+          sudo apt-get update
+          sudo apt install -y protobuf-compiler
       - name: Install Rust Toolchain
         uses: actions-rs/toolchain@v1
         with:
@@ -128,6 +132,10 @@ jobs:
           echo "BIN_DIR=target/$BUILD_PROFILE" >> $GITHUB_ENV
           echo "METADATA_FILENAME=encoded-metadata-${{env.NETWORK}}-${{github.ref_name}}.amd64.json" >> $GITHUB_ENV
           echo "HOME=/home/ubuntu" >> $GITHUB_ENV
+      - name: Install Required Packages
+        run: |
+          sudo apt-get update
+          sudo apt install -y protobuf-compiler
       - name: Check Out Repo
         uses: actions/checkout@v3
       # # XXX Keep this step as it lets us skip full binary builds during development/testing

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -43,6 +43,10 @@ jobs:
       - name: Set Ubuntu Env Vars
         run: |
           echo "HOME=/home/ubuntu" >> $GITHUB_ENV
+      - name: Install Required Packages
+        run: |
+          sudo apt-get update
+          sudo apt install -y protobuf-compiler
       - name: Check Out Repo
         uses: actions/checkout@v3
       # # XXX Keep this step as it lets us skip full binary builds during development/testing
@@ -130,6 +134,10 @@ jobs:
       - name: Set Ubuntu Env Vars
         run: |
           echo "HOME=/home/ubuntu" >> $GITHUB_ENV
+      - name: Install Required Packages
+        run: |
+          sudo apt-get update
+          sudo apt install -y protobuf-compiler
       - name: Check Out Repo
         uses: actions/checkout@v3
       - name: Install Rust Toolchain
@@ -193,6 +201,10 @@ jobs:
     steps:
       - name: Set Ubuntu Env Vars
         run: echo "HOME=/home/ubuntu" >> $GITHUB_ENV
+      - name: Install Required Packages
+        run: |
+          sudo apt-get update
+          sudo apt install -y protobuf-compiler
       - name: Check Out Repo
         uses: actions/checkout@v3
       - name: Install Rust Toolchain

--- a/.github/workflows/verify-pr-commit.yml
+++ b/.github/workflows/verify-pr-commit.yml
@@ -56,6 +56,10 @@ jobs:
           echo "BIN_DIR=target/$BUILD_PROFILE" >> $GITHUB_ENV
           echo "BUILT_BIN_FILENAME=frequency" >> $GITHUB_ENV
           echo "HOME=/home/ubuntu" >> $GITHUB_ENV
+      - name: Install Required Packages
+        run: |
+          sudo apt-get update
+          sudo apt install -y protobuf-compiler
       - name: Check Out Repo
         uses: actions/checkout@v3
       # # XXX Keep this step as it lets us skip full binary builds during development/testing
@@ -142,6 +146,10 @@ jobs:
       - name: Set Env Vars
         run: |
           echo "HOME=/home/ubuntu" >> $GITHUB_ENV
+      - name: Install Required Packages
+        run: |
+          sudo apt-get update
+          sudo apt install -y protobuf-compiler
       - name: Check Out Repo
         uses: actions/checkout@v3
       - name: Install Rust Toolchain
@@ -167,6 +175,10 @@ jobs:
       - name: Set Env Vars
         run: |
           echo "HOME=/home/ubuntu" >> $GITHUB_ENV
+      - name: Install Required Packages
+        run: |
+          sudo apt-get update
+          sudo apt install -y protobuf-compiler
       - name: Check Out Repo
         uses: actions/checkout@v3
       - name: Install Rust Toolchain
@@ -192,6 +204,10 @@ jobs:
       - name: Set Env Vars
         run: |
           echo "HOME=/home/ubuntu" >> $GITHUB_ENV
+      - name: Install Required Packages
+        run: |
+          sudo apt-get update
+          sudo apt install -y protobuf-compiler
       - name: Check Out Repo
         uses: actions/checkout@v3
       - name: Install Rust Toolchain
@@ -212,6 +228,10 @@ jobs:
       - name: Set Env Vars
         run: |
           echo "HOME=/home/ubuntu" >> $GITHUB_ENV
+      - name: Install Required Packages
+        run: |
+          sudo apt-get update
+          sudo apt install -y protobuf-compiler
       - name: Check Out Repo
         uses: actions/checkout@v3
       - name: Install Rust Toolchain
@@ -236,6 +256,10 @@ jobs:
     steps:
       - name: Check Out Repo
         uses: actions/checkout@v3
+      - name: Install Required Packages
+        run: |
+          sudo apt-get update
+          sudo apt install -y protobuf-compiler
       - name: Install Rust Toolchain
         uses: actions-rs/toolchain@v1
         with:


### PR DESCRIPTION
The goal of this PR is to fix CI error related to the missing `protobuf-compiler` package.
