### PR TITLE
Update Cargo Deny Issues

### DIFF
--- a/.cargo-deny.toml
+++ b/.cargo-deny.toml
@@ -81,14 +81,18 @@ ignore = [
     # Substrate dependency deprecation
     #   See https://github.com/paritytech/substrate/issues/12430
     "RUSTSEC-2021-0139",
-    # Pending Substrate update (v0.9.31)
-    #   See: https://github.com/LibertyDSNP/frequency/issues/402
-    "RUSTSEC-2022-0040",
-    # Not effected as kvdb-rocksdb does not use rocksdb_open_column_families_with_ttl
-    #   See: https://github.com/LibertyDSNP/frequency/issues/402
-    "RUSTSEC-2022-0046",
     # Substrate dependency. Does not effect WASM and dependencies do not appear to use effected functions
     "RUSTSEC-2020-0071",
+    # Substrate dependency.
+    #    See: https://github.com/LibertyDSNP/frequency/issues/860
+    #    See: https://github.com/LibertyDSNP/frequency/issues/864
+    "RUSTSEC-2022-0076",
+    # Substrate dependency being removed slowly
+    #    Will be removed in future substrate release
+    "RUSTSEC-2022-0080",
+    # Substrate depednency
+    #    Windows issue, does not effect Frequency
+    "RUSTSEC-2021-0145",
 ]
 # Threshold for security vulnerabilities, any vulnerability with a CVSS score
 # lower than the range specified will be ignored. Note that ignored advisories

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2080,9 +2080,9 @@ dependencies = [
 
 [[package]]
 name = "ed25519"
-version = "1.5.2"
+version = "1.5.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1e9c280362032ea4203659fc489832d0204ef09f247a0506f170dafcac08c369"
+checksum = "91cff35c70bba8a626e3185d8cd48cc11b5437e1a5bcd15b9b5fa3c64b6dfee7"
 dependencies = [
  "signature",
 ]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -11357,9 +11357,9 @@ checksum = "cda74da7e1a664f795bb1f8a87ec406fb89a02522cf6e50620d016add6dbbf5c"
 
 [[package]]
 name = "tokio"
-version = "1.22.0"
+version = "1.24.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d76ce4a75fb488c605c54bf610f221cea8b0dafb53333c1a67e8ee199dcd2ae3"
+checksum = "1d9f76183f91ecfb55e1d7d5602bd1d979e38a3a522fe900241cf195624d67ae"
 dependencies = [
  "autocfg",
  "bytes",
@@ -11372,7 +11372,7 @@ dependencies = [
  "signal-hook-registry",
  "socket2",
  "tokio-macros",
- "winapi",
+ "windows-sys 0.42.0",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -9732,9 +9732,9 @@ dependencies = [
 
 [[package]]
 name = "secp256k1"
-version = "0.24.1"
+version = "0.24.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ff55dc09d460954e9ef2fa8a7ced735a964be9981fd50e870b2b3b0705e14964"
+checksum = "6b1629c9c557ef9b293568b338dddfc8208c98a18c59d722a9d53f859d9c9b62"
 dependencies = [
  "secp256k1-sys",
 ]
@@ -11658,7 +11658,7 @@ version = "1.6.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "97fee6b57c6a41524a810daee9286c02d7752c4253064d0b05472833a438f675"
 dependencies = [
- "cfg-if 1.0.0",
+ "cfg-if 0.1.10",
  "digest 0.10.6",
  "rand 0.8.5",
  "static_assertions",

--- a/pallets/messages/src/rpc/Cargo.toml
+++ b/pallets/messages/src/rpc/Cargo.toml
@@ -23,7 +23,7 @@ sp-runtime = { git = "https://github.com/paritytech/substrate", default-features
 frame-support = { default-features = false, git = "https://github.com/paritytech/substrate.git", branch = "polkadot-v0.9.32" }
 
 [dev-dependencies]
-tokio = { version = "1.21.2", features = ["macros", "time", "parking_lot"] }
+tokio = { version = "1.24.1", features = ["macros", "time", "parking_lot"] }
 substrate-test-runtime-client = { git = "https://github.com/paritytech/substrate", default-features = false, branch = "polkadot-v0.9.32" }
 sc-client-api = { git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.32" }
 

--- a/pallets/msa/src/rpc/Cargo.toml
+++ b/pallets/msa/src/rpc/Cargo.toml
@@ -24,7 +24,7 @@ sp-blockchain = { git = "https://github.com/paritytech/substrate", default-featu
 sp-runtime = { git = "https://github.com/paritytech/substrate", default-features = false, branch = "polkadot-v0.9.32" }
 
 [dev-dependencies]
-tokio = { version = "1.21.2", features = ["macros", "time", "parking_lot"] }
+tokio = { version = "1.24.1", features = ["macros", "time", "parking_lot"] }
 substrate-test-runtime-client = { git = "https://github.com/paritytech/substrate", default-features = false, branch = "polkadot-v0.9.32" }
 sc-client-api = { git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.32" }
 

--- a/pallets/schemas/src/rpc/Cargo.toml
+++ b/pallets/schemas/src/rpc/Cargo.toml
@@ -26,7 +26,7 @@ sp-blockchain = { git = "https://github.com/paritytech/substrate", default-featu
 sp-std = { default-features = false, git = "https://github.com/paritytech/substrate.git", branch = "polkadot-v0.9.32" }
 
 [dev-dependencies]
-tokio = { version = "1.21.2", features = ["macros", "time", "parking_lot"] }
+tokio = { version = "1.24.1", features = ["macros", "time", "parking_lot"] }
 substrate-test-runtime-client = { git = "https://github.com/paritytech/substrate", default-features = false, branch = "polkadot-v0.9.32" }
 sc-client-api = { git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.32" }
 


### PR DESCRIPTION
# Goal
The goal of this PR is to update the ignore list for cargo deny and fix any fixable vulnerabilities.

Closes #915 
Closes #862 

With @JoeCap08055 

# Discussion
- Updated secp256k1 (yanked crate version & security issue #862)
- Updated ed25519 (yanked crate version)
- Updated Tokio dev dependency due to a vulnerability
- Added to the cargo deny list
- Remove outdated from the cargo deny list

# Checklist
- [x] cargo check
- [x] cargo deny