### PR TITLE
Update versioning strategy

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -6,8 +6,7 @@ on:
   push:
     tags:
       - "v[0-9]+.[0-9]+.[0-9]+" # ex. v0.29.9
-      - "v[0-9]+.[0-9]+.[0-9]+-[0-9]+" # ex. v0.29.9-1
-      - "v[0-9]+.[0-9]+.[0-9]+-rc[0-9]+" # ex. v0.29.9-1-rc1
+      - "v[0-9]+.[0-9]+.[0-9]+-rc[0-9]+" # ex. v0.29.9-rc1
       - "vX.X.X" # used for testing only
 env:
   RUST_TOOLCHAIN: nightly-2022-09-22 # Update this when updating the Rust toolchain
@@ -322,7 +321,7 @@ jobs:
           fetch-depth: 0
       - name: Full Release?
         run: |
-          is_full_release=$([[ "$NEW_RELEASE_VERSION" =~ ^v[0-9]+\.[0-9]+\.[0-9]+(\-[0-9]+)?$ ]] && \
+          is_full_release=$([[ "$NEW_RELEASE_VERSION" =~ ^v[0-9]+\.[0-9]+\.[0-9]+$ ]] && \
             echo 'true' || echo 'false')
           echo "is_full_release: $is_full_release"
           echo "IS_FULL_RELEASE=$is_full_release" >> $GITHUB_ENV

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -83,13 +83,6 @@ jobs:
         run: |
           file ${{env.BIN_DIR}}/${{env.BUILT_BIN_FILENAME}} && \
             ${{env.BIN_DIR}}/${{env.BUILT_BIN_FILENAME}} --version
-      - name: Testing Version Match
-        run: |
-          EXPECTED_VERSION="${{env.NEW_RELEASE_VERSION}}+polkadot$(make version-polkadot)"
-          ACTUAL_VERSION="v$(${{env.BIN_DIR}}/${{env.BUILT_BIN_FILENAME}} --version | cut -d " " -f 2)"
-          echo "Expected: ${EXPECTED_VERSION}"
-          echo "  Actual: ${ACTUAL_VERSION%-*}"
-          [[ ${ACTUAL_VERSION%-*} == ${EXPECTED_VERSION} ]]
       - name: Rename Binary
         run: |
           cp -p ${{env.BIN_DIR}}/${{env.BUILT_BIN_FILENAME}} \
@@ -309,8 +302,52 @@ jobs:
           path: js/api-augment/dist
           if-no-files-found: error
 
+  version-check:
+    needs: [build-binaries]
+    name: Test Version Matches Release
+    strategy:
+      matrix:
+        os: [ubuntu-20.04]
+        network: [mainnet]
+        include:
+          - network: mainnet
+            spec: frequency
+            build-profile: production
+            release-file-name-prefix: frequency
+          - os: ubuntu-20.04
+            arch: amd64
+    runs-on: ${{matrix.os}}
+    steps:
+      - name: Set Env Vars
+        run: |
+          echo "BIN_DIR=target/${{matrix.build-profile}}" >> $GITHUB_ENV
+          echo "BUILT_BIN_FILENAME=frequency" >> $GITHUB_ENV
+          echo "RELEASE_BIN_FILENAME=${{matrix.release-file-name-prefix}}.${{matrix.arch}}" >> $GITHUB_ENV
+      - name: Check Out Repo
+        uses: actions/checkout@v3
+        with:
+          fetch-depth: 0
+      - name: Download Binary Artifacts
+        id: download
+        uses: actions/download-artifact@v3
+        with:
+          name: artifacts-${{github.run_id}}
+          path: .
+      - name: Move Binary to Target Dir
+        run: |
+          mkdir -p ${{env.BIN_DIR}}
+          mv ${{env.RELEASE_BIN_FILENAME}} ${{env.BIN_DIR}}/${{env.BUILT_BIN_FILENAME}}
+          chmod +x ${{env.BIN_DIR}}/${{env.BUILT_BIN_FILENAME}}
+      - name: Testing Version Match
+        run: |
+          EXPECTED_VERSION="${{env.NEW_RELEASE_VERSION}}+polkadot$(make version-polkadot)"
+          ACTUAL_VERSION="v$(${{env.BIN_DIR}}/${{env.BUILT_BIN_FILENAME}} --version | cut -d " " -f 2)"
+          echo "Expected: ${EXPECTED_VERSION}"
+          echo "  Actual: ${ACTUAL_VERSION%-*}"
+          [[ ${ACTUAL_VERSION%-*} == ${EXPECTED_VERSION} ]]
+
   wait-for-all-builds:
-    needs: [build-binaries, build-runtimes, build-rust-developer-docs, build-js-api-augment]
+    needs: [version-check, build-binaries, build-runtimes, build-rust-developer-docs, build-js-api-augment]
     name: Wait for All Builds to Finish
     runs-on: ubuntu-20.04
     steps:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -303,7 +303,7 @@ jobs:
           if-no-files-found: error
 
   version-check:
-    needs: [build-binaries]
+    needs: build-binaries
     name: Test Version Matches Release
     strategy:
       matrix:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -83,14 +83,13 @@ jobs:
         run: |
           file ${{env.BIN_DIR}}/${{env.BUILT_BIN_FILENAME}} && \
             ${{env.BIN_DIR}}/${{env.BUILT_BIN_FILENAME}} --version
-      - name: Testing version match
+      - name: Testing Version Match
         run: |
-          EXPECTED_VERSION="${{NEW_RELEASE_VERSION}}+polkadot-$(make version-polkadot)"
-          ACTUAL_VERSION="v$(${{env.BIN_DIR}}/${{env.BUILT_BIN_FILENAME}} --version | cut -d " " -f 2 | cut -d "-" -f 1)"
-          echo "v$(./target/release/frequency --version | cut -d " " -f 2 | cut -d "-" -f 1)"
+          EXPECTED_VERSION="${{env.NEW_RELEASE_VERSION}}+polkadot$(make version-polkadot)"
+          ACTUAL_VERSION="v$(${{env.BIN_DIR}}/${{env.BUILT_BIN_FILENAME}} --version | cut -d " " -f 2)"
           echo "Expected: ${EXPECTED_VERSION}"
-          echo "Actual: ${ACTUAL_VERSION}"
-          [[ ${{ACTUAL_VERSION}} == ${EXPECTED_VERSION} ]]
+          echo "  Actual: ${ACTUAL_VERSION%-*}"
+          [[ ${ACTUAL_VERSION%-*} == ${EXPECTED_VERSION} ]]
       - name: Rename Binary
         run: |
           cp -p ${{env.BIN_DIR}}/${{env.BUILT_BIN_FILENAME}} \

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -83,6 +83,14 @@ jobs:
         run: |
           file ${{env.BIN_DIR}}/${{env.BUILT_BIN_FILENAME}} && \
             ${{env.BIN_DIR}}/${{env.BUILT_BIN_FILENAME}} --version
+      - name: Testing version match
+        run: |
+          EXPECTED_VERSION="${{NEW_RELEASE_VERSION}}+polkadot-$(make version-polkadot)"
+          ACTUAL_VERSION="v$(${{env.BIN_DIR}}/${{env.BUILT_BIN_FILENAME}} --version | cut -d " " -f 2 | cut -d "-" -f 1)"
+          echo "v$(./target/release/frequency --version | cut -d " " -f 2 | cut -d "-" -f 1)"
+          echo "Expected: ${EXPECTED_VERSION}"
+          echo "Actual: ${ACTUAL_VERSION}"
+          [[ ${{ACTUAL_VERSION}} == ${EXPECTED_VERSION} ]]
       - name: Rename Binary
         run: |
           cp -p ${{env.BIN_DIR}}/${{env.BUILT_BIN_FILENAME}} \

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -375,10 +375,13 @@ jobs:
           echo "sanitized: $clean"
           echo "2---------------------"
           echo "sanitized=$clean" >> $GITHUB_OUTPUT
+      - name: Get Polkadot Version
+        id: polkadot-version
+        run: echo "version=$(make version-polkadot)" >> $GITHUB_OUTPUT
       - name: Generate Release Notes
         working-directory: tools/ci/release-notes
         run: |
-          ./build-release-notes.sh '${{steps.sanitize-changelog.outputs.sanitized}}' > \
+          ./build-release-notes.sh '${{steps.polkadot-version.outputs.version}}' '${{steps.sanitize-changelog.outputs.sanitized}}' > \
           release-notes.md
       - name: Download Binary Artifacts
         id: download

--- a/Makefile
+++ b/Makefile
@@ -136,8 +136,8 @@ integration-test:
 	./scripts/run_integration_tests.sh
 
 # Pull the Polkadot version from the polkadot-cli package in the Cargo.lock file.
-# This will break if the lock file format changes
-POLKADOT_VERSION=$(shell grep -oz '\[\[package\]\]\nname = "polkadot-cli"\nversion = ".*\..*\..*"' Cargo.lock | tail -n 1 | cut -d " " -f 3 | tr -d \")
+# This will break if the lock file format
+POLKADOT_VERSION=$(shell awk -F "=" '/name = "polkadot-cli"/,/version = ".*"/{ print $2 }' Cargo.lock | tail -n 1 | cut -d " " -f 3 | tr -d \")
 
 .PHONY: version
 version:

--- a/Makefile
+++ b/Makefile
@@ -128,7 +128,7 @@ build-rococo-release:
 build-mainnet-release:
 	cargo build --locked --features  frequency --profile production
 
-PHONY: test
+.PHONY: test
 test:
 	cargo test --workspace --locked --features all-frequency-features
 
@@ -138,7 +138,7 @@ integration-test:
 # Pull the Polkadot version from the polkadot-cli package and remove the leading v
 POLKADOT_VERSION=$(shell cargo tree --depth 0 --manifest-path ./node/service/Cargo.toml --package polkadot-cli | grep polkadot-cli | cut -d " " -f 2 | tr -d "v")
 
-PHONY: version
+.PHONY: version
 version:
 ifndef v
 	@echo "Please set the version with v=X.X.X-X"
@@ -152,11 +152,15 @@ ifeq (,$(POLKADOT_VERSION))
 	@echo "Error: Having trouble finding the Polkadot version. Sorry about that.\nCheck my POLKADOT_VERSION variable command."
 	@exit 1
 endif
-	@echo "Setting the crate versions to "$(v)+polkadot-$(POLKADOT_VERSION)
-	find ./ -type f -name 'Cargo.toml' -exec sed -i '' 's/^version = \"0\.0\.0\"/version = \"$(v)+polkadot-$(POLKADOT_VERSION)\"/g' {} \;
-	# cargo check
+	@echo "Setting the crate versions to "$(v)+polkadot$(POLKADOT_VERSION)
+	find ./ -type f -name 'Cargo.toml' -exec sed -i '' 's/^version = \"0\.0\.0\"/version = \"$(v)+polkadot$(POLKADOT_VERSION)\"/g' {} \;
+	cargo check
 	@echo "All done. Don't forget to double check that the automated replacement worked."
 
-PHONY: version-reset
+.PHONY: version-polkadot
+version-polkadot:
+	@echo $(POLKADOT_VERSION)
+
+.PHONY: version-reset
 version-reset:
 	find ./ -type f -name 'Cargo.toml' -exec sed -i '' 's/^version = \".*+polkadot.*\"/version = \"0.0.0\"/g' {} \;

--- a/Makefile
+++ b/Makefile
@@ -135,8 +135,9 @@ test:
 integration-test:
 	./scripts/run_integration_tests.sh
 
-# Pull the Polkadot version from the polkadot-cli package and remove the leading v
-POLKADOT_VERSION=$(shell cargo tree --depth 0 --manifest-path ./node/service/Cargo.toml --package polkadot-cli | grep polkadot-cli | cut -d " " -f 2 | tr -d "v")
+# Pull the Polkadot version from the polkadot-cli package in the Cargo.lock file.
+# This will break if the lock file format changes
+POLKADOT_VERSION=$(shell grep -oz '\[\[package\]\]\nname = "polkadot-cli"\nversion = ".*\..*\..*"' Cargo.lock | tail -n 1 | cut -d " " -f 3 | tr -d \")
 
 .PHONY: version
 version:
@@ -159,6 +160,10 @@ endif
 
 .PHONY: version-polkadot
 version-polkadot:
+ifeq (,$(POLKADOT_VERSION))
+	@echo "Error: Having trouble finding the Polkadot version. Sorry about that.\nCheck my POLKADOT_VERSION variable command."
+	@exit 1
+endif
 	@echo $(POLKADOT_VERSION)
 
 .PHONY: version-reset

--- a/tools/ci/release-notes/build-release-notes.sh
+++ b/tools/ci/release-notes/build-release-notes.sh
@@ -1,6 +1,7 @@
 #!/bin/sh
 # set -ex
 
-changelog=$1
+polkadot_version=$1
+changelog=$2
 
-CHANGELOG="$changelog" tera -a --env --env-key env --env-only --template release-notes.md.tera
+CHANGELOG="$changelog" POLKADOT_VERSION="$polkadot_version" tera -a --env --env-key env --env-only --template release-notes.md.tera

--- a/tools/ci/release-notes/release-notes.md.tera
+++ b/tools/ci/release-notes/release-notes.md.tera
@@ -4,7 +4,7 @@ Full changelog: https://github.com/LibertyDSNP/frequency/compare/{{env.PREVIOUS_
 
 ## Versions
 - Rust Toolchain: `{{env.RUST_TOOLCHAIN}}`
-- Polkadot Version: `v{{env.POLKADOT_VERSION}}`
+- Substrate/Polkadot: `v{{env.POLKADOT_VERSION}}`
 
 ## What's Changed
 {% set changelog = env.CHANGELOG | split(pat='|n|') | safe %}

--- a/tools/ci/release-notes/release-notes.md.tera
+++ b/tools/ci/release-notes/release-notes.md.tera
@@ -4,6 +4,7 @@ Full changelog: https://github.com/LibertyDSNP/frequency/compare/{{env.PREVIOUS_
 
 ## Versions
 - Rust Toolchain: `{{env.RUST_TOOLCHAIN}}`
+- Polkadot Version: `v{{env.POLKADOT_VERSION}}`
 
 ## What's Changed
 {% set changelog = env.CHANGELOG | split(pat='|n|') | safe %}


### PR DESCRIPTION
# Goal
The goal of this PR is to switch to a new versioning strategy (shifting the substrate/polkadot version into the build version).

Closes #686 
Closes #823 

# Discussion

Tested with v1.0.0-rc1
```
$ ./frequency.amd64 --version
frequency.amd64 1.0.0-rc1+polkadot0.9.30-9d0f4bc96f9
```
- CI check failure test: https://github.com/LibertyDSNP/frequency/actions/runs/3842190870/jobs/6543671877
- CI check success test: https://github.com/LibertyDSNP/frequency/actions/runs/3842423288

Release Notes Update Test:
<img width="914" alt="image" src="https://user-images.githubusercontent.com/1252199/210675548-6b800016-a33a-49e9-a163-1786b6d76efc.png">


# Checklist
- [x] CI Check of binary version
- [x] Wiki Update: https://github.com/LibertyDSNP/frequency/wiki/Release
- [ ] [Update Frequency CI Diagram](https://docs.google.com/drawings/d/1IcAzZbulRcntYQ5ub-zDyIkqJY1NE0iqClhkg2PE5lo/edit) (TODO)
