### PR TITLE
Feat/epoch number #957

### DIFF
--- a/pallets/capacity/src/benchmarking.rs
+++ b/pallets/capacity/src/benchmarking.rs
@@ -30,7 +30,7 @@ pub fn create_funded_account<T: Config>(
 }
 
 // In the benchmarks we expect a new epoch to always start so as to test worst case scenario.
-pub fn set_up_epoch<T: Config>(current_block: T::BlockNumber, current_epoch: T::BlockNumber) {
+pub fn set_up_epoch<T: Config>(current_block: T::BlockNumber, current_epoch: T::EpochNumber) {
 	CurrentEpoch::<T>::set(current_epoch);
 	let epoch_start = current_block.saturating_sub(<T>::MaxEpochLength::get());
 	CurrentEpochInfo::<T>::set(EpochInfo { epoch_start });
@@ -75,7 +75,7 @@ benchmarks! {
 
 	on_initialize {
 		let current_block: T::BlockNumber = 100_000u32.into();
-		let current_epoch: T::BlockNumber = 10_000u32.into();
+		let current_epoch: T::EpochNumber = 10_000u32.into();
 		set_up_epoch::<T>(current_block, current_epoch);
 	}: {
 		Capacity::<T>::on_initialize(current_block);

--- a/pallets/capacity/src/helpers_tests.rs
+++ b/pallets/capacity/src/helpers_tests.rs
@@ -1,21 +1,21 @@
 use super::*;
 use crate::mock::*;
 
-struct TestCase {
+struct TestCase<T: Config> {
 	name: &'static str,
-	starting_epoch: u64,
-	epoch_start_block: u64,
-	expected_epoch: u64,
-	expected_epoch_start_block: u64,
+	starting_epoch: <T>::EpochNumber,
+	epoch_start_block: <T>::BlockNumber,
+	expected_epoch: <T>::EpochNumber,
+	expected_epoch_start_block: <T>::BlockNumber,
 	expected_capacity: u64,
-	at_block: u64,
+	at_block: <T>::BlockNumber,
 }
 
 #[test]
 fn start_new_epoch_works() {
 	new_test_ext().execute_with(|| {
 		// assumes the mock epoch length is 10 blocks.
-		let test_cases: Vec<TestCase> = vec![
+		let test_cases: Vec<TestCase<Test>> = vec![
 			TestCase {
 				name: "epoch changes at the right time",
 				starting_epoch: 2,

--- a/pallets/capacity/src/lib.rs
+++ b/pallets/capacity/src/lib.rs
@@ -97,7 +97,7 @@ pub mod pallet {
 
 	use frame_support::{pallet_prelude::*, Twox64Concat};
 	use frame_system::pallet_prelude::*;
-	use sp_runtime::traits::{AtLeast32BitUnsigned, Bounded, MaybeDisplay};
+	use sp_runtime::traits::{AtLeast32BitUnsigned, MaybeDisplay};
 
 	#[pallet::config]
 	pub trait Config: frame_system::Config {
@@ -142,10 +142,8 @@ pub mod pallet {
 			+ MaybeDisplay
 			+ AtLeast32BitUnsigned
 			+ Default
-			+ Bounded
 			+ Copy
 			+ sp_std::hash::Hash
-			+ sp_std::str::FromStr
 			+ MaxEncodedLen
 			+ TypeInfo;
 	}
@@ -519,7 +517,7 @@ impl<T: Config> Pallet<T> {
 		total_capacity.saturating_sub(rate.mul_ceil(total_capacity))
 	}
 
-	/// Get current epoch length.
+	/// Get current epoch length in blocks.
 	fn get_epoch_length() -> T::BlockNumber {
 		<T>::MaxEpochLength::get()
 	}

--- a/pallets/capacity/src/mock.rs
+++ b/pallets/capacity/src/mock.rs
@@ -140,6 +140,7 @@ impl Config for Test {
 
 	type UnstakingThawPeriod = ConstU16<2>;
 	type MaxEpochLength = ConstU64<10>;
+	type EpochNumber = u32;
 }
 
 pub fn new_test_ext() -> sp_io::TestExternalities {

--- a/runtime/frequency/src/lib.rs
+++ b/runtime/frequency/src/lib.rs
@@ -318,6 +318,7 @@ impl pallet_capacity::Config for Runtime {
 	type BenchmarkHelper = Msa;
 	type UnstakingThawPeriod = CapacityUnstakingThawPeriod;
 	type MaxEpochLength = CapacityMaxEpochLength;
+	type EpochNumber = u32;
 }
 
 impl pallet_schemas::Config for Runtime {


### PR DESCRIPTION
## Goal
The goal of this PR is to create and use an EpochNumber type. Closes #957 

## Discussion
We don't want EpochNumber necessarily to be the same type as BlockNumber. Its type is configurable in the pallet Config.

## Checklist
- [x] EpochNumber type created as Config
- [x] EpochNumber set in runtime and mock
- [x] EpochNumber type used where applicable
- [x] Tests <del>added</del> updated
- [x] Chain spec updated

### Not applicable
- Design doc(s) updated
- Benchmarks added
- Custom RPC OR Runtime API added/changed? Updated js/api-augment.
-  Weights updated
