### PR TITLE
Bug Fix (#882) Use correct feature flags with srtool

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -124,6 +124,7 @@ jobs:
             built-wasm-file-name-prefix: frequency_runtime
             release-wasm-file-name-prefix: frequency-rococo_runtime
             features: frequency-rococo-testnet
+            wasm-core-version: frequency-rococo
           - network: mainnet
             build-profile: production
             package: frequency-runtime
@@ -131,6 +132,7 @@ jobs:
             built-wasm-file-name-prefix: frequency_runtime
             release-wasm-file-name-prefix: frequency_runtime
             features: frequency
+            wasm-core-version: frequency
     runs-on: [self-hosted, Linux, X64]
     steps:
       - name: Set Ubuntu Env Vars
@@ -189,8 +191,8 @@ jobs:
       - name: Build Deterministic WASM
         run: |
           set -ex
-          srtool build \
-            --default-features="on-chain-release-build,no-metadata-docs,${{matrix.features}}" \
+          RUST_LOG=debug srtool build \
+            --build-opts="'--features on-chain-release-build,no-metadata-docs,${{matrix.features}}'" \
             --profile=${{matrix.build-profile}} \
             --package=${{matrix.package}} \
             --root
@@ -198,6 +200,15 @@ jobs:
         run: |
           cp -p ./${{env.WASM_DIR}}/${{env.BUILT_WASM_FILENAME}} \
             ./${{env.WASM_DIR}}/${{env.RELEASE_WASM_FILENAME}}
+      - name: Install subwasm
+        run: |
+          cargo install --locked --git https://github.com/chevdor/subwasm --tag v0.18.0
+          subwasm --version
+      - name: Test WASM file
+        run: |
+          subwasm info ${{env.WASM_DIR}}/${{env.RELEASE_WASM_FILENAME}}
+          subwasm info ${{env.WASM_DIR}}/${{env.RELEASE_WASM_FILENAME}} | grep "Core version:.*${{matrix.wasm-core-version}}-${{env.RUNTIME_SPEC_VERSION}}" || \
+            (echo "ERROR: WASM Core version didn't match ${{matrix.wasm-core-version}}-${{env.RUNTIME_SPEC_VERSION}}" && exit 1)
       - name: Upload Artifact
         uses: actions/upload-artifact@v3
         with:


### PR DESCRIPTION
# Goal
The goal of this PR is to make sure that the correct feature flags are being used with srtool for wasm generation

Closes #882 

# Discussion
- srtool default-features flag does not work as intended
- Instead using build-opts
- Enabled debug logging in srtool for easier checking
- Added subwasm check to test the output wasm

Test Runs:
- Mainnet: https://github.com/LibertyDSNP/frequency/actions/runs/3859784794/jobs/6579633360
    <img width="1010" alt="image" src="https://user-images.githubusercontent.com/1252199/211126355-d6f917d3-0ef2-447c-8f81-ac5333ce34d1.png">

- Rococo: https://github.com/LibertyDSNP/frequency/actions/runs/3859784794/jobs/6579633325
     <img width="892" alt="image" src="https://user-images.githubusercontent.com/1252199/211126378-037467be-b34d-4e6c-bafb-effdafb46328.png">


# Checklist
- [x] Tests added
