### PR TITLE
chore(capacity): Update the stake event to also include issued capacity

### DIFF
--- a/designdocs/capacity.md
+++ b/designdocs/capacity.md
@@ -214,7 +214,7 @@ pub enum Event<T: Config> {
     target: MessageSourceId,
     /// An amount that was staked.
     amount: BalanceOf<T>,
-    /// The amount of Capacity issued to target.
+    /// The Capacity amount issued to the target as a result of the stake.
     capacity: BalanceOf<T>,
   },
 

--- a/pallets/capacity/src/benchmarking.rs
+++ b/pallets/capacity/src/benchmarking.rs
@@ -41,6 +41,7 @@ benchmarks! {
 	stake {
 		let caller: T::AccountId = create_funded_account::<T>("account", SEED, 5u32);
 		let amount: BalanceOf<T> = T::MinimumStakingAmount::get();
+		let capacity: BalanceOf<T> = Capacity::<T>::calculate_capacity(amount);
 		let target = 1;
 
 		register_provider::<T>(target, "Foo");
@@ -50,7 +51,7 @@ benchmarks! {
 		assert!(StakingAccountLedger::<T>::contains_key(&caller));
 		assert!(StakingTargetLedger::<T>::contains_key(&caller, target));
 		assert!(CapacityLedger::<T>::contains_key(target));
-		assert_last_event::<T>(Event::<T>::Staked {account: caller, amount, target }.into());
+		assert_last_event::<T>(Event::<T>::Staked {account: caller, amount, target, capacity}.into());
 	}
 
 	withdraw_unstaked {

--- a/pallets/capacity/src/extrinsics_tests.rs
+++ b/pallets/capacity/src/extrinsics_tests.rs
@@ -130,6 +130,7 @@ fn stake_works() {
 		let account = 200;
 		let target: MessageSourceId = 1;
 		let amount = 5;
+		let capacity = 5;
 		register_provider(target, String::from("Foo"));
 		assert_ok!(Capacity::stake(RuntimeOrigin::signed(account), target, amount));
 
@@ -148,7 +149,7 @@ fn stake_works() {
 		assert_eq!(Capacity::get_capacity_for(target).unwrap().last_replenished_epoch, 1);
 
 		let events = staking_events();
-		assert_eq!(events.first().unwrap(), &Event::Staked { account, target, amount });
+		assert_eq!(events.first().unwrap(), &Event::Staked { account, target, amount, capacity });
 
 		assert_eq!(Balances::locks(&account)[0].amount, amount);
 		assert_eq!(Balances::locks(&account)[0].reasons, WithdrawReasons::all().into());
@@ -201,6 +202,7 @@ fn stake_increase_stake_amount_works() {
 		let account = 200;
 		let target: MessageSourceId = 1;
 		let initial_amount = 5;
+		let capacity = 5;
 		register_provider(target, String::from("Foo"));
 
 		// First Stake
@@ -208,7 +210,7 @@ fn stake_increase_stake_amount_works() {
 		let events = staking_events();
 		assert_eq!(
 			events.first().unwrap(),
-			&Event::Staked { account, target, amount: initial_amount }
+			&Event::Staked { account, target, amount: initial_amount, capacity }
 		);
 
 		assert_eq!(Balances::locks(&account)[0].amount, 5);
@@ -217,6 +219,7 @@ fn stake_increase_stake_amount_works() {
 		run_to_block(2);
 
 		let additional_amount = 10;
+		let capacity = 10;
 		// Additional Stake
 		assert_ok!(Capacity::stake(RuntimeOrigin::signed(account), target, additional_amount));
 
@@ -237,7 +240,7 @@ fn stake_increase_stake_amount_works() {
 		let events = staking_events();
 		assert_eq!(
 			events.first().unwrap(),
-			&Event::Staked { account, target, amount: additional_amount }
+			&Event::Staked { account, target, amount: additional_amount, capacity }
 		);
 
 		assert_eq!(Balances::locks(&account)[0].amount, 15);

--- a/pallets/capacity/src/lib.rs
+++ b/pallets/capacity/src/lib.rs
@@ -210,6 +210,8 @@ pub mod pallet {
 			target: MessageSourceId,
 			/// An amount that was staked.
 			amount: BalanceOf<T>,
+			/// The Capacity amount issued to the target as a result of the stake.
+			capacity: BalanceOf<T>,
 		},
 		/// Unsstaked token that has thawed was unlocked for the given account
 		StakeWithdrawn {
@@ -288,14 +290,14 @@ pub mod pallet {
 			let (mut staking_account, actual_amount) =
 				Self::ensure_can_stake(&staker, target, amount)?;
 
-			Self::increase_stake_and_issue_capacity(
+			let capacity = Self::increase_stake_and_issue_capacity(
 				&staker,
 				&mut staking_account,
 				target,
 				actual_amount,
 			)?;
 
-			Self::deposit_event(Event::Staked { account: staker, amount: actual_amount, target });
+			Self::deposit_event(Event::Staked { account: staker, amount: actual_amount, target, capacity });
 
 			Ok(())
 		}
@@ -398,12 +400,13 @@ impl<T: Config> Pallet<T> {
 		staking_account: &mut StakingAccountDetails<T>,
 		target: MessageSourceId,
 		amount: BalanceOf<T>,
-	) -> DispatchResult {
+	) -> Result<BalanceOf<T>, DispatchError> {
 		staking_account.increase_by(amount).ok_or(ArithmeticError::Overflow)?;
 
+		let capacity = Self::calculate_capacity(amount);
 		let mut target_details = Self::get_target_for(&staker, &target).unwrap_or_default();
 		target_details
-			.increase_by(amount, Self::calculate_capacity(amount))
+			.increase_by(amount, capacity)
 			.ok_or(ArithmeticError::Overflow)?;
 
 		let mut capacity_details = Self::get_capacity_for(target).unwrap_or_default();
@@ -415,7 +418,7 @@ impl<T: Config> Pallet<T> {
 		Self::set_target_details_for(&staker, target, target_details);
 		Self::set_capacity_for(target, capacity_details);
 
-		Ok(())
+		Ok(capacity)
 	}
 
 	/// Sets staking account details.

--- a/pallets/capacity/src/lib.rs
+++ b/pallets/capacity/src/lib.rs
@@ -297,7 +297,12 @@ pub mod pallet {
 				actual_amount,
 			)?;
 
-			Self::deposit_event(Event::Staked { account: staker, amount: actual_amount, target, capacity });
+			Self::deposit_event(Event::Staked {
+				account: staker,
+				amount: actual_amount,
+				target,
+				capacity,
+			});
 
 			Ok(())
 		}
@@ -405,9 +410,7 @@ impl<T: Config> Pallet<T> {
 
 		let capacity = Self::calculate_capacity(amount);
 		let mut target_details = Self::get_target_for(&staker, &target).unwrap_or_default();
-		target_details
-			.increase_by(amount, capacity)
-			.ok_or(ArithmeticError::Overflow)?;
+		target_details.increase_by(amount, capacity).ok_or(ArithmeticError::Overflow)?;
 
 		let mut capacity_details = Self::get_capacity_for(target).unwrap_or_default();
 		capacity_details


### PR DESCRIPTION
# Goal
The goal of this PR is to add capacity issued to the stake event

Closes #941

