### PR TITLE
926 add single page

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6102,6 +6102,7 @@ dependencies = [
  "frame-system",
  "log",
  "parity-scale-codec",
+ "pretty_assertions",
  "scale-info",
  "sp-core",
  "sp-io",

--- a/common/primitives/src/lib.rs
+++ b/common/primitives/src/lib.rs
@@ -21,6 +21,8 @@ pub mod node;
 pub mod parquet;
 /// Structs and traits for the Schema pallet
 pub mod schema;
+/// Types, structs and traits for the Stateful Storage pallet
+pub mod stateful_storage;
 /// Structs and traits for the utility package.
 pub mod utils;
 

--- a/common/primitives/src/stateful_storage.rs
+++ b/common/primitives/src/stateful_storage.rs
@@ -1,0 +1,2 @@
+/// Page Id is the unique identifier for a Page within a specific (MSA + SchemaId).
+pub type PageId = u16;

--- a/pallets/stateful-storage/Cargo.toml
+++ b/pallets/stateful-storage/Cargo.toml
@@ -31,6 +31,9 @@ sp-std = { git = "https://github.com/paritytech/substrate", default-features = f
 # Frequency related dependencies
 common-primitives = { default-features = false, path = "../../common/primitives" }
 
+[dev-dependencies]
+pretty_assertions = "1"
+
 [features]
 default = ['std']
 runtime-benchmarks = [

--- a/pallets/stateful-storage/src/benchmarking.rs
+++ b/pallets/stateful-storage/src/benchmarking.rs
@@ -1,7 +1,20 @@
+#![cfg(feature = "runtime-benchmarks")]
+
 use super::*;
+#[allow(unused)]
 use crate::Pallet as StatefulStoragePallet;
+use common_primitives::{benchmarks::*, msa::ProviderId, schema::*};
 use frame_benchmarking::{benchmarks, whitelisted_caller};
+use frame_support::assert_ok;
 use frame_system::RawOrigin;
+
+fn create_schema<T: Config>() -> DispatchResult {
+	T::SchemaBenchmarkHelper::create_schema(
+		Vec::from(r#"{"Name": "Bond", "Code": "007"}"#.as_bytes()),
+		ModelType::AvroBinary,
+		PayloadLocation::OnChain,
+	)
+}
 
 benchmarks! {
 	add_item {
@@ -10,30 +23,30 @@ benchmarks! {
 
 		let payload = vec![1u8; n as usize];
 	}: _ (RawOrigin::Signed(caller), payload)
-	verify {
-		assert_eq!(false, false);
-	}
 
 	remove_item {
 		let caller: T::AccountId = whitelisted_caller();
 	}: _ (RawOrigin::Signed(caller))
-	verify {
-	}
 
 	upsert_page {
-		let n in 0 .. 5;
+		let s in 0 .. T::MaxPaginatedPageSizeBytes::get() - 1;
+		let n in 0 .. (T::MaxPaginatedPageCount::get() - 1).into();
 		let caller: T::AccountId = whitelisted_caller();
+		let schema_id = 5;
 
-		let payload = vec![1u8; n as usize];
-	}: _ (RawOrigin::Signed(caller), payload)
-	verify {
-	}
+		// schema ids start from 1, and we need to add that many to make sure our desired id exists
+		for j in 0 ..schema_id {
+			assert_ok!(create_schema::<T>());
+		}
+		assert_ok!(T::MsaBenchmarkHelper::add_key(ProviderId(1).into(), caller.clone()));
+
+		let payload = vec![1u8; s as usize];
+		let page_id = n;
+	}: _ (RawOrigin::Signed(caller), schema_id, page_id as u16, payload)
 
 	remove_page {
 		let caller: T::AccountId = whitelisted_caller();
 	}: _ (RawOrigin::Signed(caller))
-	verify {
-	}
 
 	impl_benchmark_test_suite!(StatefulStoragePallet,
 		crate::mock::new_test_ext(),

--- a/pallets/stateful-storage/src/tests.rs
+++ b/pallets/stateful-storage/src/tests.rs
@@ -1,6 +1,10 @@
 use super::mock::*;
+#[allow(unused_imports)]
 use crate::{Config, Error};
+use common_primitives::{schema::SchemaId, stateful_storage::PageId};
 use frame_support::{assert_err, assert_ok};
+#[allow(unused_imports)]
+use pretty_assertions::{assert_eq, assert_ne, assert_str_eq};
 
 #[test]
 fn add_item_ok() {
@@ -34,6 +38,8 @@ fn add_item_with_large_payload_errors() {
 fn upsert_page_too_large_errors() {
 	new_test_ext().execute_with(|| {
 		let caller_1 = 5u64;
+		let schema_id: SchemaId = 1;
+		let page_id: PageId = 1;
 		let payload =
 			vec![
 				1;
@@ -42,7 +48,12 @@ fn upsert_page_too_large_errors() {
 			];
 
 		assert_err!(
-			StatefulStoragePallet::upsert_page(RuntimeOrigin::signed(caller_1), payload),
+			StatefulStoragePallet::upsert_page(
+				RuntimeOrigin::signed(caller_1),
+				schema_id,
+				page_id,
+				payload
+			),
 			Error::<Test>::PageExceedsMaxPageSizeBytes
 		)
 	})

--- a/runtime/common/src/constants.rs
+++ b/runtime/common/src/constants.rs
@@ -311,6 +311,6 @@ pub const MaxPaginatedPageSizeBytes: u32 = 4096;
 /// The maximum size of a single item in an itemized storage model (in bytes)
 pub const MaxItemizedBlobSizeBytes: u32 = 512;
 /// The maximum number of pages in a Paginated storage model
-pub const MaxPaginatedPageCount: u32 = 64;
+pub const MaxPaginatedPageCount: u16 = 64;
 }
 // -end- Stateful Storage Pallet

--- a/runtime/frequency/src/lib.rs
+++ b/runtime/frequency/src/lib.rs
@@ -725,6 +725,10 @@ impl pallet_messages::Config for Runtime {
 impl pallet_stateful_storage::Config for Runtime {
 	type RuntimeEvent = RuntimeEvent;
 	type WeightInfo = pallet_stateful_storage::weights::SubstrateWeight<Runtime>;
+	// The type that supplies MSA info
+	type MsaInfoProvider = Msa;
+	// The type that provides schema info
+	type SchemaProvider = Schemas;
 	/// The maximum size of a page (in bytes) for an Itemized storage model
 	type MaxItemizedPageSizeBytes = MaxItemizedPageSizeBytes;
 	/// The maximum size of a page (in bytes) for a Paginated storage model
@@ -733,6 +737,12 @@ impl pallet_stateful_storage::Config for Runtime {
 	type MaxItemizedBlobSizeBytes = MaxItemizedBlobSizeBytes;
 	/// The maximum number of pages in a Paginated storage model
 	type MaxPaginatedPageCount = MaxPaginatedPageCount;
+
+	/// A set of helper functions for benchmarking.
+	#[cfg(feature = "runtime-benchmarks")]
+	type MsaBenchmarkHelper = Msa;
+	#[cfg(feature = "runtime-benchmarks")]
+	type SchemaBenchmarkHelper = Schemas;
 }
 
 // See https://paritytech.github.io/substrate/master/pallet_sudo/index.html for


### PR DESCRIPTION
# Goal
The goal of this PR is add the implementation for Stateful Storage `upsert_page()` (add new page) functionality.

Closes #926 

# Checklist
- [ ] Chain spec updated
- [ ] Custom RPC OR Runtime API added/changed? Updated js/api-augment.
- [ ] Design doc(s) updated
- [ ] Tests added
- [ ] Benchmarks added
- [ ] Weights updated
