### PR TITLE
match dummy build binaries matrix to the real one

### DIFF
--- a/.github/workflows/verify-pr-commit.yml
+++ b/.github/workflows/verify-pr-commit.yml
@@ -57,13 +57,23 @@ jobs:
     name: Build ${{matrix.network}} Binary on ${{matrix.branch_alias}} Branch
     strategy:
       matrix:
-        network: [local, rococo, mainnet]
-        git_branch: ["${{github.head_ref}}", main]
+        network: [rococo, mainnet]
+        # Match this include to the real build-binaries job
         include:
           - git_branch: ${{github.head_ref}}
+            spec: frequency-rococo-local
             branch_alias: pr
+            network: local
           - git_branch: main
+            spec: frequency-rococo-local
             branch_alias: main
+            network: local
+          - network: rococo
+            spec: frequency-rococo-testnet
+            branch_alias: pr
+          - network: mainnet
+            spec: frequency
+            branch_alias: pr
     steps:
       - run: echo "Just a dummy matrix to satisfy GitHub required checks that were skipped"
 


### PR DESCRIPTION
# Goal
The goal of this PR is to match matrix jobs in `build-binaries` and `build-binaries-dummy` jobs to avoid missing required checks.


![Screenshot 2023-01-18 at 4 01 00 PM](https://user-images.githubusercontent.com/4452412/213324520-7c759006-3355-4c11-b36e-108d1774610b.jpg)

