### PR TITLE
Make export-metadata command always use a tmp directory for data

### DIFF
--- a/node/cli/src/command.rs
+++ b/node/cli/src/command.rs
@@ -257,17 +257,7 @@ pub fn run() -> Result<()> {
 			})
 		},
 		Some(Subcommand::ExportMetadata(cmd)) => {
-			let runner = cli.create_runner(cmd)?;
-
-			runner.async_run(|config| {
-				// grab the task manager.
-				let registry = config.prometheus_config.as_ref().map(|cfg| &cfg.registry);
-				let task_manager =
-					sc_service::TaskManager::new(config.tokio_handle.clone(), registry)
-						.map_err(|e| format!("Error: {:?}", e))?;
-				let partials = new_partial(&config, false)?;
-				Ok((cmd.run(partials.client), task_manager))
-			})
+			construct_async_run!(|components, cli, cmd, config| Ok(cmd.run(components.client)))
 		},
 		Some(Subcommand::PurgeChain(cmd)) => {
 			let runner = cli.create_runner(cmd)?;

--- a/node/cli/src/export_metadata_cmd.rs
+++ b/node/cli/src/export_metadata_cmd.rs
@@ -1,8 +1,7 @@
 use clap::Parser;
-use polkadot_cli::ProvideRuntimeApi;
 use sc_cli::{CliConfiguration, Error, GenericNumber, SharedParams};
 use serde_json::{json, to_writer};
-use sp_api::Metadata;
+use sp_api::{Metadata, ProvideRuntimeApi};
 use sp_core::Bytes;
 use sp_runtime::{
 	generic::BlockId,
@@ -34,7 +33,7 @@ impl ExportMetadataCmd {
 	where
 		B: BlockT,
 		C: ProvideRuntimeApi<B>,
-		C::Api: sp_api::Metadata<B> + 'static,
+		C::Api: Metadata<B> + 'static,
 		<<B::Header as HeaderT>::Number as FromStr>::Err: Debug,
 	{
 		let from = self.from.as_ref().and_then(|f| f.parse().ok()).unwrap_or(0u32);
@@ -53,5 +52,10 @@ impl ExportMetadataCmd {
 impl CliConfiguration for ExportMetadataCmd {
 	fn shared_params(&self) -> &SharedParams {
 		&self.shared_params
+	}
+
+	// We never want to use any stored data. Always just use fresh.
+	fn base_path(&self) -> Result<Option<sc_service::BasePath>, sc_cli::Error> {
+		Ok(Some(sc_service::BasePath::new_temp_dir()?))
 	}
 }

--- a/node/cli/src/runtime_version_cmd.rs
+++ b/node/cli/src/runtime_version_cmd.rs
@@ -3,7 +3,7 @@ use sc_cli::{CliConfiguration, Error, RuntimeVersion, SharedParams};
 use serde_json::{json, to_writer};
 use std::{fmt::Debug, fs, io, path::PathBuf};
 
-/// The `export-metadata` command used to export chain metadata.
+/// The `export-runtime-version` command used to export the runtime version.
 #[derive(Debug, Clone, Parser)]
 pub struct ExportRuntimeVersionCmd {
 	/// Output file name or stdout if unspecified.
@@ -16,7 +16,7 @@ pub struct ExportRuntimeVersionCmd {
 }
 
 impl ExportRuntimeVersionCmd {
-	/// Run the get-runtime-version command.
+	/// Run the export-runtime-version command.
 	pub async fn run(&self, runtime_version: &RuntimeVersion) -> Result<(), Error> {
 		let result = json!(runtime_version);
 		let file: Box<dyn io::Write> = match &self.output {


### PR DESCRIPTION
# Goal
The goal of this PR is make sure that the metadata from the `export-metadata` command is always fresh.

Closes #984

With @saraswatpuneet 

# Discussion
- Might be other better fix ideas from https://substrate.stackexchange.com/questions/6928/custom-metadata-command-returnning-incorrect-data however this works.
- Also cleaned up a bit around other cli things. See comments.

## How to test chain db bit
- Remove your chain db macOS: `$HOME/Library/Application\ Support/frequency/chains/`
- Run `cargo run --features frequency export-metadata`
- See that the chain db is not recreated

## How to test `export-metadata` == `state_getMetadata`
- Get the data from cli: `cargo run --features frequency export-metadata out.json && cat out.json | jq .result > export-metadata.test`
- Get the data from node:
    - `cargo run --features frequency -- --tmp --reserved-only -- --reserved-only` (This will keep mainnet from connecting to other nodes)
    - Wait for the node to start... "Idle (0 peers)"
    - `curl -H "Content-Type: application/json" -d '{"id":"1", "jsonrpc":"2.0", "method": "state_getMetadata", "params":[]}' http://localhost:9933 -o ./out.json && cat out.json | jq .result > node-metadata.test`
- Check the diff:
    - `diff export-metadata.test node-metadata.test`