### PR TITLE
Test Genesis State Output

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -24,14 +24,17 @@ jobs:
         include:
           - network: local
             spec: frequency-rococo-local
+            genesis: "skip"
             build-profile: release
             release-file-name-prefix: frequency-local
           - network: rococo
             spec: frequency-rococo-testnet
+            genesis: "0x000000000000000000000000000000000000000000000000000000000000000000e3495742b019f5ad49dff7de4040bc965b75eaf46769c24db1027d4ff86fc92703170a2e7597b7b7e3d84c05391d139a62b157e78786d8c082f29dcf4c11131400"
             build-profile: production
             release-file-name-prefix: frequency-rococo
           - network: mainnet
             spec: frequency
+            genesis: "0x000000000000000000000000000000000000000000000000000000000000000000393a2a0f7778716d006206c5a4787cbf2ea3b26a67379b7a38ee54519d7fd4be03170a2e7597b7b7e3d84c05391d139a62b157e78786d8c082f29dcf4c11131400"
             build-profile: production
             release-file-name-prefix: frequency
           - os: [self-hosted, Linux, X64]
@@ -102,6 +105,12 @@ jobs:
       - name: Verify Binary
         working-directory: ${{env.BIN_DIR}}
         run: gpg --verify ${{env.RELEASE_BIN_FILENAME}}.asc
+      - name: Test Genesis State
+        if: matrix.genesis != 'skip'
+        run: |
+          echo "Expected genesis state: ${{matrix.genesis}}"
+          echo "  Actual genesis state: " $(${{env.BIN_DIR}}/${{env.BUILT_BIN_FILENAME}} export-genesis-state)
+          [[ $(${{env.BIN_DIR}}/${{env.BUILT_BIN_FILENAME}} export-genesis-state) == ${{matrix.genesis}} ]]
       - name: Upload Artifacts
         uses: actions/upload-artifact@v3
         with:


### PR DESCRIPTION
# Goal
The goal of this PR is to make sure that #847 cannot happen again.

# Discussion
- Added simple test for mainnet and rococo to always be on the same genesis block as those networks require.
- Also ends up being a good basic test for the binary

# Checklist
- [x] Tested: https://github.com/LibertyDSNP/frequency/actions/runs/3803259957
- [x] Updated CI Diagram
<img width="1587" alt="image" src="https://user-images.githubusercontent.com/1252199/210403164-0a4ebddb-8749-471d-8ad3-21133ce3d7b1.png">

