### PR TITLE
remove reset runner condition from verify pr workflow

### DIFF
--- a/.github/workflows/verify-pr-commit.yml
+++ b/.github/workflows/verify-pr-commit.yml
@@ -109,8 +109,6 @@ jobs:
         with:
           ref: ${{matrix.git_branch}}
       - name: Reset Runner
-        # XXX Remove condition when reset-self-hosted-runner action is available on main
-        if: matrix.branch_alias == 'pr'
         uses: ./.github/workflows/common/reset-self-hosted-runner
       - name: Set Env Vars
         run: |


### PR DESCRIPTION
# Goal
The goal of this PR is to remove temporary reset runner condition from verify pr workflow. This is a follow-up PR to the previously merged #1003 
