### PR TITLE
Spike: Add deploy schemas to instant seal node

### DIFF
--- a/docker/instant-seal-node-with-deployed-schemas.dockerfile
+++ b/docker/instant-seal-node-with-deployed-schemas.dockerfile
@@ -1,0 +1,53 @@
+# Docker image for running Frequency parachain node container (with collating)
+# locally in instant seal mode then deploying schemas to that node.
+# Requires to run from repository root and to copy
+# the binary in the build folder.
+
+#This pulls the latest instant-seal-node image
+FROM frequencychain/instant-seal-node as frequency-image
+
+#Creates base image
+FROM --platform=linux/amd64 ubuntu:20.04 AS base
+
+LABEL maintainer="Frequency"
+LABEL description="Frequency collator node in instant seal mode"
+
+RUN apt-get update && apt-get install -y ca-certificates && update-ca-certificates
+
+#Install git and clone schemas repo
+RUN apt-get update && apt-get install -y git
+
+RUN git clone https://github.com/LibertyDSNP/schemas.git
+
+# Install node-js to base image
+RUN apt-get update && apt-get install -y curl gnupg
+RUN curl -sL https://deb.nodesource.com/setup_16.x | bash
+RUN apt-get update && apt-get install -y nodejs
+
+# Add frequency user
+
+RUN useradd -m -u 1000 -U -s /bin/sh -d /frequency frequency && \
+    chown -R frequency:frequency /schemas  && \
+    mkdir -p /data /frequency/.local/share && \
+	chown -R frequency:frequency /data && \
+	ln -s /data /frequency/.local/share/frequency
+
+USER frequency
+
+# Copy over depoly_schemas script to base image
+COPY --chown=frequency scripts/deploy_schemas.sh ./frequency/
+RUN chmod +x ./frequency/deploy_schemas.sh
+
+# Copy over latest frequency binary from instant-seal image to base image
+COPY --from=frequency-image --chown=frequency /frequency/frequency /frequency/frequency
+RUN chmod +x /frequency/frequency
+
+# 9933 P2P port
+# 9944 for RPC call
+# 30333 for Websocket
+EXPOSE 9933 9944 30333
+
+VOLUME ["/data"]
+
+# Params which can be overriden from CLI
+CMD ["/bin/bash", "frequency/deploy_schemas.sh"]

--- a/scripts/deploy_schemas.sh
+++ b/scripts/deploy_schemas.sh
@@ -1,0 +1,29 @@
+#!/bin/bash
+
+set -m
+
+npm --version
+ldd --version
+
+chmod +x /frequency/frequency
+/frequency/frequency --dev \
+    -lruntime=debug \
+    --instant-sealing \
+    --wasm-execution=compiled \
+    --execution=wasm \
+    --no-telemetry \
+    --no-prometheus \
+    --port=30333 \
+    --rpc-port=9933 \
+    --ws-port=9944 \
+    --rpc-external \
+    --rpc-cors=all \
+    --ws-external \
+    --rpc-methods=Unsafe \
+    --tmp \
+    &
+
+cd schemas
+npm install && npm run deploy
+
+fg %1


### PR DESCRIPTION
# Goal
The goal of this PR is to create a new docker image that extends the existing instant seal image and deploys the schemas to that node. This will especially help with testing clients using test containers pulling a frequency docker image.  

# Closes [184003669](https://www.pivotaltracker.com/story/show/184003669)

# Discussion
- The reason I'm copying over the frequency binary from the existing instant-seal-node image to a new ubuntu image is that you can't override an existing entrypoint (to my knowledge), so creating a new image, installing node, checking out the schemas repo, and changing permissions to make things executable was the best solution I came up with. However, I am no docker expert and would be open to a better solution. 
- To run locally
  - Make sure terminal is at frequency root directory
  - To build on intel mac (on a m1 chip switch "amd64" with "arm64"), run this (and sub <give image a name> with whatever name you want the image to be: 
    - docker buildx build --platform=linux/amd64 -f docker/instant-seal-node-with-deployed-schemas.dockerfile -t <give image a name> .
  - To run on intel mac, run this (and sub image name with whatever you tagged the name in previous command): 
    - docker run --rm -dp 9944:9944 -p 9933:9933 -p 30333:30333 <image name> 