### PR TITLE
930 test cron schedule

### DIFF
--- a/.github/workflows/track-polkadot-releases.yml
+++ b/.github/workflows/track-polkadot-releases.yml
@@ -1,7 +1,7 @@
 name: Track Polkadot Releases
 on:
   schedule:
-    - cron: "0 18 * * *" # midnight
+    - cron: "0 0 * * *" # midnight (UTC)
 env:
   REPO_URL: https://api.github.com/repos/paritytech/polkadot
   RELEASE_TRACK_FILENAME: .github/workflows/.polkadot-latest-full-release.txt
@@ -9,6 +9,8 @@ jobs:
   record-polkadot-latest-release-version:
     runs-on: ubuntu-20.04
     steps:
+      - name: Timestamp
+        run: date
       - uses: actions/checkout@v3
         with:
           ref: main


### PR DESCRIPTION
# Goal
The goal of this PR is to reset Polkadot releases check cron schedule back to UTC midnight.

Part of #930