### PR TITLE
create new GH issue for new polkadot release

### DIFF
--- a/.github/issues/new-polkadot-release-template.md
+++ b/.github/issues/new-polkadot-release-template.md
@@ -1,0 +1,24 @@
+---
+title: Upgrade to Polkadot Release {{env.NEW_POLKADOT_RELEASE_VERSION}}
+labels: change/major
+---
+
+The Parity team has published new version of Polkadot: `{{env.NEW_POLKADOT_RELEASE_VERSION}}`
+
+See {{env.RELEASE_PAGE_PREFIX_URL}}/{{env.NEW_POLKADOT_RELEASE_VERSION}}
+
+## Upgrade Priority
+
+See [Polkadot Release Page]({{env.RELEASE_PAGE_PREFIX_URL}}/{{env.NEW_POLKADOT_RELEASE_VERSION}})
+
+## Host Functions
+
+See [Polkadot Release Page]({{env.RELEASE_PAGE_PREFIX_URL}}/{{env.NEW_POLKADOT_RELEASE_VERSION}})
+
+## Database Migrations
+
+See [Polkadot Release Page]({{env.RELEASE_PAGE_PREFIX_URL}}/{{env.NEW_POLKADOT_RELEASE_VERSION}})
+
+## Runtime Migrations
+
+See [Polkadot Release Page]({{env.RELEASE_PAGE_PREFIX_URL}}/{{env.NEW_POLKADOT_RELEASE_VERSION}})

--- a/.github/workflows/check-polkadot-releases.yml
+++ b/.github/workflows/check-polkadot-releases.yml
@@ -1,4 +1,4 @@
-name: Track Polkadot Releases
+name: Check Polkadot Releases
 on:
   schedule:
     - cron: "0 0 * * *" # midnight (UTC)
@@ -11,7 +11,8 @@ jobs:
     steps:
       - name: Timestamp
         run: date
-      - uses: actions/checkout@v3
+      - name: Check Out Repo
+        uses: actions/checkout@v3
         with:
           ref: main
           token: ${{secrets.FREQUENCY_REPO_TRACK_POLKADOT_RELEASES}}
@@ -30,7 +31,6 @@ jobs:
       - name: Check for Modified Files
         id: git-check
         run: |
-          set -x
           modified=$([ -z "`git status --porcelain`" ] && echo "false" || echo "true")
           echo "repo_modified=$modified" >> $GITHUB_OUTPUT
       - name: Commit Latest Release Version

--- a/.github/workflows/create-polkadot-release-upgrade-issue.yml
+++ b/.github/workflows/create-polkadot-release-upgrade-issue.yml
@@ -1,0 +1,26 @@
+name: Create Upgrade Issue for New Polkadot Release
+on:
+  push:
+    branches:
+      - main
+    paths:
+      - .github/workflows/.polkadot-latest-full-release.txt
+env:
+  RELEASE_PAGE_PREFIX_URL: https://github.com/paritytech/polkadot/releases/tag
+  RELEASE_TRACK_FILENAME: .github/workflows/.polkadot-latest-full-release.txt
+jobs:
+  create-issue:
+    runs-on: ubuntu-20.04
+    steps:
+      - name: Check Out Repo
+        uses: actions/checkout@v3
+      - name: Set Env Vars
+        run: |
+          release_version=$(cat ${{env.RELEASE_TRACK_FILENAME}})
+          echo "NEW_POLKADOT_RELEASE_VERSION=$release_version" >> $GITHUB_ENV
+      - name: Create GitHub Issue
+        uses: JasonEtco/create-an-issue@e27dddc79c92bc6e4562f268fffa5ed752639abd
+        env:
+          GITHUB_TOKEN: ${{secrets.GITHUB_TOKEN}}
+        with:
+          filename: .github/issues/new-polkadot-release-template.md


### PR DESCRIPTION
# Goal
The goal of this PR is to create a new GitHub issue each time the Polkadot release tracking file gets updated.

Here is an example of the issue that was automatically created: https://github.com/LibertyDSNP/frequency/issues/1055

Closes #930