### PR TITLE
chore(staking): add integration test

### DIFF
--- a/integration-tests/capacity/staking.test.ts
+++ b/integration-tests/capacity/staking.test.ts
@@ -17,9 +17,6 @@ describe.only("Capacity Scenario Tests", function () {
     let withdrawProviderId: u64;
 
     before(async function () {
-        log("*********************************")
-        log("********** BEGIN SETUP **********")
-        log("*********************************")
         // Set the Maximum Epoch Length to TEST_EPOCH_LENGTH blocks
         // This will allow us to test the epoch transition logic
         // without having to wait for 100 blocks
@@ -83,11 +80,6 @@ describe.only("Capacity Scenario Tests", function () {
             otherProviderId = providerEvent.data.providerId;
         }
         assert.notEqual(otherProviderId, undefined, "setup should populate providerId");
-
-        log("*********************************")
-        log("*********** END SETUP ***********")
-        log("*********************************\n\n")
-
     });
 
     describe("stake-unstake-withdraw_unstaked testing-->happy path", function () {
@@ -119,16 +111,10 @@ describe.only("Capacity Scenario Tests", function () {
                 assert.fail("setup should return an UnStaked event");
             }
 
-
-            log("*********************************")
-            log("*** Advance to the next Epoch ***")
-            log("*********************************")
+            // Mine enough blocks to pass the unstake period
             for (let index = 0; index < 2*TEST_EPOCH_LENGTH; index++) {
                 await ExtrinsicHelper.createBlock();
             }
-            log("*********************************")
-            log("*** mined %d blocks", TEST_EPOCH_LENGTH);
-            log("*********************************")
         });
         it("should successfully withdraw the unstaked amount", async function () {
             const withdrawObj = ExtrinsicHelper.withdrawUnstaked(stakeKeys);
@@ -147,7 +133,7 @@ describe.only("Capacity Scenario Tests", function () {
 
     describe("stake testing-invalid paths", function () {
         it("should fail to stake for InvalidTarget", async function () {
-            const failStakeObj = ExtrinsicHelper.stake(stakeKeys, 999999, 1000000);
+            const failStakeObj = ExtrinsicHelper.stake(stakeKeys, 99, 1000000);
             await assert.rejects(failStakeObj.fundAndSend(), { name: "InvalidTarget" });
         });
 

--- a/integration-tests/capacity/staking.test.ts
+++ b/integration-tests/capacity/staking.test.ts
@@ -1,11 +1,11 @@
 import "@frequency-chain/api-augment";
 import { KeyringPair } from "@polkadot/keyring/types";
-import { u16, u64 } from "@polkadot/types";
+import { u64 } from "@polkadot/types";
 import assert from "assert";
 import { ExtrinsicHelper } from "../scaffolding/extrinsicHelpers";
 import { devAccounts, createAndFundKeypair, log } from "../scaffolding/helpers";
 
-describe.only("Capacity Scenario Tests", function () {
+describe("Capacity Scenario Tests", function () {
     const TEST_EPOCH_LENGTH = 25;
     let otherProviderKeys: KeyringPair;
     let otherProviderId: u64;

--- a/integration-tests/capacity/staking.test.ts
+++ b/integration-tests/capacity/staking.test.ts
@@ -1,0 +1,186 @@
+import "@frequency-chain/api-augment";
+import { KeyringPair } from "@polkadot/keyring/types";
+import { u16, u64 } from "@polkadot/types";
+import assert from "assert";
+import { ExtrinsicHelper } from "../scaffolding/extrinsicHelpers";
+import { devAccounts, createAndFundKeypair, log } from "../scaffolding/helpers";
+
+describe.only("Capacity Scenario Tests", function () {
+    const TEST_EPOCH_LENGTH = 25;
+    let otherProviderKeys: KeyringPair;
+    let otherProviderId: u64;
+    let stakeKeys: KeyringPair;
+    let stakeProviderId: u64;
+    let unstakeKeys: KeyringPair;
+    let unstakeProviderId: u64;
+    let withdrawKeys: KeyringPair;
+    let withdrawProviderId: u64;
+
+    before(async function () {
+        log("*********************************")
+        log("********** BEGIN SETUP **********")
+        log("*********************************")
+        // Set the Maximum Epoch Length to TEST_EPOCH_LENGTH blocks
+        // This will allow us to test the epoch transition logic
+        // without having to wait for 100 blocks
+        let setEpochLengthOp = ExtrinsicHelper.setEpochLength(devAccounts[0].keys, TEST_EPOCH_LENGTH);
+        let [setEpochLengthEvent] = await setEpochLengthOp.sudoSignAndSend();
+        if (setEpochLengthEvent && 
+            ExtrinsicHelper.api.events.capacity.EpochLengthUpdated.is(setEpochLengthEvent)) {
+            let epochLength = setEpochLengthEvent.data.blocks;
+            assert.equal(epochLength.toNumber(), TEST_EPOCH_LENGTH, "setup should set epoch length to TEST_EPOCH_LENGTH blocks");
+        }
+        else {
+            assert.fail("setup should return an EpochLengthUpdated event");
+        }
+
+        // Create and fund a keypair with EXISTENTIAL_DEPOSIT
+        // Use this keypair for stake operations
+        stakeKeys = await createAndFundKeypair();
+        let createStakeProviderMsaOp = ExtrinsicHelper.createMsa(stakeKeys);
+        await createStakeProviderMsaOp.fundAndSend();
+        let createStakeProviderOp = ExtrinsicHelper.createProvider(stakeKeys, "TestProvider");
+        let [stakeProviderEvent] = await createStakeProviderOp.fundAndSend();
+        assert.notEqual(stakeProviderEvent, undefined, "setup should return a ProviderCreated event");
+        if (stakeProviderEvent && ExtrinsicHelper.api.events.msa.ProviderCreated.is(stakeProviderEvent)) {
+            stakeProviderId = stakeProviderEvent.data.providerId;
+        }
+        assert.notEqual(stakeProviderId, undefined, "setup should populate stakeProviderId");
+
+        // Create and fund a keypair with EXISTENTIAL_DEPOSIT
+        // Use this keypair for unstake operations
+        unstakeKeys = await createAndFundKeypair();
+        let createUnstakeProviderMsaOp = ExtrinsicHelper.createMsa(unstakeKeys);
+        await createUnstakeProviderMsaOp.fundAndSend();
+        let createUnstakeProviderOp = ExtrinsicHelper.createProvider(unstakeKeys, "TestProvider");
+        let [unstakeProviderEvent] = await createUnstakeProviderOp.fundAndSend();
+        assert.notEqual(unstakeProviderEvent, undefined, "setup should return a ProviderCreated event");
+        if (unstakeProviderEvent && ExtrinsicHelper.api.events.msa.ProviderCreated.is(unstakeProviderEvent)) {
+            unstakeProviderId = unstakeProviderEvent.data.providerId;
+        }
+        assert.notEqual(unstakeProviderId, undefined, "setup should populate unstakeProviderId");
+
+        // Create and fund a keypair with EXISTENTIAL_DEPOSIT
+        // Use this keypair for withdraw operations
+        withdrawKeys = await createAndFundKeypair();
+        let createWithdrawProviderMsaOp = ExtrinsicHelper.createMsa(withdrawKeys);
+        await createWithdrawProviderMsaOp.fundAndSend();
+        let createWithdrawProviderOp = ExtrinsicHelper.createProvider(withdrawKeys, "TestProvider");
+        let [withdrawProviderEvent] = await createWithdrawProviderOp.fundAndSend();
+        assert.notEqual(withdrawProviderEvent, undefined, "setup should return a ProviderCreated event");
+        if (withdrawProviderEvent && ExtrinsicHelper.api.events.msa.ProviderCreated.is(withdrawProviderEvent)) {
+            withdrawProviderId = withdrawProviderEvent.data.providerId;
+        }
+        assert.notEqual(withdrawProviderId, undefined, "setup should populate withdrawProviderId");
+
+        otherProviderKeys = await createAndFundKeypair();
+        let createProviderMsaOp = ExtrinsicHelper.createMsa(otherProviderKeys);
+        await createProviderMsaOp.fundAndSend();
+        let createProviderOp = ExtrinsicHelper.createProvider(otherProviderKeys, "TestProvider");
+        let [providerEvent] = await createProviderOp.fundAndSend();
+        assert.notEqual(providerEvent, undefined, "setup should return a ProviderCreated event");
+        if (providerEvent && ExtrinsicHelper.api.events.msa.ProviderCreated.is(providerEvent)) {
+            otherProviderId = providerEvent.data.providerId;
+        }
+        assert.notEqual(otherProviderId, undefined, "setup should populate providerId");
+
+        log("*********************************")
+        log("*********** END SETUP ***********")
+        log("*********************************\n\n")
+
+    });
+
+    describe("stake-unstake-withdraw_unstaked testing-->happy path", function () {
+
+        it("should successfully stake the minimum amount for Staked event", async function () {
+            const stakeObj = ExtrinsicHelper.stake(stakeKeys, stakeProviderId, 1000000);
+            const [stakeEvent] = await stakeObj.fundAndSend();
+            assert.notEqual(stakeEvent, undefined, "setup should return a Stake event");
+
+            if (stakeEvent && ExtrinsicHelper.api.events.capacity.Staked.is(stakeEvent)) {   
+                let stakedCapacity = stakeEvent.data.capacity;
+                assert.equal(stakedCapacity, 1000000, "setup should return a Stake event with 1000000 capacity");
+            }
+            else {
+                assert.fail("setup should return a Stake event");
+            }
+        });
+
+        it("should successfully unstake the minimum amount", async function () {
+            const stakeObj = ExtrinsicHelper.unstake(stakeKeys, stakeProviderId, 1000000);
+            const [unStakeEvent] = await stakeObj.fundAndSend();
+            assert.notEqual(unStakeEvent, undefined, "setup should return an UnStaked event");
+
+            if (unStakeEvent && ExtrinsicHelper.api.events.capacity.UnStaked.is(unStakeEvent)) {
+                let unstakedCapacity = unStakeEvent.data.capacity;
+                assert.equal(unstakedCapacity, 1000000, "setup should return an UnStaked event with 1000000 reduced capacity");
+            }
+            else {
+                assert.fail("setup should return an UnStaked event");
+            }
+
+
+            log("*********************************")
+            log("*** Advance to the next Epoch ***")
+            log("*********************************")
+            for (let index = 0; index < 2*TEST_EPOCH_LENGTH; index++) {
+                await ExtrinsicHelper.createBlock();
+            }
+            log("*********************************")
+            log("*** mined %d blocks", TEST_EPOCH_LENGTH);
+            log("*********************************")
+        });
+        it("should successfully withdraw the unstaked amount", async function () {
+            const withdrawObj = ExtrinsicHelper.withdrawUnstaked(stakeKeys);
+            const [withdrawEvent] = await withdrawObj.fundAndSend();
+            assert.notEqual(withdrawEvent, undefined, "setup should return a StakeWithdrawn event");
+
+            if (withdrawEvent && ExtrinsicHelper.api.events.capacity.StakeWithdrawn.is(withdrawEvent)) {
+                let amount = withdrawEvent.data.amount;
+                assert.equal(amount, 1000000, "setup should return a StakeWithdrawn event with 1000000 amount");
+            }
+            else {
+                assert.fail("setup should return a StakeWithdrawn event");
+            }
+        });
+    });
+
+    describe("stake testing-invalid paths", function () {
+        it("should fail to stake for InvalidTarget", async function () {
+            const failStakeObj = ExtrinsicHelper.stake(stakeKeys, 999999, 1000000);
+            await assert.rejects(failStakeObj.fundAndSend(), { name: "InvalidTarget" });
+        });
+
+        it("should fail to stake for InsufficientStakingAmount", async function () {
+            const failStakeObj = ExtrinsicHelper.stake(stakeKeys, stakeProviderId, 999999);
+            await assert.rejects(failStakeObj.fundAndSend(), { name: "InsufficientStakingAmount" });
+        });
+
+        it("should fail to stake for ZeroAmountNotAllowed", async function () {
+            const failStakeObj = ExtrinsicHelper.stake(stakeKeys, stakeProviderId, 0);
+            await assert.rejects(failStakeObj.fundAndSend(), { name: "ZeroAmountNotAllowed" });
+        });
+    });
+
+    describe("unstake testing", function () {   
+        it("should fail to unstake for UnstakedAmountIsZero", async function () {
+            const failUnstakeObj = ExtrinsicHelper.unstake(unstakeKeys, unstakeProviderId, 0);
+            await assert.rejects(failUnstakeObj.fundAndSend(), { name: "UnstakedAmountIsZero" });
+        });
+        it("should fail to unstake for StakingAccountNotFound", async function () {
+            const failUnstakeObj = ExtrinsicHelper.unstake(otherProviderKeys, unstakeProviderId, 1000000);
+            await assert.rejects(failUnstakeObj.fundAndSend(), { name: "StakingAccountNotFound" });
+        });
+    });
+
+    describe("withdraw_unstaked testing", function () {
+        it("should fail to withdraw the unstaked amount", async function () {
+            const stakeObj = ExtrinsicHelper.stake(withdrawKeys, withdrawProviderId, 1000000);
+            const [stakeEvent] = await stakeObj.fundAndSend();
+            assert.notEqual(stakeEvent, undefined, "setup should return a Stake event");
+
+            const withdrawObj = ExtrinsicHelper.withdrawUnstaked(withdrawKeys);
+            assert.rejects(withdrawObj.fundAndSend(), { name: "NoUnstakedTokensAvailable" });
+        });
+    });
+})

--- a/integration-tests/scaffolding/extrinsicHelpers.ts
+++ b/integration-tests/scaffolding/extrinsicHelpers.ts
@@ -7,7 +7,7 @@ import { AnyNumber, AnyTuple, Codec, IEvent, ISubmittableResult } from "@polkado
 import { firstValueFrom, filter, map, pipe, tap } from "rxjs";
 import { devAccounts, log, Sr25519Signature } from "./helpers";
 import { connect } from "./apiConnection";
-import { DispatchError, Event, SignedBlock } from "@polkadot/types/interfaces";
+import { CreatedBlock, DispatchError, Event, SignedBlock } from "@polkadot/types/interfaces";
 import { IsEvent } from "@polkadot/types/metadata/decorate/types";
 
 export type AddKeyData = { msaId?: u64; expiration?: any; newPublicKey?: any; }
@@ -164,6 +164,11 @@ export class ExtrinsicHelper {
         return firstValueFrom(ExtrinsicHelper.api.rpc.chain.getBlock());
     }
 
+    /** engine_createBlock **/
+    public static createBlock(): Promise<CreatedBlock> {
+        return firstValueFrom(ExtrinsicHelper.api.rpc.engine.createBlock(true, true));
+    }
+
     /** Query Extrinsics */
     public static getAccountInfo(address: string): Promise<FrameSystemAccountInfo> {
         return firstValueFrom(ExtrinsicHelper.api.query.system.account(address));
@@ -232,5 +237,21 @@ export class ExtrinsicHelper {
     /** Messages Extrinsics */
     public static addIPFSMessage(keys: KeyringPair, schemaId: any, cid: string, payload_length: number): Extrinsic {
         return new Extrinsic(() => ExtrinsicHelper.api.tx.messages.addIpfsMessage(schemaId, cid, payload_length), keys, ExtrinsicHelper.api.events.messages.MessagesStored);
+    }
+
+    /** Capacity Extrinsics **/
+    public static setEpochLength(keys: KeyringPair, epoch_length: any): Extrinsic {
+        return new Extrinsic(() => ExtrinsicHelper.api.tx.capacity.setEpochLength(epoch_length), keys, ExtrinsicHelper.api.events.capacity.EpochLengthUpdated);
+    }
+    public static stake(keys: KeyringPair, target: any, amount: any): Extrinsic {
+        return new Extrinsic(() => ExtrinsicHelper.api.tx.capacity.stake(target, amount), keys, ExtrinsicHelper.api.events.capacity.Staked);
+    }
+
+    public static unstake(keys: KeyringPair, target: any, amount: any): Extrinsic {
+        return new Extrinsic(() => ExtrinsicHelper.api.tx.capacity.unstake(target, amount), keys, ExtrinsicHelper.api.events.capacity.UnStaked);
+    }
+
+    public static withdrawUnstaked(keys: KeyringPair): Extrinsic {
+        return new Extrinsic(() => ExtrinsicHelper.api.tx.capacity.withdrawUnstaked(), keys, ExtrinsicHelper.api.events.capacity.StakeWithdrawn);
     }
 }


### PR DESCRIPTION
# Goal
Get happy-path working; mine blocks to move the epoch forward

Description:
Write integration tests for the lifecycle of staking testing the "happy path"

- [x] Staker should be able stake tokens and target a provider to be issued capacity
--- ensure the provider capacity has been issued

- [x] Staker should be able to un-stake (submit a process of retracting their tokens)
--- and ensure the provider capacity has been reduced

- [x] Staker should be able to withdrawal the amount that was un-staked
--- Staker tokens are unlocked (should be able to use the retuned funds)

- [ ] A user should be able to increase a staking amount and target the same provider after initial stake has taken place
-- A user staking account is updated and it has been increased and the correct amount
-- Check capacity has also been increased for the target

- [ ] A staker should be able to increase a staking amount and target the dif provider after initial stake has taken place
-- A user staking account is updated and it has been increased and the correct amount on the dif provider
-- Check capacity has also been increased for the dif provider

Error returns should represent the errors thrown

- [x] when a user attempts to stake to a un-registered provider it should throw an InvalidTarget
- [x] when a user attempts to stake below an amount below the min stake amount it should error with InsufficientStakingAmount
- [x] when a user attempts to stake an amount 0 it should error with ZeroAmountNotAllowed

Relates to #888 
