### PR TITLE
Amended run integration tests script to log node output to a separate file

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -19,3 +19,5 @@
 res/
 
 scratch/
+
+frequency.log

--- a/scripts/kill_freq.sh
+++ b/scripts/kill_freq.sh
@@ -2,10 +2,10 @@
 
 set -e
 
-PID="$(ps aux | grep target/release/frequency | grep -v grep | xargs | awk '{print $2}')"
+PID=$(lsof -i tcp:9933 | grep frequency | grep -v grep | xargs | awk '{print $2}')
 
 if ! [ -z $PID ]
 then
     kill -9 $PID
-    echo "Frequency is dead 💀"
+    echo "Frequency has been killed. 💀"
 fi

--- a/scripts/run_integration_tests.sh
+++ b/scripts/run_integration_tests.sh
@@ -1,5 +1,9 @@
 #!/usr/bin/env bash
 
+echo "The integration test output will be logged on this console"
+echo "and the Frequency node output will be logged to the file frequency.log."
+echo "You can 'tail -f frequency.log' in another terminal to see both side-by-side."
+echo ""
 echo -e "Checking to see if Frequency is running..."
 
 PID=$(lsof -i tcp:9933 | grep frequency | grep -v grep | xargs | awk '{print $2}')
@@ -9,7 +13,7 @@ SHOULD_KILL=false
 if [ -z "$PID" ]
 then
     echo -e "Starting a Frequency Node..."
-    make start &
+    make start >& frequency.log &
     SHOULD_KILL=true
 fi
 
@@ -29,6 +33,6 @@ WS_PROVIDER_URL="ws://127.0.0.1:9944" npm test
 
 if $SHOULD_KILL
 then
-    kill -9 $PID > /dev/null
-    echo "Frequency node has been stopped"
+   pwd
+   ../scripts/kill_freq.sh
 fi


### PR DESCRIPTION
Amended run integration tests to log node output to a separate file and fixed kill script

# Goal
The goal of this PR is to separate output from tests from that of the chain.

Closes #772 

