### PR TITLE
Chore/capacity custom error messages

### DIFF
--- a/pallets/frequency-tx-payment/src/lib.rs
+++ b/pallets/frequency-tx-payment/src/lib.rs
@@ -186,6 +186,8 @@ pub mod pallet {
 pub enum ChargeFrqTransactionPaymentError {
 	/// The call is not eligible to be paid for with Capacity
 	CallIsNotCapacityEligible,
+	/// The account key is not associated with an MSA
+	InvalidMsaKey,
 }
 
 /// Require the transactor pay for themselves and maybe include a tip to gain additional priority
@@ -237,7 +239,7 @@ where
 				use frame_support::traits::Contains;
 				if <T as Config>::CapacityEligibleCalls::contains(call.as_ref()) {
 					let msa_id = pallet_msa::Pallet::<T>::ensure_valid_msa_key(who).map_err(
-						|_| -> TransactionValidityError { InvalidTransaction::Payment.into() },
+						|_| -> TransactionValidityError { InvalidTransaction::Custom(ChargeFrqTransactionPaymentError::InvalidMsaKey as u8).into() },
 					)?;
 
 					T::Capacity::withdraw(msa_id, fee.into()).map_err(

--- a/pallets/frequency-tx-payment/src/lib.rs
+++ b/pallets/frequency-tx-payment/src/lib.rs
@@ -239,7 +239,12 @@ where
 				use frame_support::traits::Contains;
 				if <T as Config>::CapacityEligibleCalls::contains(call.as_ref()) {
 					let msa_id = pallet_msa::Pallet::<T>::ensure_valid_msa_key(who).map_err(
-						|_| -> TransactionValidityError { InvalidTransaction::Custom(ChargeFrqTransactionPaymentError::InvalidMsaKey as u8).into() },
+						|_| -> TransactionValidityError {
+							InvalidTransaction::Custom(
+								ChargeFrqTransactionPaymentError::InvalidMsaKey as u8,
+							)
+							.into()
+						},
 					)?;
 
 					T::Capacity::withdraw(msa_id, fee.into()).map_err(

--- a/pallets/frequency-tx-payment/src/tests.rs
+++ b/pallets/frequency-tx-payment/src/tests.rs
@@ -484,6 +484,10 @@ fn withdraw_fee_returns_custom_error_when_the_account_key_is_not_associated_with
 			let expected_err = TransactionValidityError::Invalid(InvalidTransaction::Custom(
 				ChargeFrqTransactionPaymentError::InvalidMsaKey as u8,
 			));
-			assert_withdraw_fee_result(account_id_not_associated_with_msa, call, Some(expected_err));
+			assert_withdraw_fee_result(
+				account_id_not_associated_with_msa,
+				call,
+				Some(expected_err),
+			);
 		});
 }

--- a/pallets/frequency-tx-payment/src/tests.rs
+++ b/pallets/frequency-tx-payment/src/tests.rs
@@ -417,10 +417,10 @@ fn charge_frq_transaction_payment_tip_is_some_amount_for_non_capacity_calls() {
 }
 
 pub fn assert_withdraw_fee_result(
+	account_id: <Test as frame_system::Config>::AccountId,
 	call: &<Test as Config>::RuntimeCall,
 	expected_err: Option<TransactionValidityError>,
 ) {
-	let account_id = 1u64;
 	let dispatch_info = DispatchInfo { weight: Weight::from_ref_time(5), ..Default::default() };
 
 	let call: &<Test as Config>::RuntimeCall =
@@ -451,17 +451,39 @@ fn withdraw_fee_allows_only_configured_capacity_calls() {
 		.base_weight(Weight::from_ref_time(5))
 		.build()
 		.execute_with(|| {
+			let account_id = 1u64;
 			let allowed_call: &<Test as Config>::RuntimeCall =
 				&RuntimeCall::Balances(BalancesCall::transfer { dest: 2, value: 100 });
 
 			let forbidden_call: &<Test as Config>::RuntimeCall =
 				&RuntimeCall::Balances(BalancesCall::transfer_all { dest: 2, keep_alive: false });
 
-			assert_withdraw_fee_result(allowed_call, None);
+			assert_withdraw_fee_result(account_id, allowed_call, None);
 
 			let expected_err = TransactionValidityError::Invalid(InvalidTransaction::Custom(
 				ChargeFrqTransactionPaymentError::CallIsNotCapacityEligible as u8,
 			));
-			assert_withdraw_fee_result(forbidden_call, Some(expected_err));
+			assert_withdraw_fee_result(account_id, forbidden_call, Some(expected_err));
+		});
+}
+
+#[test]
+fn withdraw_fee_returns_custom_error_when_the_account_key_is_not_associated_with_an_msa() {
+	let balance_factor = 10;
+
+	ExtBuilder::default()
+		.balance_factor(balance_factor)
+		.base_weight(Weight::from_ref_time(5))
+		.build()
+		.execute_with(|| {
+			let account_id_not_associated_with_msa = 10u64;
+
+			let call: &<Test as Config>::RuntimeCall =
+				&RuntimeCall::Balances(BalancesCall::transfer { dest: 2, value: 100 });
+
+			let expected_err = TransactionValidityError::Invalid(InvalidTransaction::Custom(
+				ChargeFrqTransactionPaymentError::InvalidMsaKey as u8,
+			));
+			assert_withdraw_fee_result(account_id_not_associated_with_msa, call, Some(expected_err));
 		});
 }

--- a/runtime/frequency/src/lib.rs
+++ b/runtime/frequency/src/lib.rs
@@ -425,7 +425,7 @@ pub const VERSION: RuntimeVersion = RuntimeVersion {
 	spec_name: spec_name!("frequency"),
 	impl_name: create_runtime_str!("frequency"),
 	authoring_version: 1,
-	spec_version: 18,
+	spec_version: 19,
 	impl_version: 0,
 	apis: RUNTIME_API_VERSIONS,
 	transaction_version: 1,


### PR DESCRIPTION
# Goal
The goal of this PR is to return a custom `TransactionValidityError`, `ChargeFrqTransactionPaymentError::InvalidMsaKey`  when attempting to withdraw capacity with an account key that has no associated MSA.

Closes #1027