### PR TITLE
set home dir to /root on self-hosted runners in remaining workflows

### DIFF
--- a/.github/workflows/common/reset-self-hosted-runner/action.yml
+++ b/.github/workflows/common/reset-self-hosted-runner/action.yml
@@ -6,8 +6,13 @@ runs:
     - name: Remove /home/runner
       shell: bash
       run: |
+        whoami
+        echo "***> BEFORE removal of /home/runner dir:"
+        ls -la /home
         echo "Removing no longer used /home/runner dir..."
         rm -fr /home/runner
+        echo "***> After removal of /home/runner dir:"
+        ls -la /home
     - name: Remove Cargo Generated Artifacts
       shell: bash
       run: |

--- a/.github/workflows/merge-pr.yml
+++ b/.github/workflows/merge-pr.yml
@@ -19,7 +19,7 @@ jobs:
   publish-js-api-augment-rc:
     name: Merge - Publish JS API Augment Release Candidate
     env:
-      HOME: /home/runner
+      HOME: /root
     runs-on: [self-hosted, Linux, X64]
     steps:
       - name: Check Out Repo

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -16,7 +16,7 @@ jobs:
   build-binaries:
     name: Build ${{matrix.arch}} Binary for ${{matrix.network}}
     env:
-      HOME: /home/runner
+      HOME: /root
     strategy:
       fail-fast: true
       matrix:
@@ -112,7 +112,7 @@ jobs:
       runtime_filename_rococo: ${{steps.set-env-vars.outputs.runtime_filename_rococo}}
       runtime_filename_mainnet: ${{steps.set-env-vars.outputs.runtime_filename_mainnet}}
     env:
-      HOME: /home/runner
+      HOME: /root
     strategy:
       fail-fast: true
       matrix:
@@ -209,7 +209,7 @@ jobs:
     name: Build Rust Developer Docs
     runs-on: [self-hosted, Linux, X64]
     env:
-      HOME: /home/runner
+      HOME: /root
     steps:
       - name: Check Out Repo
         uses: actions/checkout@v3


### PR DESCRIPTION
# Goal
The goal of this PR is to sync up remaining workflows and set home dir to `/root` for all jobs executed on the current self-hosted build runners. 

Closes #1129