### PR TITLE
Update the instant sealing docker to use the docker volume

### DIFF
--- a/docker/instant-seal-node.dockerfile
+++ b/docker/instant-seal-node.dockerfile
@@ -36,9 +36,6 @@ ENTRYPOINT ["/frequency/frequency", \
 	# Required params for starting the chain
 	"--dev", \
 	"-lruntime=debug", \
-	"--instant-sealing", \
-	"--wasm-execution=compiled", \
-	"--execution=wasm", \
 	"--no-telemetry", \
 	"--no-prometheus", \
 	"--port=30333", \
@@ -48,8 +45,8 @@ ENTRYPOINT ["/frequency/frequency", \
 	"--rpc-cors=all", \
 	"--ws-external", \
 	"--rpc-methods=Unsafe", \
-	"--tmp" \
+	"--base-path=/data" \
 	]
 
 # Params which can be overriden from CLI
-# CMD ["", "", ...]
+CMD ["--instant-sealing"]

--- a/docker/instant-seal-node.overview.md
+++ b/docker/instant-seal-node.overview.md
@@ -1,19 +1,57 @@
-# Frequency Collator Node in Instant Seal Mode
+# Frequency Collator Node in Local Only Sealing Mode
 
-Runs just one collator node in instant seal mode.
-A "collator node" is a Frequency parachain node that is actively collating (aka forming blocks to submit to the relay chain).
-The instant seal mode allows a blockchain node to author a block
-as soon as it goes into a queue.
-This is also a great option to run with an example client.
+Runs just one collator node that will not connect to any other nodes.
+Defaults to running in instant sealing mode where a block will be triggered when a transaction enters the validated transaction pool.
+A "collator node" is a Frequency parachain node that is actively collating (aka forming blocks to submit to the relay chain, although in this case without a relay chain).
 
-![](https://github.com/LibertyDSNP/frequency/blob/main/docs/images/local-dev-env-option-1.jpg?raw=true)
-
-## Run
+### Quick Run
 
 ```sh
 docker run --rm -p 9944:9944 -p 9933:9933 -p 30333:30333 frequencychain/instant-seal-node:<version.tag>
 ```
 
+
+## Trigger Block Manually
+
+If running in manual sealing mode or to form empty blocks in instant sealing mode, the `engine_createBlock` RPC can be used:
+
+```sh
+curl http://localhost:9933 -H "Content-Type:application/json;charset=utf-8" -d   '{ \
+    "jsonrpc":"2.0", \
+    "id":1, \
+    "method":"engine_createBlock", \
+    "params": [true, true] \
+    }'
+```
+
+
+## Default Arguments
+
+| Argument | Description |
+| --- | --- |
+| `--instant-sealing` | Manual sealing + automatically form a block each time a transaction enters the validated transaction pool |
+
+### Run
+
+Note: Docker `--rm` removes the volume when stopped.
+
+```sh
+docker run --rm -p 9944:9944 -p 9933:9933 -p 30333:30333 frequencychain/instant-seal-node:<version.tag>
+```
+
+## Overriding Arguments
+
+| Argument | Description |
+| --- | --- |
+| `--manual-sealing` | Only form a block when `engine_createBlock` RPC is called |
+| `--help` | See all the options possible |
+
+### Run
+
+```sh
+docker run --rm -p 9944:9944 -p 9933:9933 -p 30333:30333 frequencychain/instant-seal-node:<version.tag> -- --manual-seal
+```
+
 | **Node**                |             **Ports**             | **Explorer URL**                                                                          |
 | ----------------------- | :-------------------------------: | ----------------------------------------------------------------------------------------- |
-| Frequency Collator Node | ws:`9944`, rpc`:9933`, p2p:`3033` | [127.0.0.1:9944](https://polkadot.js.org/apps/?rpc=ws%3A%2F%2F127.0.0.1%3A9944#/explorer) |
+| Frequency Local-Only Node | ws:`9944`, rpc`:9933`, p2p:`3033` | [127.0.0.1:9944](https://polkadot.js.org/apps/?rpc=ws%3A%2F%2F127.0.0.1%3A9944#/explorer) |


### PR DESCRIPTION
# Goal
The goal of this PR is to update the instant sealing docker.

No breaking changes for most people:
- if you had it setup to use the volume, it will correctly start loading up the chain data from prior runs when it wouldn't before.

Closes #1107

# Discussion
- Better Docker documentation
- Allow instant-sealing or manual-sealing in the docker
- Use the docker volume