### PR TITLE
747 add labels to runners

### DIFF
--- a/.github/workflows/merge-pr.yml
+++ b/.github/workflows/merge-pr.yml
@@ -20,7 +20,7 @@ jobs:
     name: Merge - Publish JS API Augment Release Candidate
     env:
       HOME: /root
-    runs-on: [self-hosted, Linux, X64]
+    runs-on: [self-hosted, Linux, X64, build]
     steps:
       - name: Check Out Repo
         uses: actions/checkout@v3

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -20,8 +20,8 @@ jobs:
     strategy:
       fail-fast: true
       matrix:
-        # os: [[self-hosted, Linux, X64], [self-hosted, Linux, ARM64]]
-        os: [[self-hosted, Linux, X64]]
+        # os: [[self-hosted, Linux, X64, build], [self-hosted, Linux, ARM64,  build]]
+        os: [[self-hosted, Linux, X64, build]]
         network: [local, rococo, mainnet]
         include:
           - network: local
@@ -36,7 +36,7 @@ jobs:
             spec: frequency
             build-profile: production
             release-file-name-prefix: frequency
-          - os: [self-hosted, Linux, X64]
+          - os: [self-hosted, Linux, X64, build]
             arch: amd64
           # - os: [self-hosted, Linux, ARM64]
           #   arch: arm64
@@ -134,7 +134,7 @@ jobs:
             release-wasm-file-name-prefix: frequency_runtime
             features: frequency
             wasm-core-version: frequency
-    runs-on: [self-hosted, Linux, X64]
+    runs-on: [self-hosted, Linux, X64, build]
     steps:
       - name: Check Out Repo
         uses: actions/checkout@v3
@@ -207,7 +207,7 @@ jobs:
 
   build-rust-developer-docs:
     name: Build Rust Developer Docs
-    runs-on: [self-hosted, Linux, X64]
+    runs-on: [self-hosted, Linux, X64, build]
     env:
       HOME: /root
     steps:

--- a/.github/workflows/verify-pr-commit.yml
+++ b/.github/workflows/verify-pr-commit.yml
@@ -100,7 +100,7 @@ jobs:
           - network: mainnet
             spec: frequency
             branch_alias: pr
-    runs-on: [self-hosted, Linux, X64]
+    runs-on: [self-hosted, Linux, X64, build]
     env:
       HOME: /root
       NETWORK: mainnet
@@ -201,7 +201,7 @@ jobs:
     name: Lint Rust Code
     env:
       HOME: /root
-    runs-on: [self-hosted, Linux, X64]
+    runs-on: [self-hosted, Linux, X64, build]
     steps:
       # https://github.com/LibertyDSNP/frequency/issues/1102
       - name: Debug Leftovers
@@ -239,7 +239,7 @@ jobs:
     name: Verify Rust Developer Docs
     env:
       HOME: /root
-    runs-on: [self-hosted, Linux, X64]
+    runs-on: [self-hosted, Linux, X64, build]
     steps:
       # https://github.com/LibertyDSNP/frequency/issues/1102
       - name: Debug Leftovers
@@ -273,7 +273,7 @@ jobs:
     name: Verify Rust Packages and Dependencies
     env:
       HOME: /root
-    runs-on: [self-hosted, Linux, X64]
+    runs-on: [self-hosted, Linux, X64, build]
     steps:
       # https://github.com/LibertyDSNP/frequency/issues/1102
       - name: Debug Leftovers
@@ -307,7 +307,7 @@ jobs:
     name: Run Rust Tests
     env:
       HOME: /root
-    runs-on: [self-hosted, Linux, X64]
+    runs-on: [self-hosted, Linux, X64, build]
     steps:
       # https://github.com/LibertyDSNP/frequency/issues/1102
       - name: Debug Leftovers
@@ -402,7 +402,7 @@ jobs:
             package: frequency-runtime
             runtime-dir: runtime/frequency
             features: frequency
-    runs-on: [self-hosted, Linux, X64]
+    runs-on: [self-hosted, Linux, X64, build]
     steps:
       # https://github.com/LibertyDSNP/frequency/issues/1102
       - name: Debug Leftovers


### PR DESCRIPTION
# Goal
The goal of this PR is to update self-hosted build runner labels so build runners are targeted separately from other runners (i.e. benchmark).

Closes #747
