### PR TITLE
Deprecated revoke_schema_permissions()

### DIFF
--- a/pallets/msa/src/lib.rs
+++ b/pallets/msa/src/lib.rs
@@ -806,7 +806,7 @@ pub mod pallet {
 		schema_ids.len() as u32
 		))]
 		#[allow(deprecated)]
-		#[deprecated(since="1.3.0", note = "revoke_schema_permissions() has been deprecated.")]
+		#[deprecated(since = "1.3.0", note = "revoke_schema_permissions() has been deprecated.")]
 		pub fn revoke_schema_permissions(
 			origin: OriginFor<T>,
 			provider_msa_id: MessageSourceId,

--- a/pallets/msa/src/lib.rs
+++ b/pallets/msa/src/lib.rs
@@ -805,6 +805,8 @@ pub mod pallet {
 		#[pallet::weight(T::WeightInfo::revoke_schema_permissions(
 		schema_ids.len() as u32
 		))]
+		#[allow(deprecated)]
+		#[deprecated(since="1.3.0", note = "revoke_schema_permissions() has been deprecated.")]
 		pub fn revoke_schema_permissions(
 			origin: OriginFor<T>,
 			provider_msa_id: MessageSourceId,

--- a/runtime/frequency/src/lib.rs
+++ b/runtime/frequency/src/lib.rs
@@ -422,7 +422,7 @@ pub const VERSION: RuntimeVersion = RuntimeVersion {
 	spec_name: spec_name!("frequency"),
 	impl_name: create_runtime_str!("frequency"),
 	authoring_version: 1,
-	spec_version: 16,
+	spec_version: 17,
 	impl_version: 0,
 	apis: RUNTIME_API_VERSIONS,
 	transaction_version: 1,


### PR DESCRIPTION
# Goal
The goal of this PR is to deprecate the extrinsic `revoke_schema_permissions()` on the MSA pallet.

Closes #875 
