### PR TITLE
Small cleanups

### DIFF
--- a/.github/workflows/verify-pr-commit.yml
+++ b/.github/workflows/verify-pr-commit.yml
@@ -211,7 +211,7 @@ jobs:
       - name: Lint
         run: |
           SKIP_WASM_BUILD=1 env -u RUSTFLAGS cargo clippy \
-            --features all-frequency-features,std \
+            --features runtime-benchmarks,all-frequency-features \
             -- \
             -D warnings
 
@@ -262,7 +262,7 @@ jobs:
           profile: minimal
           toolchain: stable
       - name: Check
-        run: SKIP_WASM_BUILD= cargo check --features runtime-benchmarks,all-frequency-features,std
+        run: SKIP_WASM_BUILD= cargo check --features runtime-benchmarks,all-frequency-features
 
   run-rust-tests:
     needs: changes
@@ -287,7 +287,7 @@ jobs:
           target: wasm32-unknown-unknown
           toolchain: stable
       - name: Run Tests
-        run: cargo test --features runtime-benchmarks,all-frequency-features,std --workspace --release
+        run: cargo test --features runtime-benchmarks,all-frequency-features --workspace --release
 
   calc-code-coverage:
     needs: changes

--- a/Makefile
+++ b/Makefile
@@ -158,7 +158,7 @@ ifeq (,$(POLKADOT_VERSION))
 endif
 	@echo "Setting the crate versions to "$(v)+polkadot$(POLKADOT_VERSION)
 	find ./ -type f -name 'Cargo.toml' -exec sed -i '' 's/^version = \"0\.0\.0\"/version = \"$(v)+polkadot$(POLKADOT_VERSION)\"/g' {} \;
-	cargo check
+	$(MAKE) check
 	@echo "All done. Don't forget to double check that the automated replacement worked."
 
 .PHONY: version-polkadot

--- a/Makefile
+++ b/Makefile
@@ -65,6 +65,9 @@ lint-audit:
 .PHONY: format-lint
 format-lint: format lint
 
+.PHONY: ci-local
+ci-local: check lint lint-audit test integration-test
+
 .PHONY: upgrade
 upgrade-local:
 	./scripts/init.sh upgrade-frequency

--- a/Makefile
+++ b/Makefile
@@ -120,7 +120,7 @@ build-benchmarks:
 	cargo build --profile production --features runtime-benchmarks --features all-frequency-features --workspace
 
 build-local:
-	cargo build --locked --release --features  frequency-rococo-local
+	cargo build --locked --features  frequency-rococo-local
 
 build-rococo:
 	cargo build --locked --release --features  frequency-rococo-testnet

--- a/README.md
+++ b/README.md
@@ -139,30 +139,36 @@ There are 2 options to run the chain locally:
 
 _Note, Running frequency via following options does not require binary to be built or chain specs to be generated separately, and is programmed within the scripts for simplicity._
 
-1.  Collator Node in Instant Sealing Mode,
+1.  Collator Node in Instant/Manual Sealing Mode,
 2.  Collator Node with Local Relay Chain
 
-## 1. Collator Node in Instant Sealing Mode
+## 1. Collator Node in Instant/Manual Sealing Mode
 
 ![](docs/images/local-dev-env-option-1.jpg)
 
-This option runs just one collator node in instant seal mode and nothing more.
-A "collator node" is a Frequency parachain node that is actively collating (aka forming blocks to submit to the relay chain). The instant seal mode allows a blockchain node to author a block
-as soon as it goes into a queue. This is also a great option to run with an example client.
+This option runs just one collator node without the need for a relay chain.
 
-### In Terminal
+Blocks can be triggered by calling the `engine_createBlock` RPC
+
+```sh
+curl http://localhost:9933 -H "Content-Type:application/json;charset=utf-8" -d   '{ \
+    "jsonrpc":"2.0", \
+    "id":1, \
+    "method":"engine_createBlock", \
+    "params": [true, true] \
+    }'
+```
+
+### Terminal: Instant Sealing
+
+Same as Manual Sealing, but will also automatically trigger the formation of a block whenever a transaction is added to the validated transaction pool.
+Great for most testing.
 
 ```sh
 make start
 ```
 
-If you want to run Frequency in manual seal mode, run
-
-```sh
-make start-manual
-```
-
-### In Docker Container
+Also available as a Docker image: [`frequencychain/instant-seal-node`](https://hub.docker.com/r/frequencychain/instant-seal-node)
 
 ```sh
 docker run --rm -p 9944:9944 -p 9933:9933 -p 30333:30333 frequencychain/instant-seal-node
@@ -173,6 +179,15 @@ To stop running chain hit [Ctrl+C] in terminal where the chain was started.
 | **Node**                |             **Ports**             | **Explorer URL**                                                                          |
 | ----------------------- | :-------------------------------: | ----------------------------------------------------------------------------------------- |
 | Frequency Collator Node | ws:`9944`, rpc`:9933`, p2p:`3033` | [127.0.0.1:9944](https://polkadot.js.org/apps/?rpc=ws%3A%2F%2F127.0.0.1%3A9944#/explorer) |
+
+### Terminal: Manual Sealing
+
+Will only form a block when the `engine_createBlock` RPC is called.
+Great for testing multiple items in the same block or other block formation tests.
+
+```sh
+make start-manual
+```
 
 ## 2. Collator Node with Local Relay Chain
 

--- a/runtime/common/Cargo.toml
+++ b/runtime/common/Cargo.toml
@@ -15,7 +15,7 @@ targets = ["x86_64-unknown-linux-gnu"]
 substrate-wasm-builder = { git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.36" }
 
 [dependencies]
-# Unfinished
+# Frequency
 codec = { package = "parity-scale-codec", version = "3.1.5", default-features = false, features = [
 	"derive",
 ] }

--- a/runtime/frequency/Cargo.toml
+++ b/runtime/frequency/Cargo.toml
@@ -62,7 +62,7 @@ sp-version = { git = "https://github.com/paritytech/substrate", default-features
 #ORML
 orml-benchmarking = { git = "https://github.com/open-web3-stack/open-runtime-module-library", default-features = false, optional = true, branch = "polkadot-v0.9.36" }
 orml-vesting = { git = "https://github.com/open-web3-stack/open-runtime-module-library", default-features = false, branch = "polkadot-v0.9.36" }
-# Unfinished
+# Frequency
 common-primitives = { default-features = false, path = "../../common/primitives" }
 common-runtime = { path = '../common', default-features = false }
 pallet-messages = { path = "../../pallets/messages", default-features = false }

--- a/scripts/init.sh
+++ b/scripts/init.sh
@@ -183,7 +183,7 @@ onboard-frequency)
       ./target/release/frequency export-genesis-wasm --chain="frequency-local" > $wasm_location
     fi
 
-  echo "WASM path:" "${parachain}-${para_id}.wasm"
+  echo "WASM path:" "${wasm_location}"
 
   cd scripts/js/onboard
   yarn && yarn onboard "ws://0.0.0.0:9946" "//Alice" ${para_id} "${genesis}" $wasm_location
@@ -201,14 +201,13 @@ upgrade-frequency)
   root_dir=$(git rev-parse --show-toplevel)
   echo "root_dir is set to $root_dir"
 
+  # Due to defaults and profile=release, the target directory will be $root_dir/target/release
   cargo build \
     --locked \
     --profile release \
     --package frequency-runtime \
     --features frequency-rococo-local \
-    --target-dir $root_dir/target/release \
     -Z unstable-options
-
 
   wasm_location=$root_dir/target/release/wbuild/frequency-runtime/frequency_runtime.compact.compressed.wasm
 

--- a/scripts/runtime-upgrade.sh
+++ b/scripts/runtime-upgrade.sh
@@ -10,7 +10,7 @@ fi
 
 
 echo "🏭 installing subwasm..."
-cargo install --locked --git https://github.com/chevdor/subwasm --tag v0.16.1
+cargo install --locked --git https://github.com/chevdor/subwasm
 
 sudo_secret=$1
 ws_provider=$2
@@ -18,6 +18,6 @@ wasm_location=$3
 
 hash=$(subwasm info --json $wasm_location | jq -r .blake2_256)
 
-cd scripts/js/onboard 
+cd scripts/js/onboard
 
-yarn && yarn upgrade-auth $ws_provider $sudo_secret $hash 
+yarn && yarn upgrade-auth $ws_provider $sudo_secret $hash


### PR DESCRIPTION
# Goal
The goal of this PR is fix a pile of small things that I found while working on other issues

*NO Rust code changes*

# Discussion
-  Fix upgrade script issues
-  Update inline docs
-  Fix it so that make version always uses the correct make check command 
-  slight fixes for the verify-pr features 
-  New make command that runs almost everything that ci does, but local versions
-  Clean up Readme some 
-  Remove the "release" profile from build-local so that it matches the normal `cargo build --features ...`