### PR TITLE
Zero-out staking account if unstake to below minimum

### DIFF
--- a/common/primitives/src/capacity.rs
+++ b/common/primitives/src/capacity.rs
@@ -17,7 +17,7 @@ pub trait Nontransferable {
 	fn balance(msa_id: MessageSourceId) -> Self::Balance;
 
 	/// Reduce Capacity of an MSA account by amount.
-	fn deduct(msa_id: MessageSourceId, amount: Self::Balance) -> Result<(), DispatchError>;
+	fn withdraw(msa_id: MessageSourceId, amount: Self::Balance) -> Result<(), DispatchError>;
 
 	/// Increase Capacity of an MSA account by an amount.
 	fn deposit(msa_id: MessageSourceId, amount: Self::Balance) -> Result<(), DispatchError>;

--- a/pallets/capacity/src/benchmarking.rs
+++ b/pallets/capacity/src/benchmarking.rs
@@ -58,7 +58,7 @@ benchmarks! {
 		let amount: BalanceOf<T> = T::MinimumStakingAmount::get();
 
 		let mut staking_account = StakingAccountDetails::<T>::default();
-		staking_account.increase_by(500u32.into());
+		staking_account.deposit(500u32.into());
 
 		// set new unlock chunks using tuples of (value, thaw_at)
 		let new_unlocks: Vec<(u32, u32)> = Vec::from([(50u32, 3u32), (50u32, 5u32)]);
@@ -95,9 +95,9 @@ benchmarks! {
 		let mut target_details = StakingTargetDetails::<BalanceOf<T>>::default();
 		let mut capacity_details = CapacityDetails::<BalanceOf<T>, <T as Config>::EpochNumber>::default();
 
-		staking_account.increase_by(staking_amount);
-		target_details.increase_by(staking_amount, capacity_amount);
-		capacity_details.increase_by(capacity_amount, block_number.into());
+		staking_account.deposit(staking_amount);
+		target_details.deposit(staking_amount, capacity_amount);
+		capacity_details.deposit(capacity_amount, block_number.into());
 
 		Capacity::<T>::set_staking_account(&caller.clone(), &staking_account);
 		Capacity::<T>::set_target_details_for(&caller.clone(), target, target_details);

--- a/pallets/capacity/src/extrinsics_tests.rs
+++ b/pallets/capacity/src/extrinsics_tests.rs
@@ -393,7 +393,7 @@ fn unstake_happy_path() {
 		let token_account = 200;
 		let target: MessageSourceId = 1;
 		let staking_amount = 10;
-		let unstaking_amount = 5;
+		let unstaking_amount = 4;
 
 		register_provider(target, String::from("Test Target"));
 
@@ -411,15 +411,16 @@ fn unstake_happy_path() {
 		let expected_unlocking_chunks: BoundedVec<
 			UnlockChunk<BalanceOf<Test>, <Test as Config>::EpochNumber>,
 			<Test as Config>::MaxUnlockingChunks,
-		> = BoundedVec::try_from(vec![UnlockChunk { value: 5u64, thaw_at: 2u32 }]).unwrap();
+		> = BoundedVec::try_from(vec![UnlockChunk { value: unstaking_amount, thaw_at: 2u32 }])
+			.unwrap();
 
 		assert_eq!(
-			staking_account_details,
 			StakingAccountDetails::<Test> {
-				active: BalanceOf::<Test>::from(5u64),
-				total: BalanceOf::<Test>::from(10u64),
+				active: BalanceOf::<Test>::from(6u64),
+				total: BalanceOf::<Test>::from(staking_amount),
 				unlocking: expected_unlocking_chunks,
-			}
+			},
+			staking_account_details,
 		);
 
 		// Assert that staking target detail values are decremented correctly after unstaking
@@ -428,8 +429,8 @@ fn unstake_happy_path() {
 		assert_eq!(
 			staking_target_details,
 			StakingTargetDetails::<BalanceOf<Test>> {
-				amount: BalanceOf::<Test>::from(5u64),
-				capacity: BalanceOf::<Test>::from(5u64),
+				amount: BalanceOf::<Test>::from(6u64),
+				capacity: BalanceOf::<Test>::from(6u64),
 			}
 		);
 
@@ -440,8 +441,8 @@ fn unstake_happy_path() {
 			capacity_details,
 			CapacityDetails::<BalanceOf<Test>, <Test as Config>::EpochNumber> {
 				remaining: BalanceOf::<Test>::from(10u64),
-				total_tokens_staked: BalanceOf::<Test>::from(5u64),
-				total_available: BalanceOf::<Test>::from(5u64),
+				total_tokens_staked: BalanceOf::<Test>::from(6u64),
+				total_available: BalanceOf::<Test>::from(6u64),
 				last_replenished_epoch: <Test as Config>::EpochNumber::from(0u32),
 			}
 		);
@@ -453,7 +454,7 @@ fn unstake_happy_path() {
 				account: token_account,
 				target,
 				amount: unstaking_amount,
-				capacity: BalanceOf::<Test>::from(5u64)
+				capacity: BalanceOf::<Test>::from(4u64)
 			}
 		);
 	});

--- a/pallets/capacity/src/extrinsics_tests.rs
+++ b/pallets/capacity/src/extrinsics_tests.rs
@@ -17,7 +17,7 @@ fn withdraw_unstaked_happy_path() {
 		let mut staking_account = StakingAccountDetails::<Test>::default();
 
 		// we have 10 total staked, and 6 of those are unstaking.
-		staking_account.increase_by(10);
+		staking_account.deposit(10);
 		assert_eq!(true, staking_account.set_unlock_chunks(&unlocks));
 		assert_eq!(10u64, staking_account.total);
 		Capacity::set_staking_account(&staker, &staking_account.into());
@@ -46,7 +46,7 @@ fn withdraw_unstaked_correctly_sets_new_lock_state() {
 	new_test_ext().execute_with(|| {
 		let staker = 500;
 		let mut staking_account = StakingAccountDetails::<Test>::default();
-		staking_account.increase_by(10);
+		staking_account.deposit(10);
 
 		// set new unlock chunks using tuples of (value, thaw_at)
 		let new_unlocks: Vec<(u32, u32)> = vec![(1u32, 2u32), (2u32, 3u32), (3u32, 4u32)];
@@ -72,7 +72,7 @@ fn withdraw_unstaked_cleans_up_storage_and_removes_all_locks_if_no_stake_left() 
 	new_test_ext().execute_with(|| {
 		let mut staking_account = StakingAccountDetails::<Test>::default();
 		let staking_amount: BalanceOf<Test> = 10;
-		staking_account.increase_by(staking_amount);
+		staking_account.deposit(staking_amount);
 
 		// set new unlock chunks using tuples of (value, thaw_at)
 		let new_unlocks: Vec<(u32, u32)> = vec![(10u32, 2u32)];
@@ -96,7 +96,7 @@ fn withdraw_unstaked_cannot_withdraw_if_no_unstaking_chunks() {
 	new_test_ext().execute_with(|| {
 		let staker = 500;
 		let mut staking_account = StakingAccountDetails::<Test>::default();
-		staking_account.increase_by(10);
+		staking_account.deposit(10);
 		Capacity::set_staking_account(&staker, &staking_account);
 		assert_noop!(
 			Capacity::withdraw_unstaked(RuntimeOrigin::signed(500)),
@@ -109,7 +109,7 @@ fn withdraw_unstaked_cannot_withdraw_if_unstaking_chunks_not_thawed() {
 	new_test_ext().execute_with(|| {
 		let staker = 500;
 		let mut staking_account = StakingAccountDetails::<Test>::default();
-		staking_account.increase_by(10);
+		staking_account.deposit(10);
 
 		// set new unlock chunks using tuples of (value, thaw_at)
 		let new_unlocks: Vec<(u32, u32)> = vec![(1u32, 3u32), (2u32, 40u32), (3u32, 9u32)];

--- a/pallets/capacity/src/helpers_tests.rs
+++ b/pallets/capacity/src/helpers_tests.rs
@@ -185,7 +185,7 @@ fn set_staking_account_is_succesful() {
 	new_test_ext().execute_with(|| {
 		let staker = 100;
 		let mut staking_account = StakingAccountDetails::<Test>::default();
-		staking_account.increase_by(55);
+		staking_account.deposit(55);
 
 		Capacity::set_staking_account(&staker, &staking_account);
 

--- a/pallets/capacity/src/helpers_tests.rs
+++ b/pallets/capacity/src/helpers_tests.rs
@@ -263,7 +263,7 @@ fn calculate_capacity_reduction_determines_the_correct_capacity_reduction_amount
 		total_capacity,
 	);
 
-	assert_eq!(capacity_reduction, 180);
+	assert_eq!(capacity_reduction, 20);
 }
 
 #[test]

--- a/pallets/capacity/src/helpers_tests.rs
+++ b/pallets/capacity/src/helpers_tests.rs
@@ -293,7 +293,7 @@ fn impl_balance_returns_zero_when_target_capacity_is_not_found() {
 }
 
 #[test]
-fn impl_deduct_is_successful() {
+fn impl_withdraw_is_successful() {
 	new_test_ext().execute_with(|| {
 		let target_msa_id = 1;
 		let remaining_amount = BalanceOf::<Test>::from(10u32);
@@ -305,7 +305,7 @@ fn impl_deduct_is_successful() {
 			1u32,
 		);
 
-		assert_ok!(Capacity::deduct(target_msa_id, 5u32.into()));
+		assert_ok!(Capacity::withdraw(target_msa_id, 5u32.into()));
 
 		let mut capacity_details =
 			CapacityDetails::<BalanceOf<Test>, <Test as Config>::EpochNumber>::default();
@@ -320,19 +320,19 @@ fn impl_deduct_is_successful() {
 }
 
 #[test]
-fn impl_deduct_errors_target_capacity_not_found() {
+fn impl_withdraw_errors_target_capacity_not_found() {
 	new_test_ext().execute_with(|| {
 		let target_msa_id = 1;
 		let amount = BalanceOf::<Test>::from(10u32);
 		assert_noop!(
-			Capacity::deduct(target_msa_id, amount),
+			Capacity::withdraw(target_msa_id, amount),
 			Error::<Test>::TargetCapacityNotFound
 		);
 	});
 }
 
 #[test]
-fn impl_deduct_errors_insufficient_balance() {
+fn impl_withdraw_errors_insufficient_balance() {
 	new_test_ext().execute_with(|| {
 		let target_msa_id = 1;
 		let remaining_amount = BalanceOf::<Test>::from(10u32);
@@ -345,7 +345,7 @@ fn impl_deduct_errors_insufficient_balance() {
 		);
 
 		assert_noop!(
-			Capacity::deduct(target_msa_id, 20u32.into()),
+			Capacity::withdraw(target_msa_id, 20u32.into()),
 			Error::<Test>::InsufficientBalance
 		);
 

--- a/pallets/capacity/src/lib.rs
+++ b/pallets/capacity/src/lib.rs
@@ -524,7 +524,7 @@ impl<T: Config> Pallet<T> {
 		let thaw_at =
 			current_epoch.saturating_add(T::EpochNumber::from(T::UnstakingThawPeriod::get()));
 
-		let unstake_result = staking_account.deduct(amount, thaw_at)?;
+		let unstake_result = staking_account.withdraw(amount, thaw_at)?;
 
 		Self::set_staking_account(&unstaker, &staking_account);
 
@@ -546,8 +546,8 @@ impl<T: Config> Pallet<T> {
 			capacity_details.total_tokens_staked,
 			capacity_details.total_available,
 		);
-		staking_target_details.deduct(amount, capacity_reduction);
-		capacity_details.deduct(capacity_reduction, amount);
+		staking_target_details.withdraw(amount, capacity_reduction);
+		capacity_details.withdraw(capacity_reduction, amount);
 
 		Self::set_capacity_for(target, capacity_details);
 		Self::set_target_details_for(unstaker, target, staking_target_details);
@@ -591,7 +591,7 @@ impl<T: Config> Nontransferable for Pallet<T> {
 		}
 	}
 
-	fn deduct(msa_id: MessageSourceId, amount: Self::Balance) -> Result<(), DispatchError> {
+	fn withdraw(msa_id: MessageSourceId, amount: Self::Balance) -> Result<(), DispatchError> {
 		let mut capacity_details =
 			Self::get_capacity_for(msa_id).ok_or(Error::<T>::TargetCapacityNotFound)?;
 

--- a/pallets/capacity/src/types.rs
+++ b/pallets/capacity/src/types.rs
@@ -92,8 +92,8 @@ impl<T: Config> StakingAccountDetails<T> {
 		total_reaped
 	}
 
-	/// Decrease the amount of active stake by an amount and createa an UnlockChunk.
-	pub fn deduct(
+	/// Decrease the amount of active stake by an amount and create an UnlockChunk.
+	pub fn withdraw(
 		&mut self,
 		amount: BalanceOf<T>,
 		thaw_at: T::EpochNumber,
@@ -148,7 +148,7 @@ impl<Balance: Saturating + Copy + CheckedAdd> StakingTargetDetails<Balance> {
 	}
 
 	/// Decrease an MSA target Staking total and Capacity amount.
-	pub fn deduct(&mut self, amount: Balance, capacity: Balance) {
+	pub fn withdraw(&mut self, amount: Balance, capacity: Balance) {
 		self.amount = self.amount.saturating_sub(amount);
 		self.capacity = self.capacity.saturating_sub(capacity);
 	}
@@ -179,7 +179,7 @@ impl<Balance: Saturating + Copy + CheckedAdd, EpochNumber> CapacityDetails<Balan
 	}
 
 	/// Decrease a target's total available capacity.
-	pub fn deduct(&mut self, capacity_deduction: Balance, tokens_staked_deduction: Balance) {
+	pub fn withdraw(&mut self, capacity_deduction: Balance, tokens_staked_deduction: Balance) {
 		self.total_tokens_staked = self.total_tokens_staked.saturating_sub(tokens_staked_deduction);
 		self.total_available = self.total_available.saturating_sub(capacity_deduction);
 	}

--- a/pallets/capacity/src/types.rs
+++ b/pallets/capacity/src/types.rs
@@ -34,7 +34,7 @@ pub struct UnlockChunk<Balance, EpochNumber> {
 
 impl<T: Config> StakingAccountDetails<T> {
 	/// Increases total and active balances by an amount.
-	pub fn increase_by(&mut self, amount: BalanceOf<T>) -> Option<()> {
+	pub fn deposit(&mut self, amount: BalanceOf<T>) -> Option<()> {
 		self.total = amount.checked_add(&self.total)?;
 		self.active = amount.checked_add(&self.active)?;
 
@@ -93,7 +93,7 @@ impl<T: Config> StakingAccountDetails<T> {
 	}
 
 	/// Decrease the amount of active stake by an amount and createa an UnlockChunk.
-	pub fn decrease_by(
+	pub fn deduct(
 		&mut self,
 		amount: BalanceOf<T>,
 		thaw_at: T::EpochNumber,
@@ -140,7 +140,7 @@ pub struct StakingTargetDetails<Balance> {
 
 impl<Balance: Saturating + Copy + CheckedAdd> StakingTargetDetails<Balance> {
 	/// Increase an MSA target Staking total and Capacity amount.
-	pub fn increase_by(&mut self, amount: Balance, capacity: Balance) -> Option<()> {
+	pub fn deposit(&mut self, amount: Balance, capacity: Balance) -> Option<()> {
 		self.amount = amount.checked_add(&self.amount)?;
 		self.capacity = capacity.checked_add(&self.capacity)?;
 
@@ -148,7 +148,7 @@ impl<Balance: Saturating + Copy + CheckedAdd> StakingTargetDetails<Balance> {
 	}
 
 	/// Decrease an MSA target Staking total and Capacity amount.
-	pub fn decrease_by(&mut self, amount: Balance, capacity: Balance) {
+	pub fn deduct(&mut self, amount: Balance, capacity: Balance) {
 		self.amount = self.amount.saturating_sub(amount);
 		self.capacity = self.capacity.saturating_sub(capacity);
 	}
@@ -169,7 +169,7 @@ pub struct CapacityDetails<Balance, EpochNumber> {
 
 impl<Balance: Saturating + Copy + CheckedAdd, EpochNumber> CapacityDetails<Balance, EpochNumber> {
 	/// Increase a targets Capacity balance by an amount.
-	pub fn increase_by(&mut self, amount: Balance, replenish_at: EpochNumber) -> Option<()> {
+	pub fn deposit(&mut self, amount: Balance, replenish_at: EpochNumber) -> Option<()> {
 		self.remaining = amount.checked_add(&self.remaining)?;
 		self.total_tokens_staked = amount.checked_add(&self.total_tokens_staked)?;
 		self.total_available = amount.checked_add(&self.total_available)?;
@@ -179,9 +179,9 @@ impl<Balance: Saturating + Copy + CheckedAdd, EpochNumber> CapacityDetails<Balan
 	}
 
 	/// Decrease a target's total available capacity.
-	pub fn decrease_by(&mut self, amount: Balance, token_reduction_amount: Balance) {
-		self.total_tokens_staked = self.total_tokens_staked.saturating_sub(token_reduction_amount);
-		self.total_available = self.total_available.saturating_sub(amount);
+	pub fn deduct(&mut self, capacity_deduction: Balance, tokens_staked_deduction: Balance) {
+		self.total_tokens_staked = self.total_tokens_staked.saturating_sub(tokens_staked_deduction);
+		self.total_available = self.total_available.saturating_sub(capacity_deduction);
 	}
 }
 

--- a/pallets/capacity/src/types_tests.rs
+++ b/pallets/capacity/src/types_tests.rs
@@ -115,14 +115,14 @@ fn impl_staking_capacity_details_increase_by() {
 }
 
 #[test]
-fn staking_account_details_deduct_reduces_active_staking_balance_and_creates_unlock_chunk() {
+fn staking_account_details_withdraw_reduces_active_staking_balance_and_creates_unlock_chunk() {
 	new_test_ext().execute_with(|| {
 		let mut staking_account_details = StakingAccountDetails::<Test> {
 			active: BalanceOf::<Test>::from(10u64),
 			total: BalanceOf::<Test>::from(10u64),
 			unlocking: BoundedVec::default(),
 		};
-		assert_eq!(Ok(3u64), staking_account_details.deduct(3, 3));
+		assert_eq!(Ok(3u64), staking_account_details.withdraw(3, 3));
 		let expected_chunks: UnlockBVec<Test> =
 			BoundedVec::try_from(vec![UnlockChunk { value: 3u64, thaw_at: 3u32 }]).unwrap();
 
@@ -138,21 +138,21 @@ fn staking_account_details_deduct_reduces_active_staking_balance_and_creates_unl
 }
 
 #[test]
-fn staking_account_details_deduct_goes_to_zero_when_result_below_minimum() {
+fn staking_account_details_withdraw_goes_to_zero_when_result_below_minimum() {
 	new_test_ext().execute_with(|| {
 		let mut staking_account_details = StakingAccountDetails::<Test> {
 			active: BalanceOf::<Test>::from(10u64),
 			total: BalanceOf::<Test>::from(10u64),
 			unlocking: BoundedVec::default(),
 		};
-		assert_eq!(Ok(10u64), staking_account_details.deduct(6, 3));
+		assert_eq!(Ok(10u64), staking_account_details.withdraw(6, 3));
 		assert_eq!(0u64, staking_account_details.active);
 		assert_eq!(10u64, staking_account_details.total);
 	});
 }
 
 #[test]
-fn staking_account_details_deduct_returns_err_when_too_many_chunks() {
+fn staking_account_details_withdraw_returns_err_when_too_many_chunks() {
 	new_test_ext().execute_with(|| {
 		let maximum_chunks: UnlockBVec<Test> = BoundedVec::try_from(vec![
 			UnlockChunk { value: 1u64, thaw_at: 3u32 },
@@ -169,7 +169,7 @@ fn staking_account_details_deduct_returns_err_when_too_many_chunks() {
 		};
 
 		assert_noop!(
-			staking_account_details.deduct(6, 3),
+			staking_account_details.withdraw(6, 3),
 			Error::<Test>::MaxUnlockingChunksExceeded
 		);
 		assert_eq!(10u64, staking_account_details.active);
@@ -178,13 +178,13 @@ fn staking_account_details_deduct_returns_err_when_too_many_chunks() {
 }
 
 #[test]
-fn staking_target_details_deduct_reduces_staking_and_capacity_amounts() {
+fn staking_target_details_withdraw_reduces_staking_and_capacity_amounts() {
 	new_test_ext().execute_with(|| {
 		let mut staking_target_details = StakingTargetDetails::<BalanceOf<Test>> {
 			amount: BalanceOf::<Test>::from(15u64),
 			capacity: BalanceOf::<Test>::from(20u64),
 		};
-		staking_target_details.deduct(10, 10);
+		staking_target_details.withdraw(10, 10);
 
 		assert_eq!(
 			staking_target_details,
@@ -197,7 +197,7 @@ fn staking_target_details_deduct_reduces_staking_and_capacity_amounts() {
 }
 
 #[test]
-fn staking_capacity_details_deduct_reduces_total_tokens_staked_and_total_tokens_available() {
+fn staking_capacity_details_withdraw_reduces_total_tokens_staked_and_total_tokens_available() {
 	new_test_ext().execute_with(|| {
 		let mut capacity_details =
 			CapacityDetails::<BalanceOf<Test>, <Test as Config>::EpochNumber> {
@@ -206,7 +206,7 @@ fn staking_capacity_details_deduct_reduces_total_tokens_staked_and_total_tokens_
 				total_available: BalanceOf::<Test>::from(10u64),
 				last_replenished_epoch: <Test as Config>::EpochNumber::from(0u32),
 			};
-		capacity_details.deduct(4, 5);
+		capacity_details.withdraw(4, 5);
 
 		assert_eq!(
 			capacity_details,

--- a/pallets/capacity/src/types_tests.rs
+++ b/pallets/capacity/src/types_tests.rs
@@ -1,7 +1,7 @@
 use super::*;
 use crate as pallet_capacity;
 use crate::mock::*;
-use frame_support::BoundedVec;
+use frame_support::{assert_noop, BoundedVec};
 
 #[test]
 fn staking_account_details_reap_thawed_happy_path() {
@@ -118,28 +118,73 @@ fn staking_account_details_decrease_by_reduces_active_staking_balance_and_create
 			total: BalanceOf::<Test>::from(10u64),
 			unlocking: BoundedVec::default(),
 		};
-		staking_account_details.decrease_by(3, 3).expect("decrease_by failed");
-		let mut chunks: BoundedVec<
+		assert_eq!(Ok(7u64), staking_account_details.decrease_by(3, 3));
+		let mut expected_chunks: BoundedVec<
 			UnlockChunk<BalanceOf<Test>, <Test as Config>::EpochNumber>,
 			<Test as pallet_capacity::Config>::MaxUnlockingChunks,
 		> = BoundedVec::default();
 
-		chunks
+		expected_chunks
 			.try_push(UnlockChunk::<BalanceOf<Test>, <Test as Config>::EpochNumber> {
 				value: BalanceOf::<Test>::from(3u64),
 				thaw_at: <Test as Config>::EpochNumber::from(3u32),
 			})
-			.expect("try_push failed");
+			.expect("try_push shouldn't have failed");
 
 		assert_eq!(
 			staking_account_details,
 			StakingAccountDetails::<Test> {
 				active: BalanceOf::<Test>::from(7u64),
 				total: BalanceOf::<Test>::from(10u64),
-				unlocking: chunks,
+				unlocking: expected_chunks,
 			}
 		)
 	});
+}
+
+#[test]
+fn staking_account_details_decrease_by_goes_to_zero_when_result_below_minimum() {
+	new_test_ext().execute_with(|| {
+		let mut staking_account_details = StakingAccountDetails::<Test> {
+			active: BalanceOf::<Test>::from(10u64),
+			total: BalanceOf::<Test>::from(10u64),
+			unlocking: BoundedVec::default(),
+		};
+		assert_eq!(Ok(10u64), staking_account_details.decrease_by(6, 3));
+		assert_eq!(0u64, staking_account_details.active);
+		assert_eq!(0u64, staking_account_details.total);
+	});
+}
+
+#[test]
+fn staking_account_details_decrease_by_returns_none_when_too_many_chunks() {
+	new_test_ext().execute_with(|| {
+		let mut maximum_chunks: BoundedVec<
+			UnlockChunk<BalanceOf<Test>, <Test as Config>::EpochNumber>,
+			<Test as pallet_capacity::Config>::MaxUnlockingChunks,
+		> = BoundedVec::default();
+		for i in [1u64..5u64] {
+			maximum_chunks
+				.try_push(UnlockChunk::<BalanceOf<Test>, <Test as Config>::EpochNumber> {
+					value: BalanceOf::<Test>::from(1u64),
+					thaw_at: <Test as Config>::EpochNumber::from(3u32),
+				})
+				.expect("try_push shouldn't have failed");
+		}
+
+		let mut staking_account_details = StakingAccountDetails::<Test> {
+			active: BalanceOf::<Test>::from(10u64),
+			total: BalanceOf::<Test>::from(10u64),
+			unlocking: maximum_chunks,
+		};
+
+		assert_noop!(
+			staking_account_details.decrease_by(6, 3),
+			Error::<Test>::MaxUnlockingChunksExceeded
+		);
+		assert_eq!(10u64, staking_account_details.active);
+		assert_eq!(10u64, staking_account_details.total);
+	})
 }
 
 #[test]


### PR DESCRIPTION
# Goal
The goal of this PR is to implement clearing the staking account if the unstake amount would put the account below the configured minimum.

In the process had to fix a bug when updating capacity and staking target accounts.

Related to #171 

# Discussion
Because it's possible that the actual unstaked amount could be more than what was requested, `StakinAccountDetails::decrease_by` must now return a value of the actual amount that was unstaked in order to correctly adjust the target staking account and the capacity.  The needed updates revealed the bug in `calculate_capacity_reduction` where the return value was the remaining amount, not the deducted amount. Dependent tests were updated.

# Checklist
- [ ] Chain spec updated
- [x] Tests added

## Not applicable
- Custom RPC OR Runtime API added/changed? Updated js/api-augment.
- Design doc(s) updated
- Benchmarks added
- Weights updated
