### PR TITLE
Return KeyLimitExceeded if incrementing key_count overflows

### DIFF
--- a/pallets/msa/src/mock.rs
+++ b/pallets/msa/src/mock.rs
@@ -67,7 +67,7 @@ impl pallet_schemas::Config for Test {
 }
 
 parameter_types! {
-	pub const MaxPublicKeysPerMsa: u8 = 10;
+	pub const MaxPublicKeysPerMsa: u8 = 255;
 	pub const MaxProviderNameSize: u32 = 16;
 	pub const MaxSchemas: u32 = 5;
 }


### PR DESCRIPTION
# Goal
The goal of this PR is to prevent an overflow

Closes #739

# Discussion
Prevents a potential integer overflow  in `add_key` if `MaxPublicKeysPerMsa: u8` is set to `255`. 

