### PR TITLE
Feat/whitelist capacity eligible calls #1013

### DIFF
--- a/pallets/frequency-tx-payment/src/lib.rs
+++ b/pallets/frequency-tx-payment/src/lib.rs
@@ -157,12 +157,6 @@ pub mod pallet {
 		type CapacityEligibleCalls: Contains<<Self as Config>::RuntimeCall>;
 	}
 
-	#[pallet::error]
-	pub enum Error<T> {
-		/// Attempted to pay for the extrinsic with Capacity, when it is not a Capacity Eligible Call.
-		CallIsNotCapacityEligible,
-	}
-
 	#[pallet::event]
 	#[pallet::generate_deposit(pub(super) fn deposit_event)]
 	pub enum Event<T: Config> {}
@@ -186,6 +180,12 @@ pub mod pallet {
 			Ok(())
 		}
 	}
+}
+
+/// Custom Transaction Validity Errors for ChargeFrqTransactionPayment
+pub enum ChargeFrqTransactionPaymentError {
+	/// The call is not eligible to be paid for with Capacity
+	CallIsNotCapacityEligible,
 }
 
 /// Require the transactor pay for themselves and maybe include a tip to gain additional priority
@@ -246,7 +246,9 @@ where
 
 					Ok((fee, InitialPayment::Capacity))
 				} else {
-					Err(TransactionValidityError::Invalid(InvalidTransaction::Call))
+					Err(TransactionValidityError::Invalid(InvalidTransaction::Custom(
+						ChargeFrqTransactionPaymentError::CallIsNotCapacityEligible as u8,
+					)))
 				}
 			},
 			_ => {

--- a/pallets/frequency-tx-payment/src/lib.rs
+++ b/pallets/frequency-tx-payment/src/lib.rs
@@ -127,6 +127,7 @@ pub use pallet::*;
 #[frame_support::pallet]
 pub mod pallet {
 	use super::*;
+	use frame_support::traits::Contains;
 
 	// Simple declaration of the `Pallet` type. It is placeholder we use to implement traits and
 	// method.
@@ -153,6 +154,7 @@ pub mod pallet {
 
 		/// Weight information for extrinsics in this pallet.
 		type WeightInfo: WeightInfo;
+		type CapacityEligibleCalls: Contains<<Self as frame_system::Config>::RuntimeCall>;
 	}
 
 	#[pallet::event]
@@ -321,6 +323,12 @@ where
 		let (_fee, initial_payment) = self.withdraw_fee(who, call, info, len)?;
 
 		Ok((self.tip(call), who.clone(), initial_payment))
+		// 		if <T as Config>::CapacityEligibleCalls::contains(call) {
+		// 			log::debug!("this is a capacity eligible call");
+		// 			Ok(result)
+		// 		} else {
+		// 			Err(TransactionValidityError::Invalid(InvalidTransaction::Call))
+		// 		}
 	}
 
 	/// Do any post-flight stuff for an extrinsic.

--- a/pallets/frequency-tx-payment/src/mock.rs
+++ b/pallets/frequency-tx-payment/src/mock.rs
@@ -17,7 +17,7 @@ use sp_runtime::{
 
 use frame_support::{
 	parameter_types,
-	traits::{ConstU16, ConstU64},
+	traits::{ConstU16, ConstU64, Contains},
 	weights::WeightToFee as WeightToFeeTrait,
 };
 
@@ -226,11 +226,27 @@ impl pallet_capacity::Config for Test {
 	type EpochNumber = u32;
 }
 
+use pallet_balances::Call as BalancesCall;
+
+pub struct TestCapacityCalls;
+
+impl Contains<RuntimeCall> for TestCapacityCalls {
+	fn contains(call: &RuntimeCall) -> bool {
+		{
+			match call {
+				RuntimeCall::Balances(BalancesCall::transfer { .. }) => true, // for testing only
+				_ => false,
+			}
+		}
+	}
+}
+
 impl Config for Test {
 	type RuntimeEvent = RuntimeEvent;
 	type RuntimeCall = RuntimeCall;
 	type Capacity = Capacity;
 	type WeightInfo = ();
+	type CapacityEligibleCalls = TestCapacityCalls;
 }
 
 pub struct ExtBuilder {

--- a/pallets/frequency-tx-payment/src/mock.rs
+++ b/pallets/frequency-tx-payment/src/mock.rs
@@ -229,7 +229,6 @@ impl pallet_capacity::Config for Test {
 use pallet_balances::Call as BalancesCall;
 
 pub struct TestCapacityCalls;
-
 impl Contains<RuntimeCall> for TestCapacityCalls {
 	fn contains(call: &RuntimeCall) -> bool {
 		{

--- a/pallets/frequency-tx-payment/src/tests.rs
+++ b/pallets/frequency-tx-payment/src/tests.rs
@@ -458,9 +458,10 @@ fn withdraw_fee_allows_only_configured_capacity_calls() {
 				&RuntimeCall::Balances(BalancesCall::transfer_all { dest: 2, keep_alive: false });
 
 			assert_withdraw_fee_result(allowed_call, None);
-			assert_withdraw_fee_result(
-				forbidden_call,
-				Some(TransactionValidityError::Invalid(InvalidTransaction::Call)),
-			);
+
+			let expected_err = TransactionValidityError::Invalid(InvalidTransaction::Custom(
+				ChargeFrqTransactionPaymentError::CallIsNotCapacityEligible as u8,
+			));
+			assert_withdraw_fee_result(forbidden_call, Some(expected_err));
 		});
 }

--- a/pallets/frequency-tx-payment/src/tests.rs
+++ b/pallets/frequency-tx-payment/src/tests.rs
@@ -415,8 +415,35 @@ fn charge_frq_transaction_payment_tip_is_some_amount_for_non_capacity_calls() {
 
 	assert_eq!(result, 200u64);
 }
+
+pub fn assert_withdraw_fee_result(
+	call: &<Test as Config>::RuntimeCall,
+	expected_err: Option<TransactionValidityError>,
+) {
+	let account_id = 1u64;
+	let dispatch_info = DispatchInfo { weight: Weight::from_ref_time(5), ..Default::default() };
+
+	let call: &<Test as Config>::RuntimeCall =
+		&RuntimeCall::FrequencyTxPayment(Call::pay_with_capacity { call: Box::new(call.clone()) });
+
+	let withdraw_fee = ChargeFrqTransactionPayment::<Test>::from(0u64).withdraw_fee(
+		&account_id,
+		call,
+		&dispatch_info,
+		10,
+	);
+
+	match expected_err {
+		None => assert!(withdraw_fee.is_ok()),
+		Some(err) => {
+			assert!(withdraw_fee.is_err());
+			assert_eq!(err, withdraw_fee.err().unwrap())
+		},
+	}
+}
+
 #[test]
-fn call_filtering_allows_only_what_is_in_config() {
+fn withdraw_fee_allows_only_configured_capacity_calls() {
 	let balance_factor = 10;
 
 	ExtBuilder::default()
@@ -424,14 +451,14 @@ fn call_filtering_allows_only_what_is_in_config() {
 		.base_weight(Weight::from_ref_time(5))
 		.build()
 		.execute_with(|| {
-			let allowed_call: &<Test as SystemConfig>::RuntimeCall =
+			let allowed_call: &<Test as Config>::RuntimeCall =
 				&RuntimeCall::Balances(BalancesCall::transfer { dest: 2, value: 100 });
 
-			let forbidden_call: &<Test as SystemConfig>::RuntimeCall =
+			let forbidden_call: &<Test as Config>::RuntimeCall =
 				&RuntimeCall::Balances(BalancesCall::transfer_all { dest: 2, keep_alive: false });
 
-			assert_pre_dispatch_result(allowed_call, None);
-			assert_pre_dispatch_result(
+			assert_withdraw_fee_result(allowed_call, None);
+			assert_withdraw_fee_result(
 				forbidden_call,
 				Some(TransactionValidityError::Invalid(InvalidTransaction::Call)),
 			);

--- a/runtime/frequency/src/lib.rs
+++ b/runtime/frequency/src/lib.rs
@@ -895,11 +895,31 @@ impl pallet_transaction_payment::Config for Runtime {
 	type OperationalFeeMultiplier = TransactionPaymentOperationalFeeMultiplier;
 }
 
+use pallet_messages::Call as MessagesCall;
+use pallet_msa::Call as MsaCall;
+pub struct CapacityEligibleCalls;
+impl Contains<RuntimeCall> for CapacityEligibleCalls {
+	fn contains(call: &RuntimeCall) -> bool {
+		{
+			match call {
+				RuntimeCall::Msa(MsaCall::create_sponsored_account_with_delegation { .. }) => true,
+				RuntimeCall::Msa(MsaCall::add_public_key_to_msa { .. }) => true,
+				RuntimeCall::Msa(MsaCall::grant_delegation { .. }) => true,
+				RuntimeCall::Msa(MsaCall::grant_schema_permissions { .. }) => true,
+				RuntimeCall::Messages(MessagesCall::add_ipfs_message { .. }) => true,
+				RuntimeCall::Messages(MessagesCall::add_onchain_message { .. }) => true,
+				_ => false,
+			}
+		}
+	}
+}
+
 impl pallet_frequency_tx_payment::Config for Runtime {
 	type RuntimeEvent = RuntimeEvent;
 	type RuntimeCall = RuntimeCall;
 	type Capacity = Capacity;
 	type WeightInfo = pallet_frequency_tx_payment::weights::SubstrateWeight<Runtime>;
+	type CapacityEligibleCalls = CapacityEligibleCalls;
 }
 
 // See https://paritytech.github.io/substrate/master/pallet_parachain_system/index.html for


### PR DESCRIPTION
## Goal
The goal of this PR is to set up a whitelist of transactions that are eligible to be paid for with Capacity.

Closes #1013 

## Discussion
Once I realized this would work if it were set up like `BaseCallFilter` it was pretty easy to make a Config in the pallet that only needs to implement the `Contains` trait.  So we simply construct a list of call signatures to match against for a given runtime.  Then we apply the whitelist in `withdraw_fee`.

## Checklist
- [x] New Config for whitelist
- [x] New Error for when an extrinsic is called but isn't eligible to be paid for with Capacity
- [x] Tests added
- [x] Msa::create_sponsored_account_with_delegation(...)
- [x] Msa::add_public_key_to_msa(...)
- [x] Msa::grant_delegation(...)
- [x] Msa:: grant_schema_permissions(...)
- [x] Messages:: add_onchain_message(...)
- [x] Messages::add_ipfs_message(...)

## N/A
- Chain spec updated
- Custom RPC OR Runtime API added/changed? Updated js/api-augment.
- Design doc(s) updated
- Benchmarks added
- Weights updated
