### PR TITLE
whitelist CurrentEpoch storage

### DIFF
--- a/pallets/capacity/src/lib.rs
+++ b/pallets/capacity/src/lib.rs
@@ -166,6 +166,7 @@ pub mod pallet {
 
 	/// Storage for the current epoch number
 	#[pallet::storage]
+	#[pallet::whitelist_storage]
 	#[pallet::getter(fn get_current_epoch)]
 	pub type CurrentEpoch<T: Config> = StorageValue<_, T::BlockNumber, ValueQuery>;
 


### PR DESCRIPTION
# Goal
The goal of this PR is to whitelist CurrentEpoch storage for benchmarking

Closes #956 

# Discussion

# N/A
- Chain spec updated
- Custom RPC OR Runtime API added/changed? Updated js/api-augment.
- Design doc(s) updated
- Tests added
- Benchmarks added
- Weights updated
