### PR TITLE
Audit fix - schema model min/max size should be inclusive

### DIFF
--- a/pallets/schemas/src/lib.rs
+++ b/pallets/schemas/src/lib.rs
@@ -211,11 +211,11 @@ pub mod pallet {
 			let sender = ensure_signed(origin)?;
 
 			ensure!(
-				model.len() > T::MinSchemaModelSizeBytes::get() as usize,
+				model.len() >= T::MinSchemaModelSizeBytes::get() as usize,
 				Error::<T>::LessThanMinSchemaModelBytes
 			);
 			ensure!(
-				model.len() < Self::get_schema_model_max_bytes() as usize,
+				model.len() <= Self::get_schema_model_max_bytes() as usize,
 				Error::<T>::ExceedsMaxSchemaModelBytes
 			);
 


### PR DESCRIPTION
Fixes https://github.com/LibertyDSNP/frequency/issues/755

# Goal
The goal of this PR is to fix an issue raised by the audit where the min/max schema model size should be inclusive.

Closes #755 