### PR TITLE
Update target subdirectory for upgrading

### DIFF
--- a/scripts/init.sh
+++ b/scripts/init.sh
@@ -164,6 +164,7 @@ offboard-frequency)
 upgrade-frequency)
 
   root_dir=$(git rev-parse --show-toplevel)
+  echo "root_dir is set to $root_dir"
 
   cargo build \
     --locked \

--- a/scripts/init.sh
+++ b/scripts/init.sh
@@ -171,11 +171,11 @@ upgrade-frequency)
     --profile release \
     --package frequency-runtime \
     --features frequency-rococo-local \
-    --target-dir $root_dir/target/upgrade \
+    --target-dir $root_dir/target/release \
     -Z unstable-options
 
 
-  wasm_location=$root_dir/target/upgrade/release/wbuild/frequency-runtime/frequency_runtime.compact.compressed.wasm
+  wasm_location=$root_dir/target/release/wbuild/frequency-runtime/frequency_runtime.compact.compressed.wasm
 
   ./scripts/runtime-upgrade.sh "//Alice" "ws://0.0.0.0:9944" $wasm_location
 


### PR DESCRIPTION
# Goal
The goal of this PR is to fix a small bug in the init.sh script - it refers to a directory we don't generate any more.

# Discussion
Found when checking that upgrades work via script+sudo.

Checklist items not applicable.
