### PR TITLE
Disable Rust Deps Cache in CI

### DIFF
--- a/.github/workflows/merge-pr.yml
+++ b/.github/workflows/merge-pr.yml
@@ -34,10 +34,10 @@ jobs:
           target: wasm32-unknown-unknown
       - name: Check Out Repo
         uses: actions/checkout@v3
-      - name: Save/Restore Dependencies from Cache
-        uses: Swatinem/rust-cache@359a70e43a0bb8a13953b04a90f76428b4959bb6
-        with:
-          shared-key: ${{env.RUST_TOOLCHAIN}}
+      # - name: Save/Restore Dependencies from Cache
+      #   uses: Swatinem/rust-cache@359a70e43a0bb8a13953b04a90f76428b4959bb6
+      #   with:
+      #     shared-key: ${{env.RUST_TOOLCHAIN}}
       - name: Output Metadata
         # Run the cargo command and ignore any extra lines outside of the json result
         run: CARGO_INCREMENTAL=0 RUSTFLAGS="-D warnings" cargo run --features frequency export-metadata ./js/api-augment/metadata.json
@@ -61,11 +61,11 @@ jobs:
         working-directory: js/api-augment/dist
         env:
           FULL_SHA: ${{github.sha}}
-      - name: Publish on NPM @next
-        run: npm publish --tag next --access public
-        working-directory: js/api-augment/dist
-        env:
-          NODE_AUTH_TOKEN: ${{secrets.NODE_AUTH_TOKEN}}
+      # - name: Publish on NPM @next
+      #   run: npm publish --tag next --access public
+      #   working-directory: js/api-augment/dist
+      #   env:
+      #     NODE_AUTH_TOKEN: ${{secrets.NODE_AUTH_TOKEN}}
 
   calc-code-coverage-main:
     name: Merge - Calculate Code Coverage
@@ -94,8 +94,8 @@ jobs:
             -v --no-fail-fast --workspace
             -e frequency frequency-cli frequency-runtime frequency-service
             --exclude-files **/mock.rs **/weights.rs **/weights/* **/benchmarking.rs
-      - name: Upload to codecov.io
-        uses: codecov/codecov-action@v3
-        with:
-          fail_ci_if_error: false # optional (default = false)
-          verbose: true # optional (default = false)
+      # - name: Upload to codecov.io
+      #   uses: codecov/codecov-action@v3
+      #   with:
+      #     fail_ci_if_error: false # optional (default = false)
+      #     verbose: true # optional (default = false)

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -64,11 +64,11 @@ jobs:
           default: true
           profile: minimal
           target: wasm32-unknown-unknown
-      - name: Cache Rust Dependencies
-        if: steps.cache-binary.outputs.cache-hit != 'true'
-        uses: Swatinem/rust-cache@359a70e43a0bb8a13953b04a90f76428b4959bb6
-        with:
-          shared-key: ${{env.RUST_TOOLCHAIN}}
+      # - name: Cache Rust Dependencies
+      #   if: steps.cache-binary.outputs.cache-hit != 'true'
+      #   uses: Swatinem/rust-cache@359a70e43a0bb8a13953b04a90f76428b4959bb6
+      #   with:
+      #     shared-key: ${{env.RUST_TOOLCHAIN}}
       - name: Compile for ${{matrix.network}}
         if: steps.cache-binary.outputs.cache-hit != 'true'
         run: |
@@ -230,10 +230,10 @@ jobs:
           default: true
           profile: minimal
           target: wasm32-unknown-unknown
-      - name: Cache Rust Dependencies
-        uses: Swatinem/rust-cache@359a70e43a0bb8a13953b04a90f76428b4959bb6
-        with:
-          shared-key: ${{env.RUST_TOOLCHAIN}}
+      # - name: Cache Rust Dependencies
+      #   uses: Swatinem/rust-cache@359a70e43a0bb8a13953b04a90f76428b4959bb6
+      #   with:
+      #     shared-key: ${{env.RUST_TOOLCHAIN}}
       - name: Build Docs
         run: |
           RUSTDOCFLAGS="--enable-index-page -Zunstable-options" cargo doc --no-deps

--- a/.github/workflows/verify-pr-commit.yml
+++ b/.github/workflows/verify-pr-commit.yml
@@ -131,11 +131,11 @@ jobs:
           profile: minimal
           target: wasm32-unknown-unknown
           toolchain: stable
-      - name: Cache Rust Dependencies
-        if: steps.cache-binary.outputs.cache-hit != 'true'
-        uses: Swatinem/rust-cache@359a70e43a0bb8a13953b04a90f76428b4959bb6
-        with:
-          shared-key: ${{env.RUST_TOOLCHAIN}}
+      # - name: Cache Rust Dependencies
+      #   if: steps.cache-binary.outputs.cache-hit != 'true'
+      #   uses: Swatinem/rust-cache@359a70e43a0bb8a13953b04a90f76428b4959bb6
+      #   with:
+      #     shared-key: ${{env.RUST_TOOLCHAIN}}
       - name: Compile Binary
         if: steps.cache-binary.outputs.cache-hit != 'true'
         run: |
@@ -242,10 +242,10 @@ jobs:
           default: true
           profile: minimal
           target: wasm32-unknown-unknown
-      - name: Cache Rust Dependencies
-        uses: Swatinem/rust-cache@359a70e43a0bb8a13953b04a90f76428b4959bb6
-        with:
-          shared-key: ${{env.RUST_TOOLCHAIN}}
+      # - name: Cache Rust Dependencies
+      #   uses: Swatinem/rust-cache@359a70e43a0bb8a13953b04a90f76428b4959bb6
+      #   with:
+      #     shared-key: ${{env.RUST_TOOLCHAIN}}
       - name: Build Rust Docs
         run: RUSTDOCFLAGS="--enable-index-page --check -Zunstable-options" cargo doc --no-deps --all-features
 
@@ -295,10 +295,10 @@ jobs:
           profile: minimal
           target: wasm32-unknown-unknown
           toolchain: stable
-      - name: Restore Dependencies from Cache
-        uses: Swatinem/rust-cache@359a70e43a0bb8a13953b04a90f76428b4959bb6
-        with:
-          shared-key: ${{env.RUST_TOOLCHAIN}}
+      # - name: Restore Dependencies from Cache
+      #   uses: Swatinem/rust-cache@359a70e43a0bb8a13953b04a90f76428b4959bb6
+      #   with:
+      #     shared-key: ${{env.RUST_TOOLCHAIN}}
       - name: Run Tests
         run: cargo test --all-features --workspace --release
 
@@ -493,10 +493,10 @@ jobs:
           default: true
           profile: minimal
           toolchain: stable
-      - name: Restore Dependencies from Cache
-        uses: Swatinem/rust-cache@359a70e43a0bb8a13953b04a90f76428b4959bb6
-        with:
-          shared-key: ${{env.RUST_TOOLCHAIN}}
+      # - name: Restore Dependencies from Cache
+      #   uses: Swatinem/rust-cache@359a70e43a0bb8a13953b04a90f76428b4959bb6
+      #   with:
+      #     shared-key: ${{env.RUST_TOOLCHAIN}}
       - name: Download Binary
         uses: actions/download-artifact@v3
         with:


### PR DESCRIPTION
# Goal
The goal of this PR is to disable Rust dependencies cache action. As described in #947, mainly for these reasons:

1. This cache adds more overhead (up till 20 mins), but appears to have no impact on the binary compilation time. 
2. Lately, the cache has been often over GitHub's 10GB limit, so it's not being saved anyway.

Closes #947