### PR TITLE
feat(tx-payment): add ability to use Capacity

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5535,6 +5535,7 @@ dependencies = [
  "frame-support",
  "frame-system",
  "pallet-balances",
+ "pallet-capacity",
  "pallet-msa",
  "pallet-transaction-payment",
  "parity-scale-codec",

--- a/common/primitives/src/capacity.rs
+++ b/common/primitives/src/capacity.rs
@@ -8,6 +8,13 @@ pub trait TargetValidator {
 	fn validate(target: MessageSourceId) -> bool;
 }
 
+/// A blanket implementation
+impl TargetValidator for () {
+	fn validate(_target: MessageSourceId) -> bool {
+		false
+	}
+}
+
 /// A trait for Non-transferable asset.
 pub trait Nontransferable {
 	/// Scalar type for representing balance of an account.

--- a/pallets/capacity/src/lib.rs
+++ b/pallets/capacity/src/lib.rs
@@ -499,7 +499,7 @@ impl<T: Config> Pallet<T> {
 	}
 
 	/// Sets targets Capacity.
-	fn set_capacity_for(
+	pub fn set_capacity_for(
 		target: MessageSourceId,
 		capacity_details: CapacityDetails<BalanceOf<T>, T::EpochNumber>,
 	) {

--- a/pallets/frequency-tx-payment/Cargo.toml
+++ b/pallets/frequency-tx-payment/Cargo.toml
@@ -19,6 +19,8 @@ codec = {package = "parity-scale-codec", version = "3.1.5", default-features = f
 frame-benchmarking = {default-features = false, git = "https://github.com/paritytech/substrate", optional = true, branch = "polkadot-v0.9.36"}
 frame-support = {default-features = false, git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.36"}
 frame-system = {default-features = false, git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.36"}
+pallet-capacity = {default-features = false, path = "../capacity"}
+pallet-msa = {default-features = false, path = "../msa"}
 pallet-transaction-payment = {default-features = false, git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.36"}
 scale-info = {version = "2.2.0", default-features = false, features = [
   "derive",

--- a/pallets/frequency-tx-payment/src/lib.rs
+++ b/pallets/frequency-tx-payment/src/lib.rs
@@ -1,33 +1,114 @@
+//! # Frequency-Transactions Pallet
+//! The Frequency-transaction pallet allows users to transact using either capacity or token.
+//!
+//! - [Configuration: `Config`](Config)
+//! - [Extrinsics: `Call`](Call)
+//! - [Event Enum: `Event`](Event)
+//! - [Error Enum: `Error`](Error)
+//!
+//! ## Overview
+//! Capacity is a refillable resource that can be used to make transactions on the network.
+//! This pallets allows users to toggle between submitting transactions with capacity or tokens.
+//! Note that tipping for capacity transactions is not allowed and is set to zero. Users who
+//! use tokens to transact can continue to use a tip.
+//!
+//! The Frequency-transaction pallet provides functions for:
+//!
+//! - pay_with_capacity
+//!
+
 #![cfg_attr(not(feature = "std"), no_std)]
 
 use frame_support::{
-	dispatch::{DispatchInfo, GetDispatchInfo, PostDispatchInfo},
+	dispatch::{DispatchInfo, Dispatchable, GetDispatchInfo, PostDispatchInfo},
 	pallet_prelude::*,
-	traits::IsType,
+	traits::{IsSubType, IsType},
+	DefaultNoBound,
 };
+use frame_system::pallet_prelude::*;
 
 use codec::{Decode, Encode};
 use scale_info::TypeInfo;
 use sp_std::prelude::*;
 
 use sp_runtime::{
-	traits::{DispatchInfoOf, Dispatchable, PostDispatchInfoOf, SignedExtension},
+	traits::{DispatchInfoOf, PostDispatchInfoOf, SignedExtension, Zero},
 	transaction_validity::{TransactionValidity, TransactionValidityError},
 	FixedPointOperand,
 };
 
+use common_primitives::capacity::Nontransferable;
+
 use pallet_transaction_payment::OnChargeTransaction;
 
-// Type aliases used for interaction with `OnChargeTransaction`.
+/// Type aliases used for interaction with `OnChargeTransaction`.
 pub(crate) type OnChargeTransactionOf<T> =
 	<T as pallet_transaction_payment::Config>::OnChargeTransaction;
 
-// Balance type alias.
+/// Balance type alias.
 pub(crate) type BalanceOf<T> = <OnChargeTransactionOf<T> as OnChargeTransaction<T>>::Balance;
 
-// Liquidity info type alias (imbalances).
+/// Liquidity info type alias (imbalances).
 pub(crate) type LiquidityInfoOf<T> =
 	<OnChargeTransactionOf<T> as OnChargeTransaction<T>>::LiquidityInfo;
+
+/// Capacity Balance type
+pub(crate) type CapacityOf<T> = <T as Config>::Capacity;
+
+/// Capacity Balance alias
+pub(crate) type CapacityBalanceOf<T> = <CapacityOf<T> as Nontransferable>::Balance;
+
+/// Used to pass the initial payment info from pre- to post-dispatch.
+#[derive(Encode, Decode, DefaultNoBound, TypeInfo)]
+pub enum InitialPayment<T: Config> {
+	/// No initial fee was paid.
+	#[default]
+	Free,
+	/// The initial fee was payed in the native currency.
+	Token(LiquidityInfoOf<T>),
+	/// The initial fee was paid in an asset.
+	Capacity,
+}
+
+#[cfg(feature = "std")]
+impl<T: Config> InitialPayment<T> {
+	pub fn is_free(&self) -> bool {
+		match *self {
+			InitialPayment::Free => true,
+			_ => false,
+		}
+	}
+
+	pub fn is_capacity(&self) -> bool {
+		match *self {
+			InitialPayment::Capacity => true,
+			_ => false,
+		}
+	}
+
+	pub fn is_token(&self) -> bool {
+		match *self {
+			InitialPayment::Token(_) => true,
+			_ => false,
+		}
+	}
+}
+
+impl<T: Config> sp_std::fmt::Debug for InitialPayment<T> {
+	#[cfg(feature = "std")]
+	fn fmt(&self, f: &mut sp_std::fmt::Formatter) -> sp_std::fmt::Result {
+		match *self {
+			InitialPayment::Free => write!(f, "Nothing"),
+			InitialPayment::Capacity => write!(f, "Token"),
+			InitialPayment::Token(_) => write!(f, "Imbalance"),
+		}
+	}
+
+	#[cfg(not(feature = "std"))]
+	fn fmt(&self, _: &mut sp_std::fmt::Formatter) -> sp_std::fmt::Result {
+		Ok(())
+	}
+}
 
 #[cfg(test)]
 mod tests;
@@ -41,7 +122,6 @@ pub use pallet::*;
 #[frame_support::pallet]
 pub mod pallet {
 	use super::*;
-	use frame_system::pallet_prelude::*;
 	// Simple declaration of the `Pallet` type. It is placeholder we use to implement traits and
 	// method.
 	#[pallet::pallet]
@@ -49,16 +129,20 @@ pub mod pallet {
 	pub struct Pallet<T>(_);
 
 	#[pallet::config]
-	pub trait Config: frame_system::Config + pallet_transaction_payment::Config {
+	pub trait Config:
+		frame_system::Config + pallet_transaction_payment::Config + pallet_msa::Config
+	{
 		/// The overarching event type.
 		type RuntimeEvent: From<Event<Self>> + IsType<<Self as frame_system::Config>::RuntimeEvent>;
 
 		/// The overarching call type.
 		type RuntimeCall: Parameter
-			+ Dispatchable<RuntimeOrigin = Self::RuntimeOrigin>
+			+ Dispatchable<RuntimeOrigin = Self::RuntimeOrigin, PostInfo = PostDispatchInfo>
 			+ GetDispatchInfo
-			+ From<frame_system::Call<Self>>
+			+ IsSubType<Call<Self>>
 			+ IsType<<Self as frame_system::Config>::RuntimeCall>;
+
+		type Capacity: Nontransferable;
 	}
 
 	#[pallet::event]
@@ -102,7 +186,9 @@ pub struct ChargeFrqTransactionPayment<T: Config>(#[codec(compact)] BalanceOf<T>
 
 impl<T: Config> ChargeFrqTransactionPayment<T>
 where
-	BalanceOf<T>: Send + Sync + FixedPointOperand,
+	BalanceOf<T>: Send + Sync + FixedPointOperand + IsType<CapacityBalanceOf<T>> + From<u64>,
+	<T as frame_system::Config>::RuntimeCall:
+		Dispatchable<Info = DispatchInfo, PostInfo = PostDispatchInfo> + IsSubType<Call<T>>,
 {
 	/// Utility construct from tip.
 	pub fn from(tip: BalanceOf<T>) -> Self {
@@ -110,8 +196,52 @@ where
 	}
 
 	/// Return the tip as being chosen by the transaction sender.
-	pub fn tip(&self) -> BalanceOf<T> {
-		self.0
+	pub fn tip(&self, call: &<T as frame_system::Config>::RuntimeCall) -> BalanceOf<T> {
+		match call.is_sub_type() {
+			Some(Call::pay_with_capacity { .. }) => Zero::zero(),
+			_ => self.0,
+		}
+	}
+
+	/// Withdraws fee from eigher Capacity ledger or Token account.
+	fn withdraw_fee(
+		&self,
+		who: &T::AccountId,
+		call: &<T as frame_system::Config>::RuntimeCall,
+		info: &DispatchInfoOf<<T as frame_system::Config>::RuntimeCall>,
+		len: usize,
+	) -> Result<(BalanceOf<T>, InitialPayment<T>), TransactionValidityError> {
+		let fee =
+			pallet_transaction_payment::Pallet::<T>::compute_fee(len as u32, info, self.tip(call));
+
+		match call.is_sub_type() {
+			Some(Call::pay_with_capacity { .. }) => {
+				let msa_id = pallet_msa::Pallet::<T>::ensure_valid_msa_key(who).map_err(
+					|_| -> TransactionValidityError { InvalidTransaction::Payment.into() },
+				)?;
+
+				T::Capacity::withdraw(msa_id, fee.into()).map_err(
+					|_| -> TransactionValidityError { InvalidTransaction::Payment.into() },
+				)?;
+
+				Ok((fee, InitialPayment::Capacity))
+			},
+			_ => {
+				if fee.is_zero() {
+					return Ok((fee, InitialPayment::Free))
+				}
+
+				<OnChargeTransactionOf<T> as OnChargeTransaction<T>>::withdraw_fee(
+					who,
+					call,
+					info,
+					fee,
+					self.tip(&call),
+				)
+				.map(|i| (fee, InitialPayment::Token(i)))
+				.map_err(|_| -> TransactionValidityError { InvalidTransaction::Payment.into() })
+			},
+		}
 	}
 }
 
@@ -129,8 +259,9 @@ impl<T: Config> sp_std::fmt::Debug for ChargeFrqTransactionPayment<T> {
 impl<T: Config> SignedExtension for ChargeFrqTransactionPayment<T>
 where
 	<T as frame_system::Config>::RuntimeCall:
-		Dispatchable<Info = DispatchInfo, PostInfo = PostDispatchInfo>,
-	BalanceOf<T>: Send + Sync + From<u64> + FixedPointOperand,
+		IsSubType<Call<T>> + Dispatchable<Info = DispatchInfo, PostInfo = PostDispatchInfo>,
+
+	BalanceOf<T>: Send + Sync + FixedPointOperand + From<u64> + IsType<CapacityBalanceOf<T>>,
 {
 	const IDENTIFIER: &'static str = "ChargeTransactionPayment";
 	type AccountId = T::AccountId;
@@ -140,7 +271,7 @@ where
 		// tip
 		BalanceOf<T>,
 		Self::AccountId,
-		LiquidityInfoOf<T>,
+		InitialPayment<T>,
 	);
 
 	/// Construct any additional data that should be in the signed payload of the transaction. Can
@@ -157,10 +288,16 @@ where
 		info: &DispatchInfoOf<Self::Call>,
 		len: usize,
 	) -> TransactionValidity {
-		let result = pallet_transaction_payment::ChargeTransactionPayment::<T>::from(self.0)
-			.validate(who, call, info, len)?;
+		let (fee, _) = self.withdraw_fee(who, call, info, len)?;
 
-		Ok(result)
+		let priority = pallet_transaction_payment::ChargeTransactionPayment::<T>::get_priority(
+			info,
+			len,
+			self.tip(call),
+			fee,
+		);
+
+		Ok(ValidTransaction { priority, ..Default::default() })
 	}
 
 	/// Do any pre-flight stuff for a signed transaction.
@@ -171,10 +308,9 @@ where
 		info: &DispatchInfoOf<Self::Call>,
 		len: usize,
 	) -> Result<Self::Pre, TransactionValidityError> {
-		let result = pallet_transaction_payment::ChargeTransactionPayment::<T>::from(self.tip())
-			.pre_dispatch(&who, &call, &info, len)?;
+		let (_fee, initial_payment) = self.withdraw_fee(who, call, info, len)?;
 
-		Ok(result)
+		Ok((self.tip(call), who.clone(), initial_payment))
 	}
 
 	/// Do any post-flight stuff for an extrinsic.
@@ -185,16 +321,29 @@ where
 		len: usize,
 		result: &DispatchResult,
 	) -> Result<(), TransactionValidityError> {
-		if let Some((tip, who, imbalance)) = maybe_pre {
-			pallet_transaction_payment::ChargeTransactionPayment::<T>::post_dispatch(
-				Some((tip, who, imbalance)),
-				info,
-				post_info,
-				len,
-				result,
-			)?;
+		if let Some((tip, who, initial_payment)) = maybe_pre {
+			match initial_payment {
+				InitialPayment::Token(already_withdrawn) => {
+					pallet_transaction_payment::ChargeTransactionPayment::<T>::post_dispatch(
+						Some((tip, who, already_withdrawn)),
+						info,
+						post_info,
+						len,
+						result,
+					)?;
+				},
+				InitialPayment::Capacity => {
+					debug_assert!(tip.is_zero(), "tip should be zero for Capacity tx.");
+				},
+				InitialPayment::Free => {
+					// `actual_fee` should be zero here for any signed extrinsic. It would be
+					// non-zero here in case of unsigned extrinsics as they don't pay fees but
+					// `compute_actual_fee` is not aware of them. In both cases it's fine to just
+					// move ahead without adjusting the fee, though, so we do nothing.
+					debug_assert!(tip.is_zero(), "tip should be zero if initial fee was zero.");
+				},
+			}
 		}
-
 		Ok(())
 	}
 }

--- a/pallets/frequency-tx-payment/src/mock.rs
+++ b/pallets/frequency-tx-payment/src/mock.rs
@@ -1,5 +1,6 @@
 use super::*;
 use crate as pallet_frequency_tx_payment;
+use common_primitives::msa::MessageSourceId;
 
 use common_primitives::{
 	node::{AccountId, ProposalProvider},
@@ -10,7 +11,8 @@ use pallet_transaction_payment::CurrencyAdapter;
 use sp_core::{ConstU8, H256};
 use sp_runtime::{
 	testing::Header,
-	traits::{BlakeTwo256, IdentityLookup, SaturatedConversion},
+	traits::{BlakeTwo256, Convert, IdentityLookup, SaturatedConversion},
+	AccountId32,
 };
 
 use frame_support::{
@@ -18,7 +20,6 @@ use frame_support::{
 	traits::{ConstU16, ConstU64},
 	weights::WeightToFee as WeightToFeeTrait,
 };
-use sp_runtime::{traits::Convert, AccountId32};
 
 type UncheckedExtrinsic = frame_system::mocking::MockUncheckedExtrinsic<Test>;
 type Block = frame_system::mocking::MockBlock<Test>;
@@ -32,11 +33,95 @@ frame_support::construct_runtime!(
 		{
 			System: frame_system::{Pallet, Call, Config, Storage, Event<T>},
 			Balances: pallet_balances::{Pallet, Call, Storage, Config<T>, Event<T>},
+			Msa: pallet_msa::{Pallet, Call, Storage, Event<T>},
+			Capacity: pallet_capacity::{Pallet, Call, Storage, Event<T>},
 			TransactionPayment: pallet_transaction_payment::{Pallet, Storage, Event<T>},
 			FrequencyTxPayment: pallet_frequency_tx_payment::{Pallet, Call, Event<T>},
-			Msa: pallet_msa::{Pallet, Call, Storage, Event<T>},
 		}
 );
+
+parameter_types! {
+	pub const MaxSchemaGrantsPerDelegation: u32 = 30;
+}
+
+impl Clone for MaxSchemaGrantsPerDelegation {
+	fn clone(&self) -> Self {
+		MaxSchemaGrantsPerDelegation {}
+	}
+}
+
+impl Eq for MaxSchemaGrantsPerDelegation {
+	fn assert_receiver_is_total_eq(&self) -> () {}
+}
+
+impl PartialEq for MaxSchemaGrantsPerDelegation {
+	fn eq(&self, _other: &Self) -> bool {
+		true
+	}
+}
+
+impl sp_std::fmt::Debug for MaxSchemaGrantsPerDelegation {
+	fn fmt(&self, _: &mut sp_std::fmt::Formatter) -> sp_std::fmt::Result {
+		Ok(())
+	}
+}
+pub struct TestAccountId;
+
+impl Convert<u64, AccountId> for TestAccountId {
+	fn convert(_x: u64) -> AccountId32 {
+		AccountId32::new([1u8; 32])
+	}
+}
+pub struct Schemas;
+impl SchemaValidator<SchemaId> for Schemas {
+	fn are_all_schema_ids_valid(_schema_id: &Vec<SchemaId>) -> bool {
+		true
+	}
+
+	fn set_schema_count(_n: SchemaId) {}
+}
+
+pub struct CouncilProposalProvider;
+
+impl ProposalProvider<u64, RuntimeCall> for CouncilProposalProvider {
+	fn propose(
+		_who: u64,
+		_threshold: u32,
+		_proposal: Box<RuntimeCall>,
+	) -> Result<(u32, u32), DispatchError> {
+		Ok((1u32, 1u32))
+	}
+
+	fn propose_with_simple_majority(
+		_who: u64,
+		_proposal: Box<RuntimeCall>,
+	) -> Result<(u32, u32), DispatchError> {
+		Ok((1u32, 1u32))
+	}
+
+	#[cfg(any(feature = "runtime-benchmarks", feature = "test"))]
+	fn proposal_count() -> u32 {
+		1u32
+	}
+}
+
+impl pallet_msa::Config for Test {
+	type RuntimeEvent = RuntimeEvent;
+	type WeightInfo = ();
+	type ConvertIntoAccountId32 = TestAccountId;
+	type MaxPublicKeysPerMsa = ConstU8<255>;
+	type MaxSchemaGrantsPerDelegation = MaxSchemaGrantsPerDelegation;
+	type MaxProviderNameSize = ConstU32<16>;
+	type SchemaValidator = Schemas;
+	type MortalityWindowSize = ConstU32<100>;
+	type MaxSignaturesPerBucket = ConstU32<4000>;
+	type NumberOfBuckets = ConstU32<2>;
+	type Proposal = RuntimeCall;
+	type ProposalProvider = CouncilProposalProvider;
+	type CreateProviderViaGovernanceOrigin = EnsureSigned<u64>;
+	/// This MUST ALWAYS be MaxSignaturesPerBucket * NumberOfBuckets.
+	type MaxSignaturesStored = ConstU32<8000>;
+}
 
 pub struct BlockWeights;
 impl Get<frame_system::limits::BlockWeights> for BlockWeights {
@@ -93,86 +178,6 @@ impl pallet_balances::Config for Test {
 }
 
 parameter_types! {
-	pub const MaxSchemaGrantsPerDelegation: u32 = 30;
-}
-impl Clone for MaxSchemaGrantsPerDelegation {
-	fn clone(&self) -> Self {
-		MaxSchemaGrantsPerDelegation {}
-	}
-}
-impl Eq for MaxSchemaGrantsPerDelegation {
-	fn assert_receiver_is_total_eq(&self) -> () {}
-}
-impl PartialEq for MaxSchemaGrantsPerDelegation {
-	fn eq(&self, _other: &Self) -> bool {
-		true
-	}
-}
-impl sp_std::fmt::Debug for MaxSchemaGrantsPerDelegation {
-	fn fmt(&self, _: &mut sp_std::fmt::Formatter) -> sp_std::fmt::Result {
-		Ok(())
-	}
-}
-
-pub struct TestAccountId;
-impl Convert<u64, AccountId> for TestAccountId {
-	fn convert(_x: u64) -> AccountId32 {
-		AccountId32::new([1u8; 32])
-	}
-}
-
-pub struct Schemas;
-impl SchemaValidator<SchemaId> for Schemas {
-	fn are_all_schema_ids_valid(_schema_id: &Vec<SchemaId>) -> bool {
-		true
-	}
-
-	fn set_schema_count(_n: SchemaId) {}
-}
-
-pub struct CouncilProposalProvider;
-
-impl ProposalProvider<u64, RuntimeCall> for CouncilProposalProvider {
-	fn propose(
-		_who: u64,
-		_threshold: u32,
-		_proposal: Box<RuntimeCall>,
-	) -> Result<(u32, u32), DispatchError> {
-		Ok((1u32, 1u32))
-	}
-
-	fn propose_with_simple_majority(
-		_who: u64,
-		_proposal: Box<RuntimeCall>,
-	) -> Result<(u32, u32), DispatchError> {
-		Ok((1u32, 1u32))
-	}
-
-	#[cfg(any(feature = "runtime-benchmarks", feature = "test"))]
-	fn proposal_count() -> u32 {
-		1u32
-	}
-}
-
-impl pallet_msa::Config for Test {
-	type RuntimeEvent = RuntimeEvent;
-	type WeightInfo = ();
-	type ConvertIntoAccountId32 = TestAccountId;
-	type MaxPublicKeysPerMsa = ConstU8<255>;
-	type MaxSchemaGrantsPerDelegation = MaxSchemaGrantsPerDelegation;
-	type MaxProviderNameSize = ConstU32<16>;
-	type SchemaValidator = Schemas;
-	type MortalityWindowSize = ConstU32<100>;
-	type MaxSignaturesPerBucket = ConstU32<4000>;
-	type NumberOfBuckets = ConstU32<2>;
-	type Proposal = RuntimeCall;
-	type ProposalProvider = CouncilProposalProvider;
-	type CreateProviderViaGovernanceOrigin = EnsureSigned<u64>;
-	/// This MUST ALWAYS be MaxSignaturesPerBucket * NumberOfBuckets.
-	type MaxSignaturesStored = ConstU32<8000>;
-}
-
-parameter_types! {
 	pub static WeightToFee: u64 = 1;
 	pub static TransactionByteFee: u64 = 1;
 	static ExtrinsicBaseWeight: Weight = Weight::zero();
@@ -205,9 +210,26 @@ impl pallet_transaction_payment::Config for Test {
 	type OperationalFeeMultiplier = ConstU8<5>;
 }
 
+impl pallet_capacity::Config for Test {
+	type RuntimeEvent = RuntimeEvent;
+	type WeightInfo = ();
+	type Currency = pallet_balances::Pallet<Self>;
+	type TargetValidator = ();
+	type MinimumStakingAmount = ConstU64<5>;
+	type MaxUnlockingChunks = ConstU32<4>;
+
+	#[cfg(feature = "runtime-benchmarks")]
+	type BenchmarkHelper = ();
+
+	type UnstakingThawPeriod = ConstU16<2>;
+	type MaxEpochLength = ConstU64<100>;
+	type EpochNumber = u32;
+}
+
 impl Config for Test {
 	type RuntimeEvent = RuntimeEvent;
 	type RuntimeCall = RuntimeCall;
+	type Capacity = Capacity;
 }
 
 pub struct ExtBuilder {
@@ -266,6 +288,40 @@ impl ExtBuilder {
 		.assimilate_storage(&mut t)
 		.unwrap();
 
+		let mut t: sp_io::TestExternalities = t.into();
+
+		// Create MSA account 1 - 6 and add Balance to them with Capacity balance
+		t.execute_with(|| {
+			let msa_accounts: Vec<(
+				<Test as frame_system::Config>::AccountId,
+				<Test as pallet_balances::Config>::Balance,
+			)> = vec![
+				(1, 10 * self.balance_factor),
+				(2, 20 * self.balance_factor),
+				(3, 30 * self.balance_factor),
+				(4, 40 * self.balance_factor),
+				(5, 50 * self.balance_factor),
+				(6, 60 * self.balance_factor),
+			];
+			msa_accounts.iter().for_each(|(account, balance)| {
+				let msa_id = create_msa_account(account.clone());
+				create_capacity_for(msa_id, balance.clone());
+			});
+		});
+
 		t.into()
 	}
+}
+
+fn create_msa_account(account_id: <Test as frame_system::Config>::AccountId) -> MessageSourceId {
+	pub const EMPTY_FUNCTION: fn(MessageSourceId) -> DispatchResult = |_| Ok(());
+	let (msa_id, _) = Msa::create_account(account_id, EMPTY_FUNCTION).unwrap();
+
+	msa_id
+}
+
+fn create_capacity_for(target: MessageSourceId, amount: u64) {
+	let mut capacity_details = Capacity::get_capacity_for(target).unwrap_or_default();
+	capacity_details.deposit(amount, Capacity::get_current_epoch()).unwrap();
+	Capacity::set_capacity_for(target, capacity_details);
 }

--- a/pallets/frequency-tx-payment/src/tests.rs
+++ b/pallets/frequency-tx-payment/src/tests.rs
@@ -1,6 +1,9 @@
 use super::*;
 use crate::{self as pallet_frequency_tx_payment, mock::*, ChargeFrqTransactionPayment};
 use frame_support::{assert_noop, assert_ok, weights::Weight};
+use pallet_capacity::Nontransferable;
+
+use sp_runtime::transaction_validity::TransactionValidityError;
 
 use pallet_balances::Call as BalancesCall;
 use pallet_frequency_tx_payment::Call as FrequencyTxPaymentCall;
@@ -151,6 +154,58 @@ fn transaction_payment_with_token_and_post_dispatch_refund_is_succesful() {
 }
 
 #[test]
+fn transaction_payment_with_capacity_and_no_overcharge_post_dispatch_refund_is_succesful() {
+	let balance_factor = 10;
+
+	ExtBuilder::default()
+		.balance_factor(balance_factor)
+		.base_weight(Weight::from_ref_time(5))
+		.build()
+		.execute_with(|| {
+			let account_id = 1u64;
+			let balances_call: &<Test as Config>::RuntimeCall =
+				&RuntimeCall::FrequencyTxPayment(Call::pay_with_capacity {
+					call: Box::new(RuntimeCall::Balances(BalancesCall::transfer {
+						dest: 2,
+						value: 100,
+					})),
+				});
+
+			let dispatch_info =
+				DispatchInfo { weight: Weight::from_ref_time(5), ..Default::default() };
+			let len = 10;
+
+			assert_eq!(Capacity::balance(1), 100);
+
+			let pre = ChargeFrqTransactionPayment::<Test>::from(0u64)
+				.pre_dispatch(&account_id, balances_call, &dispatch_info, len)
+				.unwrap();
+
+			// Token account Balance is not effected
+			assert_eq!(Balances::free_balance(1), 100);
+
+			// capacity_balance = free_balance - base_weight(5)
+			//   - extrinsic_weight(5) * WeightToFee(1)
+			//   - TransactionByteFee(1)* len(10) = 80
+			assert_eq!(Capacity::balance(1), 100 - 5 - 5 - 10);
+
+			let post_info: PostDispatchInfo =
+				PostDispatchInfo { actual_weight: None, pays_fee: Default::default() };
+
+			assert_ok!(ChargeFrqTransactionPayment::<Test>::post_dispatch(
+				Some(pre),
+				&dispatch_info,
+				&post_info,
+				len,
+				&Ok(()),
+			));
+
+			// Checking balance was not modified after post-dispatch.
+			assert_eq!(Capacity::balance(1), 100 - 5 - 5 - 10);
+		});
+}
+
+#[test]
 fn pay_with_capacity_happy_path() {
 	let balance_factor = 10;
 
@@ -180,4 +235,180 @@ fn pay_with_capacity_returns_weight_of_child_call() {
 	let pay_with_capacity_dispatch_info = pay_with_capacity_call.get_dispatch_info();
 
 	assert_eq!(create_msa_dispatch_info.weight, pay_with_capacity_dispatch_info.weight);
+}
+
+#[test]
+fn charge_frq_transaction_payment_withdraw_fee_for_capacity_tx_returns_tupple_with_fee_and_enum() {
+	let balance_factor = 10;
+
+	ExtBuilder::default()
+		.balance_factor(balance_factor)
+		.base_weight(Weight::from_ref_time(5))
+		.build()
+		.execute_with(|| {
+			let charge_tx_payment = ChargeFrqTransactionPayment::<Test>::from(0u64);
+			let who = 1u64;
+			let call: &<Test as Config>::RuntimeCall =
+				&RuntimeCall::FrequencyTxPayment(Call::pay_with_capacity {
+					call: Box::new(RuntimeCall::Balances(BalancesCall::transfer {
+						dest: 2,
+						value: 100,
+					})),
+				});
+
+			let info = DispatchInfo { weight: Weight::from_ref_time(5), ..Default::default() };
+			let len = 10;
+
+			// fee = base_weight(5)
+			//   + extrinsic_weight(5) * WeightToFee(1)
+			//   + TransactionByteFee(1)* len(10) = 20
+			assert_eq!(charge_tx_payment.withdraw_fee(&who, call, &info, len).unwrap().0, 20u64);
+			assert_eq!(
+				charge_tx_payment.withdraw_fee(&who, call, &info, len).unwrap().1.is_capacity(),
+				true
+			);
+		});
+}
+
+#[test]
+fn charge_frq_transaction_payment_withdraw_fee_errors_for_capacity_tx_when_user_does_not_have_enough_funds(
+) {
+	let balance_factor = 10;
+
+	ExtBuilder::default()
+		.balance_factor(balance_factor)
+		.base_weight(Weight::from_ref_time(100))
+		.build()
+		.execute_with(|| {
+			let charge_tx_payment = ChargeFrqTransactionPayment::<Test>::from(0u64);
+			let who = 1u64;
+			let call: &<Test as Config>::RuntimeCall =
+				&RuntimeCall::FrequencyTxPayment(Call::pay_with_capacity {
+					call: Box::new(RuntimeCall::Balances(BalancesCall::transfer {
+						dest: 2,
+						value: 100,
+					})),
+				});
+
+			let info = DispatchInfo { weight: Weight::from_ref_time(5), ..Default::default() };
+			let len = 10;
+			let error = charge_tx_payment.withdraw_fee(&who, call, &info, len).unwrap_err();
+			assert_eq!(error, TransactionValidityError::Invalid(InvalidTransaction::Payment));
+		});
+}
+
+#[test]
+fn charge_frq_transaction_payment_withdraw_fee_errors_for_non_capacity_tx_when_user_does_not_have_enough_funds(
+) {
+	let balance_factor = 10;
+
+	ExtBuilder::default()
+		.balance_factor(balance_factor)
+		.base_weight(Weight::from_ref_time(100))
+		.build()
+		.execute_with(|| {
+			let charge_tx_payment = ChargeFrqTransactionPayment::<Test>::from(0u64);
+			let who = 1u64;
+			let call: &<Test as Config>::RuntimeCall =
+				&RuntimeCall::Balances(BalancesCall::transfer { dest: 2, value: 100 });
+
+			let info = DispatchInfo { weight: Weight::from_ref_time(5), ..Default::default() };
+			let len = 10;
+			let error = charge_tx_payment.withdraw_fee(&who, call, &info, len).unwrap_err();
+			assert_eq!(error, TransactionValidityError::Invalid(InvalidTransaction::Payment));
+		});
+}
+
+#[test]
+fn charge_frq_transaction_payment_withdraw_fee_for_non_capacity_tx_returns_tupple_with_fee_and_initial_payment_token_enum(
+) {
+	let balance_factor = 10;
+
+	ExtBuilder::default()
+		.balance_factor(balance_factor)
+		.base_weight(Weight::from_ref_time(5))
+		.build()
+		.execute_with(|| {
+			let charge_tx_payment = ChargeFrqTransactionPayment::<Test>::from(0u64);
+			let who = 1u64;
+			let call: &<Test as Config>::RuntimeCall =
+				&RuntimeCall::Balances(BalancesCall::transfer { dest: 2, value: 100 });
+
+			let info = DispatchInfo { weight: Weight::from_ref_time(5), ..Default::default() };
+			let len = 10;
+			let result = charge_tx_payment.withdraw_fee(&who, call, &info, len).unwrap();
+
+			// fee = base_weight(5)
+			//   + extrinsic_weight(5) * WeightToFee(1)
+			//   + TransactionByteFee(1)* len(10) = 20
+			assert_eq!(result.0, 20);
+			let expected = match result.1 {
+				InitialPayment::Token(_) => true,
+				_ => false,
+			};
+
+			assert!(expected);
+		});
+}
+
+#[test]
+fn charge_frq_transaction_payment_withdraw_fee_for_free_non_capacity_tx_returns_tupple_with_fee_and_free_enum(
+) {
+	let balance_factor = 10;
+
+	ExtBuilder::default()
+		.balance_factor(balance_factor)
+		.base_weight(Weight::from_ref_time(5))
+		.build()
+		.execute_with(|| {
+			let charge_tx_payment = ChargeFrqTransactionPayment::<Test>::from(0u64);
+			let who = 1u64;
+			let call: &<Test as Config>::RuntimeCall =
+				&RuntimeCall::Balances(BalancesCall::transfer { dest: 2, value: 100 });
+
+			let info = DispatchInfo {
+				weight: Weight::from_ref_time(5),
+				pays_fee: Pays::No,
+				..Default::default()
+			};
+			let len = 10;
+			let result = charge_tx_payment.withdraw_fee(&who, call, &info, len).unwrap();
+
+			// fee = base_weight(5)
+			//   + extrinsic_weight(5) * WeightToFee(1)
+			//   + TransactionByteFee(1)* len(10) = 20
+			assert_eq!(result.0, 0);
+			let expected = match result.1 {
+				InitialPayment::Free => true,
+				_ => false,
+			};
+
+			assert!(expected);
+		});
+}
+
+#[test]
+fn charge_frq_transaction_payment_tip_is_zero_for_capacity_calls() {
+	let fake_tip = 100;
+	let charge_tx_payment = ChargeFrqTransactionPayment::<Test>::from(fake_tip);
+	let call: &<Test as Config>::RuntimeCall =
+		&RuntimeCall::FrequencyTxPayment(Call::pay_with_capacity {
+			call: Box::new(RuntimeCall::Balances(BalancesCall::transfer { dest: 2, value: 100 })),
+		});
+
+	let result = charge_tx_payment.tip(call);
+
+	assert_eq!(result, 0u64);
+}
+
+#[test]
+fn charge_frq_transaction_payment_tip_is_some_amount_for_non_capacity_calls() {
+	let tip = 200;
+	let charge_tx_payment = ChargeFrqTransactionPayment::<Test>::from(tip);
+	let call: &<Test as Config>::RuntimeCall =
+		&RuntimeCall::Balances(BalancesCall::transfer { dest: 2, value: 100 });
+
+	let result = charge_tx_payment.tip(call);
+
+	assert_eq!(result, 200u64);
 }

--- a/runtime/frequency/src/lib.rs
+++ b/runtime/frequency/src/lib.rs
@@ -898,6 +898,7 @@ impl pallet_transaction_payment::Config for Runtime {
 impl pallet_frequency_tx_payment::Config for Runtime {
 	type RuntimeEvent = RuntimeEvent;
 	type RuntimeCall = RuntimeCall;
+	type Capacity = Capacity;
 }
 
 // See https://paritytech.github.io/substrate/master/pallet_parachain_system/index.html for


### PR DESCRIPTION
# Goal
Add the ability to use Capacity for transacting.

This implementation wraps the substrate transaction-payment
pallet, and it is used to toggle between token transactions
and capacity transactions.

When Capacity is used to transact, tipping is
set to zero regardless if a user attempts to tip
with Capacity. Token transaction tipping is
still supported.

Closes #1026 

https://www.loom.com/share/b0d3a0df837547dfa7b0195db51cd0e7
