### PR TITLE
fix(cid-as-string): Return CID as string instead of byte array #787

### DIFF
--- a/common/primitives/src/messages.rs
+++ b/common/primitives/src/messages.rs
@@ -35,7 +35,10 @@ pub struct MessageResponse {
 	)]
 	pub payload: Option<Vec<u8>>,
 	/// The content address for an IPFS payload in Base32. Will always be CIDv1.
-	#[cfg_attr(feature = "std", serde(skip_serializing_if = "Option::is_none", default))]
+	#[cfg_attr(
+		feature = "std",
+		serde(with = "as_string_option", skip_serializing_if = "Option::is_none", default)
+	)]
 	pub cid: Option<Vec<u8>>,
 	///  Offchain payload length (IPFS).
 	#[cfg_attr(feature = "std", serde(skip_serializing_if = "Option::is_none", default))]
@@ -160,7 +163,7 @@ mod tests {
 			payload_length: Some(42),
 		};
 		let serialized = serde_json::to_string(&msg).unwrap();
-		assert_eq!(serialized, "{\"provider_msa_id\":1,\"index\":1,\"block_number\":1,\"cid\":[98,97,102,107,114,101,105,100,103,118,112,107,106,97,119,108,120,122,54,115,102,102,120,122,119,103,111,111,111,119,101,53,121,116,55,105,54,119,115,121,103,50,51,54,109,102,111,107,115,55,55,110,121,119,107,112,116,100,113],\"payload_length\":42}");
+		assert_eq!(serialized, "{\"provider_msa_id\":1,\"index\":1,\"block_number\":1,\"cid\":\"bafkreidgvpkjawlxz6sffxzwgooowe5yt7i6wsyg236mfoks77nywkptdq\",\"payload_length\":42}");
 
 		let deserialized: MessageResponse = serde_json::from_str(&serialized).unwrap();
 		assert_eq!(deserialized, msg);

--- a/integration-tests/messages/addIPFSMessage.test.ts
+++ b/integration-tests/messages/addIPFSMessage.test.ts
@@ -110,7 +110,6 @@ describe("Add Offchain Message", function () {
     it("should successfully retrieve added message and returned CID should have Base32 encoding", async function () {
         const f = await firstValueFrom(ExtrinsicHelper.api.rpc.messages.getBySchemaId(schemaId, { from_block: starting_block, from_index: 0, to_block: starting_block + 999, page_size: 999 }));
         const response: MessageResponse = f.content[f.content.length - 1];
-        console.log(`Got messages: schema ${schemaId}, block: ${response.block_number}`);
         const cid = Buffer.from(response.cid.unwrap()).toString();
         assert.equal(cid, ipfs_cid_32, 'returned CID should match base32-encoded CID');
     })

--- a/integration-tests/messages/addIPFSMessage.test.ts
+++ b/integration-tests/messages/addIPFSMessage.test.ts
@@ -22,8 +22,10 @@ describe("Add Offchain Message", function () {
     let ipfs_node: any;
     const ipfs_payload_data = "This is a test of Frequency.";
     const ipfs_payload_len = ipfs_payload_data.length + 1;
+    let starting_block: number;
 
     before(async function () {
+        starting_block = (await firstValueFrom(ExtrinsicHelper.api.rpc.chain.getHeader())).number.toNumber();
         ipfs_node = await loadIpfs();
         const { base64, base32 } = await getBases();
         const file = await ipfs_node.add({ path: 'integration_test.txt', content: ipfs_payload_data }, { cidVersion: 1, onlyHash: true });
@@ -106,8 +108,9 @@ describe("Add Offchain Message", function () {
     });
 
     it("should successfully retrieve added message and returned CID should have Base32 encoding", async function () {
-        const f = await firstValueFrom(ExtrinsicHelper.api.rpc.messages.getBySchemaId(schemaId, { from_block: 0, from_index: 0, to_block: 999, page_size: 999 }));
-        const response: MessageResponse = f.content[0];
+        const f = await firstValueFrom(ExtrinsicHelper.api.rpc.messages.getBySchemaId(schemaId, { from_block: starting_block, from_index: 0, to_block: starting_block + 999, page_size: 999 }));
+        const response: MessageResponse = f.content[f.content.length - 1];
+        console.log(`Got messages: schema ${schemaId}, block: ${response.block_number}`);
         const cid = Buffer.from(response.cid.unwrap()).toString();
         assert.equal(cid, ipfs_cid_32, 'returned CID should match base32-encoded CID');
     })

--- a/integration-tests/package-lock.json
+++ b/integration-tests/package-lock.json
@@ -725,7 +725,7 @@
         "node_modules/@frequency-chain/api-augment": {
             "version": "0.0.0",
             "resolved": "file:../js/api-augment/dist/frequency-chain-api-augment-0.0.0.tgz",
-            "integrity": "sha512-qpihpTWsk86wV7Od7n55J8/0kGHIAGCP5ll87bmemDNW6SSBHA0Ko9EIEqgkHIA9FomI4WEaIPHdTy/mWHa8XQ==",
+            "integrity": "sha512-0dFn3WxAasGiuLpbJHp+ae601uvuend+UKD44A8xBmZNNcCckB64MioU108PcoU5M3shTqECmtUMbHipFSwJ6A==",
             "license": "Apache-2.0",
             "dependencies": {
                 "@polkadot/api": "^9.13.2",
@@ -8032,9 +8032,9 @@
             }
         },
         "node_modules/http-cache-semantics": {
-            "version": "4.1.0",
-            "resolved": "https://registry.npmjs.org/http-cache-semantics/-/http-cache-semantics-4.1.0.tgz",
-            "integrity": "sha512-carPklcUh7ROWRK7Cv27RPtdhYhUsela/ue5/jKzjegVvXDqM2ILE9Q2BGn9JZJh1g87cp56su/FgQSzcWS8cQ=="
+            "version": "4.1.1",
+            "resolved": "https://registry.npmjs.org/http-cache-semantics/-/http-cache-semantics-4.1.1.tgz",
+            "integrity": "sha512-er295DKPVsV82j5kw1Gjt+ADA/XYHsajl82cGNQG2eyoPkvgUhX+nDIyelzhIWbbsXP39EHcI6l5tYs2FYqYXQ=="
         },
         "node_modules/http2-wrapper": {
             "version": "2.2.0",
@@ -13059,9 +13059,9 @@
             }
         },
         "node_modules/undici": {
-            "version": "5.14.0",
-            "resolved": "https://registry.npmjs.org/undici/-/undici-5.14.0.tgz",
-            "integrity": "sha512-yJlHYw6yXPPsuOH0x2Ib1Km61vu4hLiRRQoafs+WUgX1vO64vgnxiCEN9dpIrhZyHFsai3F0AEj4P9zy19enEQ==",
+            "version": "5.20.0",
+            "resolved": "https://registry.npmjs.org/undici/-/undici-5.20.0.tgz",
+            "integrity": "sha512-J3j60dYzuo6Eevbawwp1sdg16k5Tf768bxYK4TUJRH7cBM4kFCbf3mOnM/0E3vQYXvpxITbbWmBafaDbxLDz3g==",
             "dependencies": {
                 "busboy": "^1.6.0"
             },

--- a/runtime/frequency/src/lib.rs
+++ b/runtime/frequency/src/lib.rs
@@ -422,7 +422,7 @@ pub const VERSION: RuntimeVersion = RuntimeVersion {
 	spec_name: spec_name!("frequency"),
 	impl_name: create_runtime_str!("frequency"),
 	authoring_version: 1,
-	spec_version: 16,
+	spec_version: 17,
 	impl_version: 0,
 	apis: RUNTIME_API_VERSIONS,
 	transaction_version: 1,


### PR DESCRIPTION
# Goal
The goal of this PR is to return CID as a string instead of `Vec<u8>` bytes. Based on:

> Peter Frank
  [6:36 PM](https://unfinished-team.slack.com/archives/C01L4J5SQA1/p1675467404682619)
@here think I found a bug, or really an incomplete ticket. 
[@Aziz Abada](https://unfinished-team.slack.com/team/U02J2JHFZJ4)
 is integrating against the messages.getMessagesBySchemaId  call and for the cid itself we are being returned a byte array (really a JSON array of very small numbers that are less than u8 :)). It appears this was noticed in this ticket https://github.com/LibertyDSNP/frequency/issues/787 and the comment on this code https://github.com/LibertyDSNP/frequency/blob/main/common/primitives/src/messages.rs#L38-L39 talks about the base32 encoding in the comment but it doesn’t actually change the data type from Option<Vec<u8>> to Option<string>. Just wanted to call this out, we will be adding a method to convert this on our side for now receiving a naked byte array (but especially one that is really a string) isn’t terribly useful but not sure how we go about fixing/changing this.

Closes #787 

# Checklist
- [ ] Chain spec updated
- [ ] Custom RPC OR Runtime API added/changed? Updated js/api-augment.
- [ ] Design doc(s) updated
- [ ] Tests added
- [ ] Benchmarks added
- [ ] Weights updated
