### PR TITLE
Update the `main` development branch to have a version of 0.0.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1026,7 +1026,7 @@ dependencies = [
 
 [[package]]
 name = "common-helpers"
-version = "0.9.30"
+version = "0.0.0"
 dependencies = [
  "apache-avro",
  "common-primitives",
@@ -1039,7 +1039,7 @@ dependencies = [
 
 [[package]]
 name = "common-primitives"
-version = "0.9.30"
+version = "0.0.0"
 dependencies = [
  "frame-support",
  "impl-serde 0.4.0",
@@ -1056,7 +1056,7 @@ dependencies = [
 
 [[package]]
 name = "common-runtime"
-version = "0.9.30"
+version = "0.0.0"
 dependencies = [
  "common-primitives",
  "frame-support",
@@ -2675,7 +2675,7 @@ dependencies = [
 
 [[package]]
 name = "frequency"
-version = "0.9.30"
+version = "0.0.0"
 dependencies = [
  "frequency-cli",
  "frequency-service",
@@ -2684,7 +2684,7 @@ dependencies = [
 
 [[package]]
 name = "frequency-cli"
-version = "0.9.30"
+version = "0.0.0"
 dependencies = [
  "clap",
  "common-primitives",
@@ -2717,7 +2717,7 @@ dependencies = [
 
 [[package]]
 name = "frequency-runtime"
-version = "0.9.30"
+version = "0.0.0"
 dependencies = [
  "common-primitives",
  "common-runtime",
@@ -2783,7 +2783,7 @@ dependencies = [
 
 [[package]]
 name = "frequency-service"
-version = "0.9.30"
+version = "0.0.0"
 dependencies = [
  "clap",
  "common-primitives",
@@ -5720,7 +5720,7 @@ dependencies = [
 
 [[package]]
 name = "pallet-messages"
-version = "0.9.30"
+version = "0.0.0"
 dependencies = [
  "common-primitives",
  "frame-benchmarking",
@@ -5737,7 +5737,7 @@ dependencies = [
 
 [[package]]
 name = "pallet-messages-rpc"
-version = "0.9.30"
+version = "0.0.0"
 dependencies = [
  "common-helpers",
  "common-primitives",
@@ -5755,7 +5755,7 @@ dependencies = [
 
 [[package]]
 name = "pallet-messages-runtime-api"
-version = "0.9.30"
+version = "0.0.0"
 dependencies = [
  "common-primitives",
  "frame-support",
@@ -5798,7 +5798,7 @@ dependencies = [
 
 [[package]]
 name = "pallet-msa"
-version = "0.9.30"
+version = "0.0.0"
 dependencies = [
  "common-primitives",
  "common-runtime",
@@ -5817,7 +5817,7 @@ dependencies = [
 
 [[package]]
 name = "pallet-msa-rpc"
-version = "0.9.30"
+version = "0.0.0"
 dependencies = [
  "common-helpers",
  "common-primitives",
@@ -5836,7 +5836,7 @@ dependencies = [
 
 [[package]]
 name = "pallet-msa-runtime-api"
-version = "0.9.30"
+version = "0.0.0"
 dependencies = [
  "common-primitives",
  "frame-support",
@@ -6011,7 +6011,7 @@ dependencies = [
 
 [[package]]
 name = "pallet-schemas"
-version = "0.9.30"
+version = "0.0.0"
 dependencies = [
  "common-primitives",
  "frame-benchmarking",
@@ -6032,7 +6032,7 @@ dependencies = [
 
 [[package]]
 name = "pallet-schemas-rpc"
-version = "0.9.30"
+version = "0.0.0"
 dependencies = [
  "common-helpers",
  "common-primitives",
@@ -6053,7 +6053,7 @@ dependencies = [
 
 [[package]]
 name = "pallet-schemas-runtime-api"
-version = "0.9.30"
+version = "0.0.0"
 dependencies = [
  "common-primitives",
  "frame-support",

--- a/Makefile
+++ b/Makefile
@@ -134,3 +134,17 @@ test:
 
 integration-test:
 	./scripts/run_integration_tests.sh
+
+PHONY: version
+version:
+ifndef v
+	@echo "Please set the version with v=X.X.X-X"
+	@exit 1
+endif
+ifneq (,$(findstring v,  $(v)))
+	@echo "Please don't prefix with a 'v'. Use: v=X.X.X-X"
+	@exit 1
+endif
+	find ./ -type f -name 'Cargo.toml' -exec sed -i '' 's/^version = \"0\.0\.0\"/version = \"$(v)\"/g' {} \;
+	cargo check
+	@echo "All done. Don't forget to double check that the automated replacement worked."

--- a/common/helpers/Cargo.toml
+++ b/common/helpers/Cargo.toml
@@ -7,7 +7,7 @@ license = "Apache-2.0"
 name = "common-helpers"
 publish = false
 repository = "https://github.com/LibertyDSNP/frequency/"
-version = "0.9.30"
+version = "0.0.0"
 
 [package.metadata.docs.rs]
 targets = ['x86_64-unknown-linux-gnu']

--- a/common/primitives/Cargo.toml
+++ b/common/primitives/Cargo.toml
@@ -7,7 +7,7 @@ license = "Apache-2.0"
 name = "common-primitives"
 publish = false
 repository = "https://github.com/LibertyDSNP/frequency/"
-version = "0.9.30"
+version = "0.0.0"
 
 [package.metadata.docs.rs]
 targets = ['x86_64-unknown-linux-gnu']

--- a/node/Cargo.toml
+++ b/node/Cargo.toml
@@ -7,7 +7,7 @@ homepage = "https://frequency.xyz"
 license = "Apache-2.0"
 name = "frequency"
 repository = "https://github.com/LibertyDSNP/frequency/"
-version = "0.9.30"
+version = "0.0.0"
 
 [[bin]]
 name = "frequency"

--- a/node/cli/Cargo.toml
+++ b/node/cli/Cargo.toml
@@ -6,7 +6,7 @@ homepage = "https://unfinishedlabs.io/"
 license = "Apache-2.0"
 name = "frequency-cli"
 repository = "https://github.com/LibertyDSNP/frequency/"
-version = "0.9.30"
+version = "0.0.0"
 
 [dependencies]
 clap = { version = "3.2.22", features = ["derive"] }

--- a/node/service/Cargo.toml
+++ b/node/service/Cargo.toml
@@ -6,7 +6,7 @@ homepage = "https://frequency.xyz"
 license = "Apache-2.0"
 name = "frequency-service"
 repository = "https://github.com/LibertyDSNP/frequency/"
-version = "0.9.30"
+version = "0.0.0"
 
 [dependencies]
 clap = { version = "3.2.22", features = ["derive"] }

--- a/pallets/messages/Cargo.toml
+++ b/pallets/messages/Cargo.toml
@@ -7,7 +7,7 @@ license = "Apache-2.0"
 name = "pallet-messages"
 publish = false
 repository = "https://github.com/LibertyDSNP/frequency/"
-version = "0.9.30"
+version = "0.0.0"
 
 [package.metadata.docs.rs]
 targets = ["x86_64-unknown-linux-gnu"]

--- a/pallets/messages/src/rpc/Cargo.toml
+++ b/pallets/messages/src/rpc/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "pallet-messages-rpc"
-version = "0.9.30"
+version = "0.0.0"
 description = "A package that adds RPC to Messages pallet"
 authors = ["Frequency"]
 license = "Apache-2.0"

--- a/pallets/messages/src/runtime-api/Cargo.toml
+++ b/pallets/messages/src/runtime-api/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "pallet-messages-runtime-api"
-version = "0.9.30"
+version = "0.0.0"
 description = "A package that adds Runtime Api for Messages pallet"
 authors = ["Frequency"]
 license = "Apache-2.0"

--- a/pallets/msa/Cargo.toml
+++ b/pallets/msa/Cargo.toml
@@ -7,7 +7,7 @@ license = "Apache-2.0"
 name = "pallet-msa"
 publish = false
 repository = "https://github.com/libertyDSNP/frequency/"
-version = "0.9.30"
+version = "0.0.0"
 
 [package.metadata.docs.rs]
 targets = ["x86_64-unknown-linux-gnu"]

--- a/pallets/msa/src/rpc/Cargo.toml
+++ b/pallets/msa/src/rpc/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "pallet-msa-rpc"
-version = "0.9.30"
+version = "0.0.0"
 description = "A package that adds RPC to Msa pallet"
 authors = ["Frequency"]
 license = "Apache-2.0"

--- a/pallets/msa/src/runtime-api/Cargo.toml
+++ b/pallets/msa/src/runtime-api/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "pallet-msa-runtime-api"
-version = "0.9.30"
+version = "0.0.0"
 description = "A package that adds Runtime Api for Msa pallet"
 authors = ["Frequency"]
 license = "Apache-2.0"

--- a/pallets/schemas/Cargo.toml
+++ b/pallets/schemas/Cargo.toml
@@ -7,7 +7,7 @@ license = "Apache-2.0"
 name = "pallet-schemas"
 publish = false
 repository = "https://github.com/libertyDSNP/frequency/"
-version = "0.9.30"
+version = "0.0.0"
 
 [package.metadata.docs.rs]
 targets = ["x86_64-unknown-linux-gnu"]

--- a/pallets/schemas/src/rpc/Cargo.toml
+++ b/pallets/schemas/src/rpc/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "pallet-schemas-rpc"
-version = "0.9.30"
+version = "0.0.0"
 description = "RPC package for schemas"
 authors = ["Frequency"]
 license = "Apache-2.0"

--- a/pallets/schemas/src/runtime-api/Cargo.toml
+++ b/pallets/schemas/src/runtime-api/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "pallet-schemas-runtime-api"
-version = "0.9.30"
+version = "0.0.0"
 description = "RPC runtime package for schemas"
 authors = ["Frequency"]
 license = "Apache-2.0"

--- a/runtime/common/Cargo.toml
+++ b/runtime/common/Cargo.toml
@@ -6,7 +6,7 @@ homepage = "https://frequency.xyz"
 license = "Apache-2.0"
 name = "common-runtime"
 repository = "https://github.com/LibertyDSNP/frequency/"
-version = "0.9.30"
+version = "0.0.0"
 
 [package.metadata.docs.rs]
 targets = ["x86_64-unknown-linux-gnu"]

--- a/runtime/frequency/Cargo.toml
+++ b/runtime/frequency/Cargo.toml
@@ -6,7 +6,7 @@ homepage = "https://frequency.xyz"
 license = "Apache-2.0"
 name = "frequency-runtime"
 repository = "https://github.com/LibertyDSNP/frequency/"
-version = "0.9.30"
+version = "0.0.0"
 
 [package.metadata.docs.rs]
 targets = ["x86_64-unknown-linux-gnu"]


### PR DESCRIPTION
# Goal
The goal of this PR is to align with the https://github.com/LibertyDSNP/frequency/wiki/Release documentation

# Discussion
- Updated cargo toml versions to 0.0.0
- Added `make version v=X.X.X` to make updating versions easy.
