### PR TITLE
fix docker not found error in reset action

### DIFF
--- a/.github/workflows/common/reset-self-hosted-runner/action.yml
+++ b/.github/workflows/common/reset-self-hosted-runner/action.yml
@@ -16,5 +16,12 @@ runs:
     - name: Prune docker Resources
       shell: bash
       run: |
-        docker system prune -a --volumes
-        docker image prune -a -f --filter "until=720h"
+        if [ "$(which docker)" ] && [ "$(docker --version)" ]; then
+          echo "Docker is found. Cleaning..."
+          docker system prune -a --volumes
+          docker image prune -a -f --filter "until=720h"
+          echo "Finished cleaning docker resources."
+        else
+          echo "Docker's not found. Exiting..."
+          exit 0
+        fi


### PR DESCRIPTION
# Goal
The goal of this PR is to fix error arising from when a brand new build runner comes online and `docker` is not available there. 

Closes #1121