### PR TITLE
fix broken ci release job

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -238,23 +238,19 @@ jobs:
   build-js-api-augment:
     needs: build-binaries
     name: Build JS API Augment
-    strategy:
-      matrix:
-        os: [ubuntu-20.04]
-        network: [mainnet]
-        include:
-          - network: local
-            spec: frequency-rococo-local
-            build-profile: release
-            release-file-name-prefix: frequency-local
-          - os: ubuntu-20.04
-            arch: amd64
-    runs-on: ${{matrix.os}}
+    env:
+      NETWORK: local
+      CHAIN_SPEC: frequency-rococo-local
+      BUILD_PROFILE: release
+      BIN_DIR: target/release
+      RELEASE_FILENAME_PREFIX: frequency-local
+      ARCH: amd64
+    runs-on: ubuntu-20.04
     steps:
       - name: Set Env Vars
         run: |
-          echo "BIN_DIR=target/${{matrix.build-profile}}" >> $GITHUB_ENV
-          echo "RELEASE_BIN_FILENAME=${{matrix.release-file-name-prefix}}.${{matrix.arch}}" >> $GITHUB_ENV
+          echo "BIN_DIR=target/${{env.BUILD_PROFILE}}" >> $GITHUB_ENV
+          echo "RELEASE_BIN_FILENAME=${{env.RELEASE_FILENAME_PREFIX}}.${{env.ARCH}}" >> $GITHUB_ENV
       - name: Check Out Repo
         uses: actions/checkout@v3
       - name: Set up NodeJs
@@ -279,7 +275,9 @@ jobs:
           mv ${{env.RELEASE_BIN_FILENAME}} ${{env.BIN_DIR}}
           chmod 755 ${{env.BIN_DIR}}/${{env.RELEASE_BIN_FILENAME}}
       - name: Output Metadata
-        run: ${{env.BIN_DIR}}/${{env.RELEASE_BIN_FILENAME}} export-metadata --chain=frequency-local --tmp ./js/api-augment/metadata.json
+        # TODO: Enable this in 1.2.0+ release instead
+        # run: ${{env.BIN_DIR}}/${{env.RELEASE_BIN_FILENAME}} export-metadata --chain=frequency-local --tmp ./js/api-augment/metadata.json
+        run: ${{env.BIN_DIR}}/${{env.RELEASE_BIN_FILENAME}} export-metadata --chain=frequency-local ./js/api-augment/metadata.json
       - name: Build
         run: npm run build
         working-directory: js/api-augment
@@ -586,7 +584,9 @@ jobs:
           name: "[Release Candidate] ${{env.NEW_RELEASE_TAG}}"
           prerelease: true
           body_path: tools/ci/release-notes/release-notes.md
-          files: /tmp/frequency*.*
+          files: |
+            /tmp/frequency*.*
+            /tmp/metadata-compare-*
       - name: Publish Full Release on GitHub
         if: env.IS_FULL_RELEASE == 'true'
         uses: softprops/action-gh-release@de2c0eb89ae2a093876385947365aca7b0e5f844


### PR DESCRIPTION
# Goal
The goal of this PR is to fix broken `build-js-api-augment` job in the release workflow due to misconfiguration.

Closes #1030
