### PR TITLE
Implement stateful storage tree

### DIFF
--- a/pallets/stateful-storage/src/lib.rs
+++ b/pallets/stateful-storage/src/lib.rs
@@ -50,6 +50,7 @@ mod tests;
 #[cfg(feature = "runtime-benchmarks")]
 mod benchmarking;
 
+mod stateful_child_tree;
 pub mod types;
 
 pub mod weights;

--- a/pallets/stateful-storage/src/stateful_child_tree.rs
+++ b/pallets/stateful-storage/src/stateful_child_tree.rs
@@ -1,0 +1,78 @@
+use codec::{Decode, Encode};
+use common_primitives::msa::MessageSourceId;
+use frame_support::{
+	storage::{child, child::ChildInfo, ChildTriePrefixIterator},
+	Identity, StorageHasher,
+};
+use sp_core::hexdisplay::AsBytesRef;
+use sp_std::prelude::*;
+
+pub type StatefulPageKeyPart = Vec<u8>;
+
+/// Paginated Stateful data access utility
+pub struct StatefulStorageTree;
+impl StatefulStorageTree {
+	pub fn concat_keys(keys: &[StatefulPageKeyPart]) -> Vec<u8> {
+		let mut key = Vec::<u8>::new();
+		for k in keys {
+			let mut k2 = k.to_owned();
+			key.append(&mut k2);
+		}
+
+		key
+	}
+
+	/// Reads a child tree node
+	///
+	/// The read is performed from the `msa_id` only. The `key` is not required. If the
+	/// data doesn't store under the given `key` `None` is returned.
+	pub fn read<V: Decode + Sized>(
+		msa_id: &MessageSourceId,
+		keys: &[StatefulPageKeyPart],
+	) -> Option<V> {
+		let child = Self::get_child_tree(*msa_id);
+		child::get::<V>(&child, &Identity::hash(Self::concat_keys(keys).as_bytes_ref()))
+	}
+
+	/// Prefix Iterator for a child tree
+	///
+	/// Allows getting all the keys having the same prefix
+	/// Warning: This should not be used from any on-chain transaction!
+	pub fn prefix_iterator<V: Decode + Sized>(
+		msa_id: &MessageSourceId,
+		keys: &[StatefulPageKeyPart],
+	) -> ChildTriePrefixIterator<(Vec<u8>, V)> {
+		let child = Self::get_child_tree(*msa_id);
+		ChildTriePrefixIterator::<_>::with_prefix(&child, Self::concat_keys(keys).as_bytes_ref())
+	}
+
+	/// Writes directly into child tree node
+	pub fn write<V: Encode + Sized>(
+		msa_id: &MessageSourceId,
+		keys: &[StatefulPageKeyPart],
+		new_value: V,
+	) {
+		let child_trie_info = &Self::get_child_tree(*msa_id);
+		child::put_raw(
+			child_trie_info,
+			&Identity::hash(Self::concat_keys(keys).as_bytes_ref()),
+			new_value.encode().as_ref(),
+		);
+	}
+
+	/// Kills a child tree node
+	pub fn kill<V: Encode + Sized>(msa_id: &MessageSourceId, keys: &[StatefulPageKeyPart]) {
+		let child_trie_info = &Self::get_child_tree(*msa_id);
+		child::kill(child_trie_info, &Identity::hash(Self::concat_keys(keys).as_bytes_ref()));
+	}
+
+	fn get_child_tree(msa_id: MessageSourceId) -> ChildInfo {
+		let trie_root = Self::get_tree_prefix(msa_id);
+		child::ChildInfo::new_default(Identity::hash(&trie_root[..]).as_ref())
+	}
+
+	fn get_tree_prefix(msa_id: MessageSourceId) -> Vec<u8> {
+		let arr = [&msa_id.encode()[..], b"::"].concat();
+		arr.to_vec()
+	}
+}

--- a/pallets/stateful-storage/src/stateful_child_tree.rs
+++ b/pallets/stateful-storage/src/stateful_child_tree.rs
@@ -10,8 +10,8 @@ use sp_std::prelude::*;
 pub type StatefulPageKeyPart = Vec<u8>;
 
 /// Paginated Stateful data access utility
-pub struct StatefulStorageTree;
-impl StatefulStorageTree {
+pub struct StatefulChildTree;
+impl StatefulChildTree {
 	pub fn concat_keys(keys: &[StatefulPageKeyPart]) -> Vec<u8> {
 		let mut key = Vec::<u8>::new();
 		for k in keys {

--- a/pallets/stateful-storage/src/tests.rs
+++ b/pallets/stateful-storage/src/tests.rs
@@ -1,5 +1,9 @@
 use super::mock::*;
-use crate::{Config, Error};
+use crate::{
+	stateful_child_tree::{StatefulPageKeyPart, StatefulStorageTree},
+	Config, Error,
+};
+use common_primitives::schema::{ModelType, PayloadLocation};
 use frame_support::{assert_err, assert_ok};
 
 #[test]
@@ -46,4 +50,70 @@ fn upsert_page_too_large_errors() {
 			Error::<Test>::PageExceedsMaxPageSizeBytes
 		)
 	})
+}
+
+use codec::{Decode, Encode, MaxEncodedLen};
+use scale_info::TypeInfo;
+#[derive(Clone, Encode, Decode, PartialEq, Debug, TypeInfo, MaxEncodedLen)]
+/// A structure defining a Schema
+struct TestStruct {
+	pub model_type: ModelType,
+	pub payload_location: PayloadLocation,
+	pub number: u64,
+}
+
+#[test]
+fn child_tree_write_read() {
+	new_test_ext().execute_with(|| {
+		// arrange
+		let msa_id = 1;
+		let k1: StatefulPageKeyPart = 1u16.to_be_bytes().to_vec();
+		let keys = &[k1];
+		let val = TestStruct {
+			model_type: ModelType::AvroBinary,
+			payload_location: PayloadLocation::OnChain,
+			number: 8276387272,
+		};
+
+		// act
+		StatefulStorageTree::write(&msa_id, keys, &val);
+
+		// assert
+		let read = StatefulStorageTree::read::<TestStruct>(&msa_id, keys);
+		assert_eq!(Some(val), read);
+	});
+}
+
+#[test]
+fn child_tree_iterator() {
+	new_test_ext().execute_with(|| {
+		// arrange
+		let msa_id = 1;
+		let mut arr: Vec<(Vec<u8>, TestStruct)> = Vec::new();
+		for i in 1..=10 {
+			let k = [b"key", &i.encode()[..]].concat();
+			arr.push((
+				k,
+				TestStruct {
+					model_type: ModelType::AvroBinary,
+					payload_location: PayloadLocation::OnChain,
+					number: i,
+				},
+			));
+		}
+		for (k, t) in arr.as_slice() {
+			let keys = &[k.to_owned()];
+			StatefulStorageTree::write(&msa_id, keys, t);
+		}
+
+		// act
+		let mut v = Vec::new();
+		let nodes = StatefulStorageTree::prefix_iterator::<TestStruct>(&msa_id, &[]);
+		for n in nodes {
+			v.push(n);
+		}
+
+		// assert
+		assert_eq!(v, arr);
+	});
 }

--- a/pallets/stateful-storage/src/tests.rs
+++ b/pallets/stateful-storage/src/tests.rs
@@ -1,9 +1,9 @@
 use super::mock::*;
 use crate::{
-	stateful_child_tree::{StatefulPageKeyPart, StatefulStorageTree},
+	stateful_child_tree::{StatefulChildTree, StatefulPageKeyPart},
 	Config, Error,
 };
-use common_primitives::schema::{ModelType, PayloadLocation};
+use common_primitives::schema::{ModelType, PayloadLocation, SchemaId};
 use frame_support::{assert_err, assert_ok};
 
 #[test]
@@ -67,8 +67,11 @@ fn child_tree_write_read() {
 	new_test_ext().execute_with(|| {
 		// arrange
 		let msa_id = 1;
-		let k1: StatefulPageKeyPart = 1u16.to_be_bytes().to_vec();
-		let keys = &[k1];
+		let schema_id: SchemaId = 2;
+		let page_id: u8 = 3;
+		let k1: StatefulPageKeyPart = schema_id.to_be_bytes().to_vec();
+		let k2: StatefulPageKeyPart = page_id.to_be_bytes().to_vec();
+		let keys = &[k1, k2];
 		let val = TestStruct {
 			model_type: ModelType::AvroBinary,
 			payload_location: PayloadLocation::OnChain,
@@ -76,10 +79,10 @@ fn child_tree_write_read() {
 		};
 
 		// act
-		StatefulStorageTree::write(&msa_id, keys, &val);
+		StatefulChildTree::write(&msa_id, keys, &val);
 
 		// assert
-		let read = StatefulStorageTree::read::<TestStruct>(&msa_id, keys);
+		let read = StatefulChildTree::read::<TestStruct>(&msa_id, keys);
 		assert_eq!(Some(val), read);
 	});
 }
@@ -103,12 +106,12 @@ fn child_tree_iterator() {
 		}
 		for (k, t) in arr.as_slice() {
 			let keys = &[k.to_owned()];
-			StatefulStorageTree::write(&msa_id, keys, t);
+			StatefulChildTree::write(&msa_id, keys, t);
 		}
 
 		// act
 		let mut v = Vec::new();
-		let nodes = StatefulStorageTree::prefix_iterator::<TestStruct>(&msa_id, &[]);
+		let nodes = StatefulChildTree::prefix_iterator::<TestStruct>(&msa_id, &[]);
 		for n in nodes {
 			v.push(n);
 		}


### PR DESCRIPTION
# Goal
The goal of this PR is to create a first iteration of the child tree for storing Stateful Storage pages.
Based on https://github.com/LibertyDSNP/frequency/compare/child_tree_simple_utility?expand=1

Closes #926 

# Discussion
<!-- List discussion items -->

# Checklist
- [ ] Chain spec updated
- [ ] Custom RPC OR Runtime API added/changed? Updated js/api-augment.
- [ ] Design doc(s) updated
- [x] Tests added
- [ ] Benchmarks added
- [ ] Weights updated
