### PR TITLE
Set the spec name to be different for mainnet vs rococo

### DIFF
--- a/runtime/frequency/src/lib.rs
+++ b/runtime/frequency/src/lib.rs
@@ -159,9 +159,27 @@ impl_opaque_keys! {
 	}
 }
 
+// The duplicate macros are annoying, but #[sp_version::runtime_version]
+// has fairly string limits on what can go in there.
+
+// Override the spec name when not mainnet to be frequency-rococo
+#[cfg(not(feature = "frequency"))]
+macro_rules! spec_name {
+	( $y:expr ) => {{
+		create_runtime_str!("frequency-rococo")
+	}};
+}
+
+#[cfg(feature = "frequency")]
+macro_rules! spec_name {
+	( $y:expr ) => {{
+		create_runtime_str!($y)
+	}};
+}
+
 #[sp_version::runtime_version]
 pub const VERSION: RuntimeVersion = RuntimeVersion {
-	spec_name: create_runtime_str!("frequency"),
+	spec_name: spec_name!("frequency"),
 	impl_name: create_runtime_str!("frequency"),
 	authoring_version: 1,
 	spec_version: 5,


### PR DESCRIPTION
# Goal
The goal of this PR is to have a separate `spec_name` for mainnet vs other setups (specifically rococo).

Part of #839 

# Discussion
- Because of the const and macro layers, the only way to really make this work ended up being the set you see.

# Checklist
- Tested
- `make rococo-build`
- `subwasm info target/release/wbuild/frequency-runtime/frequency_runtime.compact.compressed.wasm`

## Before:

<img width="838" alt="image" src="https://user-images.githubusercontent.com/1252199/209220516-6f68135f-61ae-46e7-a915-b045b5fe09e1.png">

## After

<img width="857" alt="image" src="https://user-images.githubusercontent.com/1252199/209220657-b1a054c5-b5ad-4a8a-81bc-6649ec0859fe.png">

