### PR TITLE
chore(capacity): add storage

### DIFF
--- a/pallets/capacity/src/mock.rs
+++ b/pallets/capacity/src/mock.rs
@@ -67,6 +67,8 @@ impl Config for Test {
 	type RuntimeEvent = RuntimeEvent;
 	type WeightInfo = ();
 	type Currency = pallet_balances::Pallet<Self>;
+	type MinimumStakingAmount = ConstU64<1>;
+	type MaxUnlockingChunks = ConstU32<4>;
 }
 
 pub fn new_test_ext() -> sp_io::TestExternalities {

--- a/pallets/capacity/src/types.rs
+++ b/pallets/capacity/src/types.rs
@@ -1,0 +1,53 @@
+//! Types for the Capacity Pallet
+use super::*;
+use codec::{Decode, Encode, MaxEncodedLen};
+use frame_support::{BoundedVec, RuntimeDebug, RuntimeDebugNoBound};
+use scale_info::TypeInfo;
+use sp_runtime::traits::Zero;
+
+/// Details about the total token amount targeted to an MSA.
+/// The Capacity that the target will receive.
+#[derive(PartialEq, Eq, Default, Clone, Encode, Decode, RuntimeDebug, TypeInfo, MaxEncodedLen)]
+pub struct StakingTargetDetails<Balance> {
+	/// The total amount of tokens that have been targeted to the MSA.
+	pub amount: Balance,
+	/// The total Capacity that an MSA received.
+	pub capacity: Balance,
+}
+
+/// The type used for storing information about staking details.
+#[derive(TypeInfo, RuntimeDebugNoBound, Clone, Decode, Encode, PartialEq, Eq, MaxEncodedLen)]
+#[scale_info(skip_type_params(T))]
+pub struct StakingAccountDetails<T: Config> {
+	/// The amount a Staker has staked, minus the sum of all tokens in `unlocking`.
+	pub active: BalanceOf<T>,
+	/// The total amount of tokens in `active` and `unlocking`
+	pub total: BalanceOf<T>,
+	/// Unstaked balances that are thawing or awaiting withdrawal.
+	pub unlocking: BoundedVec<UnlockChunk<BalanceOf<T>, T::BlockNumber>, T::MaxUnlockingChunks>,
+}
+
+/// The type that is used to record a single request for a number of tokens to be unlocked.
+#[derive(PartialEq, Eq, Clone, Encode, Decode, RuntimeDebug, TypeInfo, MaxEncodedLen)]
+pub struct UnlockChunk<Balance, BlockNumber> {
+	/// Amount to be unlocked.
+	value: Balance,
+	/// Block number at which point funds are unlocked.
+	thaw_at: BlockNumber,
+}
+impl<T: Config> Default for StakingAccountDetails<T> {
+	fn default() -> Self {
+		Self { active: Zero::zero(), total: Zero::zero(), unlocking: Default::default() }
+	}
+}
+
+/// The type for storing Registered Provider Capacity balance:
+#[derive(PartialEq, Eq, Clone, Default, Encode, Decode, RuntimeDebug, TypeInfo, MaxEncodedLen)]
+pub struct CapacityDetails<Balance, BlockNumber> {
+	/// The Capacity remaining for the `last_replenished_epoch`.
+	pub remaining: Balance,
+	/// The total Capacity issued to an MSA.
+	pub total_available: Balance,
+	/// The last block-number that an MSA was replenished with Capacity.
+	pub last_replenished_epoch: BlockNumber,
+}

--- a/runtime/frequency/src/lib.rs
+++ b/runtime/frequency/src/lib.rs
@@ -290,6 +290,8 @@ impl pallet_capacity::Config for Runtime {
 	type RuntimeEvent = RuntimeEvent;
 	type WeightInfo = pallet_capacity::weights::SubstrateWeight<Runtime>;
 	type Currency = Balances;
+	type MinimumStakingAmount = ConstU128<1>;
+	type MaxUnlockingChunks = ConstU32<4>;
 }
 
 impl pallet_schemas::Config for Runtime {


### PR DESCRIPTION
# Goal
Add storage for staking and capacity:

`StakingAccountLedger`
Storage for keeping a ledger for staking

`StakingTargetLedger`
Storage to record how many tokens were targeted to an MSA.

`CapacityOf`
Storage for target Capacity usage.

These storage items are based on the [Capacity design docs](https://github.com/LibertyDSNP/frequency/blob/main/designdocs/capacity.md).

Adding storage makes it so staking, unstaking, and withdraw_unstake features can be worked on in parallel.
