### PR TITLE
Emit an event when capacity is withdrawn

### DIFF
--- a/designdocs/capacity.md
+++ b/designdocs/capacity.md
@@ -239,6 +239,20 @@ pub enum Event<T: Config> {
     /// An amount that was withdrawn.
     amount: BalanceOf<T>
   }
+
+  /// The Capacity epoch length was changed.
+  EpochLengthUpdated {
+    /// The new length of an epoch in blocks.
+    blocks: T::BlockNumber,
+  },
+
+  /// Capacity has been withdrawn from a MessageSourceId.
+  CapacityWithdrawn {
+    /// The MSA from which Capacity has been withdrawn.
+    msa_id: MessageSourceId,
+    /// The amount of Capacity withdrawn from MSA.
+    amount: BalanceOf<T>,
+  }
 }
 
 ```

--- a/pallets/capacity/src/helpers_tests.rs
+++ b/pallets/capacity/src/helpers_tests.rs
@@ -2,7 +2,7 @@ use super::*;
 use crate as pallet_capacity;
 use crate::mock::*;
 use frame_support::{assert_noop, assert_ok};
-use testing_utils::{create_capacity_account_and_fund, register_provider};
+use testing_utils::{create_capacity_account_and_fund, register_provider, staking_events};
 
 struct TestCase<T: Config> {
 	name: &'static str,
@@ -306,6 +306,15 @@ fn impl_withdraw_is_successful() {
 		);
 
 		assert_ok!(Capacity::withdraw(target_msa_id, 5u32.into()));
+		let events = staking_events();
+
+		assert_eq!(
+			events.last().unwrap(),
+			&Event::CapacityWithdrawn {
+				msa_id: target_msa_id,
+				amount: 5u32.into(),
+			}
+		);
 
 		let mut capacity_details =
 			CapacityDetails::<BalanceOf<Test>, <Test as Config>::EpochNumber>::default();

--- a/pallets/capacity/src/helpers_tests.rs
+++ b/pallets/capacity/src/helpers_tests.rs
@@ -310,10 +310,7 @@ fn impl_withdraw_is_successful() {
 
 		assert_eq!(
 			events.last().unwrap(),
-			&Event::CapacityWithdrawn {
-				msa_id: target_msa_id,
-				amount: 5u32.into(),
-			}
+			&Event::CapacityWithdrawn { msa_id: target_msa_id, amount: 5u32.into() }
 		);
 
 		let mut capacity_details =

--- a/pallets/capacity/src/lib.rs
+++ b/pallets/capacity/src/lib.rs
@@ -250,6 +250,13 @@ pub mod pallet {
 			/// The new length of an epoch in blocks.
 			blocks: T::BlockNumber,
 		},
+		/// Capacity has been withdrawn from a MessageSourceId.
+		CapacityWithdrawn {
+			/// The MSA from which Capacity has been withdrawn.
+			msa_id: MessageSourceId,
+			/// The amount of Capacity withdrawn from MSA.
+			amount: BalanceOf<T>,
+		}
 	}
 
 	#[pallet::error]
@@ -601,6 +608,8 @@ impl<T: Config> Nontransferable for Pallet<T> {
 			.ok_or(Error::<T>::InsufficientBalance)?;
 
 		Self::set_capacity_for(msa_id, capacity_details);
+
+		Self::deposit_event(Event::CapacityWithdrawn { msa_id: msa_id, amount: amount });
 		Ok(())
 	}
 

--- a/pallets/capacity/src/lib.rs
+++ b/pallets/capacity/src/lib.rs
@@ -256,7 +256,7 @@ pub mod pallet {
 			msa_id: MessageSourceId,
 			/// The amount of Capacity withdrawn from MSA.
 			amount: BalanceOf<T>,
-		}
+		},
 	}
 
 	#[pallet::error]
@@ -609,7 +609,7 @@ impl<T: Config> Nontransferable for Pallet<T> {
 
 		Self::set_capacity_for(msa_id, capacity_details);
 
-		Self::deposit_event(Event::CapacityWithdrawn { msa_id: msa_id, amount: amount });
+		Self::deposit_event(Event::CapacityWithdrawn { msa_id, amount });
 		Ok(())
 	}
 


### PR DESCRIPTION
# Goal
The goal of this PR is to emit the `CapacityWithdrawn` event when capacity is withdrawn from an MSA's capacity account.

Closes #1094