### PR TITLE
add dummy benchmark workflow

### DIFF
--- a/.github/workflows/test-benchmark-runners.yml
+++ b/.github/workflows/test-benchmark-runners.yml
@@ -1,0 +1,16 @@
+name: Test Benchmark Runners
+
+concurrency:
+  group: ${{github.workflow}}
+  cancel-in-progress: true
+
+on:
+  workflow_dispatch:
+
+jobs:
+  benchmark:
+    runs-on: [self-hosted, benchmark]
+    steps:
+      - name: Test Run
+        run: |
+          echo "The workflow has been successfully triggered"


### PR DESCRIPTION
# Goal
The goal of this PR is to add a dummy benchmark workflow that devOps can use to test their dynamic benchmark runner solution.

Closes #997

# Discussion
<!-- List discussion items -->
