### PR TITLE
Disable Utility Pallet everywhere and enable Treasury on Mainnet

### DIFF
--- a/runtime/frequency/src/lib.rs
+++ b/runtime/frequency/src/lib.rs
@@ -79,25 +79,34 @@ use frame_support::traits::Contains;
 pub struct BaseCallFilter;
 
 impl Contains<RuntimeCall> for BaseCallFilter {
-	fn contains(_call: &RuntimeCall) -> bool {
+	fn contains(call: &RuntimeCall) -> bool {
 		#[cfg(not(feature = "frequency"))]
 		{
-			true
+			match call {
+				// Utility Calls are blocked. Issue #599
+				RuntimeCall::Utility(..) => false,
+				_ => true,
+			}
 		}
 		#[cfg(feature = "frequency")]
 		{
-			matches!(
-				_call,
+			match call {
+				// Utility Calls are blocked. Issue #599
+				RuntimeCall::Utility(..) => false,
+				// Allowed Mainnet
 				RuntimeCall::System(..) |
-					RuntimeCall::Timestamp(..) |
-					RuntimeCall::ParachainSystem(..) |
-					RuntimeCall::TechnicalCommittee(..) |
-					RuntimeCall::Council(..) |
-					RuntimeCall::Democracy(..) |
-					RuntimeCall::Session(..) |
-					RuntimeCall::Preimage(..) |
-					RuntimeCall::Scheduler(..)
-			)
+				RuntimeCall::Timestamp(..) |
+				RuntimeCall::ParachainSystem(..) |
+				RuntimeCall::TechnicalCommittee(..) |
+				RuntimeCall::Council(..) |
+				RuntimeCall::Democracy(..) |
+				RuntimeCall::Session(..) |
+				RuntimeCall::Preimage(..) |
+				RuntimeCall::Scheduler(..) |
+				RuntimeCall::Treasury(..) => true,
+				// General Mainnet Calls will be enabled with Issue #877
+				_ => false,
+			}
 		}
 	}
 }


### PR DESCRIPTION
# Goal
The goal of this PR is to disable the Utility pallet pending #599

Closes #952 

# Discussion
- Added Treasury to mainnet allowed
- Add Utility to blocked everywhere
- Updated the style of the mainnet blockers to separate out utility from the generic filter.

# Checklist
- [x] Tested with both versions of the call filter locally.
<img width="337" alt="image" src="https://user-images.githubusercontent.com/1252199/214870377-18a4cd83-ec1b-4082-92c2-2b678ba9769f.png">

If you want to test mainnet locally, apply this diff:

<img width="435" alt="image" src="https://user-images.githubusercontent.com/1252199/214871570-a9319b42-3a0d-4e81-8a8f-d20d6845e61d.png">

```
diff --git a/runtime/frequency/src/lib.rs b/runtime/frequency/src/lib.rs
index b1ccd12a..34d6f883 100644
--- a/runtime/frequency/src/lib.rs
+++ b/runtime/frequency/src/lib.rs
@@ -80,15 +80,15 @@ pub struct BaseCallFilter;

 impl Contains<RuntimeCall> for BaseCallFilter {
        fn contains(call: &RuntimeCall) -> bool {
-               #[cfg(not(feature = "frequency"))]
-               {
-                       match call {
-                               // Utility Calls are blocked. Issue #599
-                               RuntimeCall::Utility(..) => false,
-                               _ => true,
-                       }
-               }
-               #[cfg(feature = "frequency")]
+               // #[cfg(not(feature = "frequency"))]
+               // {
+               //      match call {
+               //              // Utility Calls are blocked. Issue #599
+               //              RuntimeCall::Utility(..) => false,
+               //              _ => true,
+               //      }
+               // }
+               // #[cfg(feature = "frequency")]
                {
                        match call {
                                // Utility Calls are blocked. Issue #599
```