### PR TITLE
Parity - Code review

### DIFF
--- a/pallets/messages/src/lib.rs
+++ b/pallets/messages/src/lib.rs
@@ -208,10 +208,15 @@ pub mod pallet {
 		/// * [`Error::TooManyMessagesInBlock`] - Block is full of messages already
 		/// * [`Error::TypeConversionOverflow`] - Failed to add the message to storage as it is very full
 		///
+		// Wondering how the total number of messages affects in this case to calculate the weight
+		// Also why 1_000 is used. Shouldn't be MaxMessagesPerBlock as worst case?
 		#[pallet::weight(T::WeightInfo::add_ipfs_message(cid.len() as u32, 1_000))]
 		pub fn add_ipfs_message(
 			origin: OriginFor<T>,
 			#[pallet::compact] schema_id: SchemaId,
+			// CID format doesn't have a expected format with a fixed length?
+			// Consider creating a new type for it instead of a Vec<u8> of arbitrary length
+			// (Maybe not, apparently there are 2 different versions)
 			cid: Vec<u8>,
 			#[pallet::compact] payload_length: u32,
 		) -> DispatchResultWithPostInfo {
@@ -229,7 +234,7 @@ pub mod pallet {
 				Error::<T>::InvalidPayloadLocation
 			);
 
-			let provider_msa_id = Self::find_msa_id(&provider_key)?;
+			let provider_msa_id = Self::find_msa_id(&provider_key)?; // Probably check this first rigt after getting the provider_key ?
 			let message = Self::add_message(provider_msa_id, None, bounded_payload, schema_id)?;
 
 			Ok(Some(T::WeightInfo::add_ipfs_message(cid.len() as u32, message.index as u32)).into())
@@ -248,6 +253,8 @@ pub mod pallet {
 		/// * [`Error::TooManyMessagesInBlock`] - Block is full of messages already
 		/// * [`Error::TypeConversionOverflow`] - Failed to add the message to storage as it is very full
 		///
+		// Wondering how the total number of messages affects in this case to calculate the weight
+		// Also why 1_000 is used. Shouldn't be MaxMessagesPerBlock as worst case?
 		#[pallet::weight(T::WeightInfo::add_onchain_message(payload.len() as u32, 1_000))]
 		pub fn add_onchain_message(
 			origin: OriginFor<T>,
@@ -267,7 +274,7 @@ pub mod pallet {
 				Error::<T>::InvalidPayloadLocation
 			);
 
-			let provider_msa_id = Self::find_msa_id(&provider_key)?;
+			let provider_msa_id = Self::find_msa_id(&provider_key)?; // Same, should it be the first thing to check?
 			let provider_id = ProviderId(provider_msa_id);
 
 			let current_block = frame_system::Pallet::<T>::block_number();

--- a/pallets/messages/src/types.rs
+++ b/pallets/messages/src/types.rs
@@ -26,6 +26,8 @@ where
 	///  Message source account id (the original source).
 	pub msa_id: Option<MessageSourceId>,
 	///  Stores index of message in block to keep total order.
+	// Is this index really needed, messages don't end up ordered in the Messages strorage Item (form on_initialize)?
+	// Maybe necessary for reading purposes from the StorageDoubleMap I guess?
 	pub index: u16,
 }
 

--- a/pallets/schemas/src/lib.rs
+++ b/pallets/schemas/src/lib.rs
@@ -198,6 +198,8 @@ pub mod pallet {
 		/// * [`Error::InvalidSchema`] - Schema is malformed in some way
 		/// * [`Error::SchemaCountOverflow`] - The schema count has exceeded its bounds
 		///
+		// Wondering how the total number of Schemas affects in this case to calculate the weight
+		// Also why 1_000 is used. Shouldn't be MaxSchemaRegistrations as worst case?
 		#[pallet::weight(< T as Config >::WeightInfo::create_schema(model.len() as u32, 1000))]
 		pub fn create_schema(
 			origin: OriginFor<T>,
@@ -205,6 +207,9 @@ pub mod pallet {
 			model_type: ModelType,
 			payload_location: PayloadLocation,
 		) -> DispatchResult {
+			// Anyone with enough balance to pay fot the tx can create Schemas?
+			// Considering there is a fixed max number of those, might be a good idea limiting access to this method.
+			// You could for example lock/resrve some tokens (deposit for creating the Schame) or add a especial origin (Governance and Providers?)
 			let sender = ensure_signed(origin)?;
 
 			ensure!(
@@ -212,7 +217,7 @@ pub mod pallet {
 				Error::<T>::LessThanMinSchemaModelBytes
 			);
 			ensure!(
-				model.len() < Self::get_schema_model_max_bytes() as usize,
+				model.len() < Self::get_schema_model_max_bytes() as usize, // < or <= ?
 				Error::<T>::ExceedsMaxSchemaModelBytes
 			);
 
@@ -235,7 +240,7 @@ pub mod pallet {
 		/// # Errors
 		/// * [`Error::ExceedsMaxSchemaModelBytes`] - Cannot set to above the hard coded maximum [`Config::SchemaModelMaxBytesBoundedVecLimit`]
 		///
-		#[pallet::weight(30_000)]
+		#[pallet::weight(30_000)] // Set as DispatchClass::Operational
 		pub fn set_max_schema_model_bytes(
 			origin: OriginFor<T>,
 			#[pallet::compact] max_size: u32,

--- a/runtime/frequency/src/lib.rs
+++ b/runtime/frequency/src/lib.rs
@@ -69,7 +69,7 @@ pub use common_runtime::{
 /// Basefilter to only allow specified transactions call to be executed
 pub struct BaseCallFilter;
 impl Contains<Call> for BaseCallFilter {
-	fn contains(call: &Call) -> bool {
+	fn contains(call: &Call) -> bool { // I see some missing pallets here, did you double check you have all you want?
 		let core_calls = match call {
 			Call::System(..) => true,
 			Call::Timestamp(..) => true,
@@ -386,6 +386,7 @@ impl pallet_collective::Config<CouncilCollective> for Runtime {
 	type Event = Event;
 	type MotionDuration = CouncilMotionDuration;
 	type MaxProposals = CouncilMaxProposals;
+	 // Only one member? I guess it will be just sudo for now? To be consistent, probably move the value to constants.rs
 	type MaxMembers = ConstU32<1>;
 	type DefaultVote = pallet_collective::PrimeDefaultVote;
 	type WeightInfo = pallet_collective::weights::SubstrateWeight<Runtime>;
@@ -420,7 +421,7 @@ impl pallet_democracy::Config for Runtime {
 	type PreimageByteDeposit = PreimageByteDeposit;
 	type Proposal = Call;
 	type Scheduler = Scheduler;
-	type Slash = (); // Treasury;
+	type Slash = (); // Treasury; // Null for now?
 	type WeightInfo = weights::pallet_democracy::SubstrateWeight<Runtime>;
 	type VoteLockingPeriod = EnactmentPeriod; // Same as EnactmentPeriod
 	type VotingPeriod = VotingPeriod;
@@ -544,6 +545,8 @@ impl pallet_treasury::Config for Runtime {
 
 impl pallet_transaction_payment::Config for Runtime {
 	type Event = Event;
+	// You are not handling the fees, you are just burning them (). Take a look at DealWithFees in Statemint
+	// to send the fees to the ToStakingPot to be eventually collected by the Block Authors
 	type OnChargeTransaction = pallet_transaction_payment::CurrencyAdapter<Balances, ()>;
 	type WeightToFee = WeightToFee;
 	type LengthToFee = ConstantMultiplier<Balance, TransactionByteFee>;
@@ -600,7 +603,7 @@ impl pallet_collator_selection::Config for Runtime {
 
 	// Account Identifier from which the internal Pot is generated.
 	// Set to something that NEVER gets a balance i.e. No block rewards.
-	type PotId = NeverDepositIntoId;
+	type PotId = NeverDepositIntoId; // I see here that you do not want collators to collect fees
 
 	// Maximum number of candidates that we should have. This is enforced in code.
 	//


### PR DESCRIPTION
I based my review on your last release. Most of the code review comments are part of this PR. Just a few other points to mention:
### Runtime
- I see that some `OnUnbalanced` pallet’s Config types are set to `()` that will reduce the initial total issuance having a deflationary system. Are you ok with that? For instance, you are burning the fees. Wouldn't you prefer to send those fees to the collators to keep the total issuance?
### Pallet Messages
- What is the point of saving write time in `BlockMessages` if then some block time will be used anyway to move the data to `Messages` ? Did you compare weight times of writing directly in `Messages` vs moving them from `BlockMessages` in the `on_initialize`?
- Schemas Grants do not apply for IPFS messages? There is not any kind of validation for off-chain messages as long as the provider exists?
