### PR TITLE
Bug Fix: Metadata export difference 

### DIFF
--- a/node/cli/src/export_metadata_cmd.rs
+++ b/node/cli/src/export_metadata_cmd.rs
@@ -10,6 +10,7 @@ use sp_runtime::{
 use std::{fmt::Debug, fs, io, path::PathBuf, str::FromStr, sync::Arc};
 
 /// The `export-metadata` command used to export chain metadata.
+/// Remember that this uses the chain database. So it will pull the _current_ metadata from that database.
 #[derive(Debug, Clone, Parser)]
 pub struct ExportMetadataCmd {
 	/// Output file name or stdout if unspecified.
@@ -52,10 +53,5 @@ impl ExportMetadataCmd {
 impl CliConfiguration for ExportMetadataCmd {
 	fn shared_params(&self) -> &SharedParams {
 		&self.shared_params
-	}
-
-	// We never want to use any stored data. Always just use fresh.
-	fn base_path(&self) -> Result<Option<sc_service::BasePath>, sc_cli::Error> {
-		Ok(Some(sc_service::BasePath::new_temp_dir()?))
 	}
 }

--- a/node/cli/src/export_metadata_cmd.rs
+++ b/node/cli/src/export_metadata_cmd.rs
@@ -69,8 +69,7 @@ impl CliConfiguration for ExportMetadataCmd {
 	fn base_path(&self) -> Result<Option<sc_service::BasePath>, sc_cli::Error> {
 		match &self.tmp {
 			true => Ok(Some(sc_service::BasePath::new_temp_dir()?)),
-			false => self.shared_params.base_path()
+			false => self.shared_params.base_path(),
 		}
 	}
-
 }

--- a/node/cli/src/export_metadata_cmd.rs
+++ b/node/cli/src/export_metadata_cmd.rs
@@ -26,6 +26,16 @@ pub struct ExportMetadataCmd {
 	#[allow(missing_docs)]
 	#[clap(flatten)]
 	pub shared_params: SharedParams,
+
+	/// Use a temporary directory for the db
+	///
+	/// A temporary directory will be created to store the configuration and will be deleted
+	/// at the end of the process.
+	///
+	/// Note: the directory is random per process execution. This directory is used as base path
+	/// which includes: database, node key and keystore.
+	#[arg(long, conflicts_with = "base_path")]
+	pub tmp: bool,
 }
 
 impl ExportMetadataCmd {
@@ -54,4 +64,13 @@ impl CliConfiguration for ExportMetadataCmd {
 	fn shared_params(&self) -> &SharedParams {
 		&self.shared_params
 	}
+
+	// Enabling `--tmp` on this command
+	fn base_path(&self) -> Result<Option<sc_service::BasePath>, sc_cli::Error> {
+		match &self.tmp {
+			true => Ok(Some(sc_service::BasePath::new_temp_dir()?)),
+			false => self.shared_params.base_path()
+		}
+	}
+
 }


### PR DESCRIPTION
# Goal
The goal of this PR is to apply a different fix for #984

Closes #984

# Discussion
- Instead of forcing the temporary directory make it a flag and optionally use it.
- The correction of CI workflows to use this will be part of #896  