### PR TITLE
Chore/renames and fix bug

### DIFF
--- a/common/primitives/src/capacity.rs
+++ b/common/primitives/src/capacity.rs
@@ -24,7 +24,7 @@ pub trait Nontransferable {
 	fn balance(msa_id: MessageSourceId) -> Self::Balance;
 
 	/// Reduce Capacity of an MSA account by amount.
-	fn withdraw(msa_id: MessageSourceId, amount: Self::Balance) -> Result<(), DispatchError>;
+	fn deduct(msa_id: MessageSourceId, amount: Self::Balance) -> Result<(), DispatchError>;
 
 	/// Increase Capacity of an MSA account by an amount.
 	fn deposit(msa_id: MessageSourceId, amount: Self::Balance) -> Result<(), DispatchError>;

--- a/designdocs/capacity.md
+++ b/designdocs/capacity.md
@@ -453,10 +453,10 @@ trait Replenishable {
   type Balance;
 
   /// Replenish an MSA's Capacity by an amount.
-  fn replenish_by_account(msa_id: MessageSourceId, amount: Balance) -> Result<Balance, DispatchError> {};
+  fn replenish_by_amount(msa_id: MessageSourceId, amount: Balance) -> Result<Balance, DispatchError> {};
 
   /// Replenish all Capacity balance for an MSA.
-  fn replenish_all_for_account(msa_id: MessageSourceId) -> Result<Balance, DispatchError>;
+  fn replenish_all_for(msa_id: MessageSourceId) -> Result<Balance, DispatchError>;
 
   /// Checks if an account can be replenished.
   fn can_replenish(msa_id: MessageSourceId) -> bool;

--- a/designdocs/capacity.md
+++ b/designdocs/capacity.md
@@ -398,13 +398,13 @@ traits Nontransferable {
   type Balance;
 
   /// The available Capacity for an MSA account.
-  fn available(msa_id: MessageSourceId) -> Result<Balance, DispatchError>;
+  fn balance(msa_id: MessageSourceId) -> Result<Balance, DispatchError>;
 
   /// Reduce the available Capacity of an MSA account.
-  fn reduce_available(msa_id: MessageSourceId, amount: Balance) -> Result<Balance, DispatchError>;
+  fn deduct(msa_id: MessageSourceId, amount: Balance) -> Result<Balance, DispatchError>;
 
   /// Increase the available Capacity for an MSA account.
-  fn increase_available(msa_id: MessageSourceId, amount: Balance) -> Result<Balance, DispatchError>;
+  fn deposit(msa_id: MessageSourceId, amount: Balance) -> Result<Balance, DispatchError>;
 }
 
 ```

--- a/pallets/capacity/src/benchmarking.rs
+++ b/pallets/capacity/src/benchmarking.rs
@@ -97,7 +97,7 @@ benchmarks! {
 
 		staking_account.deposit(staking_amount);
 		target_details.deposit(staking_amount, capacity_amount);
-		capacity_details.deposit(capacity_amount, block_number.into());
+		capacity_details.deposit(&capacity_amount);
 
 		Capacity::<T>::set_staking_account(&caller.clone(), &staking_account);
 		Capacity::<T>::set_target_details_for(&caller.clone(), target, target_details);

--- a/pallets/capacity/src/extrinsics_tests.rs
+++ b/pallets/capacity/src/extrinsics_tests.rs
@@ -155,8 +155,8 @@ fn stake_works() {
 		assert_eq!(Capacity::get_target_for(account, target).unwrap().capacity, amount);
 
 		// Check that CapacityLedger is updated.
-		assert_eq!(Capacity::get_capacity_for(target).unwrap().remaining, amount);
-		assert_eq!(Capacity::get_capacity_for(target).unwrap().total_available, amount);
+		assert_eq!(Capacity::get_capacity_for(target).unwrap().remaining_capacity, amount);
+		assert_eq!(Capacity::get_capacity_for(target).unwrap().total_capacity_issued, amount);
 		assert_eq!(Capacity::get_capacity_for(target).unwrap().last_replenished_epoch, 0);
 
 		let events = staking_events();
@@ -247,9 +247,9 @@ fn stake_increase_stake_amount_works() {
 		assert_eq!(Capacity::get_target_for(account, target).unwrap().capacity, 15);
 
 		// Check that CapacityLedger is updated.
-		assert_eq!(Capacity::get_capacity_for(target).unwrap().remaining, 15);
-		assert_eq!(Capacity::get_capacity_for(target).unwrap().total_available, 15);
-		assert_eq!(Capacity::get_capacity_for(target).unwrap().last_replenished_epoch, 2);
+		assert_eq!(Capacity::get_capacity_for(target).unwrap().remaining_capacity, 15);
+		assert_eq!(Capacity::get_capacity_for(target).unwrap().total_capacity_issued, 15);
+		assert_eq!(Capacity::get_capacity_for(target).unwrap().last_replenished_epoch, 0);
 
 		let events = staking_events();
 		assert_eq!(
@@ -283,8 +283,8 @@ fn stake_multiple_accounts_can_stake_to_the_same_target() {
 			assert_eq!(Capacity::get_target_for(account_1, target).unwrap().capacity, 5);
 
 			// Check that CapacityLedger is updated.
-			assert_eq!(Capacity::get_capacity_for(target).unwrap().remaining, 5);
-			assert_eq!(Capacity::get_capacity_for(target).unwrap().total_available, 5);
+			assert_eq!(Capacity::get_capacity_for(target).unwrap().remaining_capacity, 5);
+			assert_eq!(Capacity::get_capacity_for(target).unwrap().total_capacity_issued, 5);
 			assert_eq!(Capacity::get_capacity_for(target).unwrap().last_replenished_epoch, 0);
 
 			assert_ok!(Capacity::set_epoch_length(RuntimeOrigin::root(), 10));
@@ -307,9 +307,9 @@ fn stake_multiple_accounts_can_stake_to_the_same_target() {
 			assert_eq!(Capacity::get_target_for(account_2, target).unwrap().capacity, 10);
 
 			// Check that CapacityLedger is updated.
-			assert_eq!(Capacity::get_capacity_for(target).unwrap().remaining, 15);
-			assert_eq!(Capacity::get_capacity_for(target).unwrap().total_available, 15);
-			assert_eq!(Capacity::get_capacity_for(target).unwrap().last_replenished_epoch, 2);
+			assert_eq!(Capacity::get_capacity_for(target).unwrap().remaining_capacity, 15);
+			assert_eq!(Capacity::get_capacity_for(target).unwrap().total_capacity_issued, 15);
+			assert_eq!(Capacity::get_capacity_for(target).unwrap().last_replenished_epoch, 0);
 		});
 	});
 }
@@ -349,14 +349,14 @@ fn stake_an_account_can_stake_to_multiple_targets() {
 		assert_eq!(Capacity::get_target_for(account, target_2).unwrap().capacity, 7);
 
 		// Check that CapacityLedger is updated for target 1.
-		assert_eq!(Capacity::get_capacity_for(target_1).unwrap().remaining, 10);
-		assert_eq!(Capacity::get_capacity_for(target_1).unwrap().total_available, 10);
+		assert_eq!(Capacity::get_capacity_for(target_1).unwrap().remaining_capacity, 10);
+		assert_eq!(Capacity::get_capacity_for(target_1).unwrap().total_capacity_issued, 10);
 		assert_eq!(Capacity::get_capacity_for(target_1).unwrap().last_replenished_epoch, 0);
 
 		// Check that CapacityLedger is updated for target 2.
-		assert_eq!(Capacity::get_capacity_for(target_2).unwrap().remaining, 7);
-		assert_eq!(Capacity::get_capacity_for(target_2).unwrap().total_available, 7);
-		assert_eq!(Capacity::get_capacity_for(target_2).unwrap().last_replenished_epoch, 2);
+		assert_eq!(Capacity::get_capacity_for(target_2).unwrap().remaining_capacity, 7);
+		assert_eq!(Capacity::get_capacity_for(target_2).unwrap().total_capacity_issued, 7);
+		assert_eq!(Capacity::get_capacity_for(target_2).unwrap().last_replenished_epoch, 0);
 	});
 }
 
@@ -381,8 +381,8 @@ fn stake_when_staking_amount_is_greater_than_free_balance_it_stakes_maximum() {
 		assert_eq!(Capacity::get_target_for(account, target).unwrap().capacity, 10);
 
 		// Check that CapacityLedger is updated.
-		assert_eq!(Capacity::get_capacity_for(target).unwrap().remaining, 10);
-		assert_eq!(Capacity::get_capacity_for(target).unwrap().total_available, 10);
+		assert_eq!(Capacity::get_capacity_for(target).unwrap().remaining_capacity, 10);
+		assert_eq!(Capacity::get_capacity_for(target).unwrap().total_capacity_issued, 10);
 		assert_eq!(Capacity::get_capacity_for(target).unwrap().last_replenished_epoch, 0);
 	});
 }
@@ -440,9 +440,9 @@ fn unstake_happy_path() {
 		assert_eq!(
 			capacity_details,
 			CapacityDetails::<BalanceOf<Test>, <Test as Config>::EpochNumber> {
-				remaining: BalanceOf::<Test>::from(10u64),
+				remaining_capacity: BalanceOf::<Test>::from(10u64),
 				total_tokens_staked: BalanceOf::<Test>::from(6u64),
-				total_available: BalanceOf::<Test>::from(6u64),
+				total_capacity_issued: BalanceOf::<Test>::from(6u64),
 				last_replenished_epoch: <Test as Config>::EpochNumber::from(0u32),
 			}
 		);

--- a/pallets/capacity/src/testing_utils.rs
+++ b/pallets/capacity/src/testing_utils.rs
@@ -42,10 +42,10 @@ pub fn create_capacity_account_and_fund(
 	let mut capacity_details =
 		CapacityDetails::<BalanceOf<Test>, <Test as Config>::EpochNumber>::default();
 
-	capacity_details.remaining = remaining;
+	capacity_details.remaining_capacity = remaining;
 	capacity_details.total_tokens_staked = available;
-	capacity_details.total_available = available;
-	capacity_details.last_replenished_epoch = last_replenished.into();
+	capacity_details.total_capacity_issued = available;
+	capacity_details.last_replenished_epoch = last_replenished;
 
 	Capacity::set_capacity_for(target_msa_id, capacity_details.clone());
 

--- a/pallets/capacity/src/types.rs
+++ b/pallets/capacity/src/types.rs
@@ -179,7 +179,7 @@ where
 		self.total_capacity_issued = amount.checked_add(&self.total_capacity_issued)?;
 
 		// We do not touch last_replenished epoch here, because it would create a DoS vulnerability.
-		// Somce capacity is lazily replenished, an attacker could stake
+		// Since capacity is lazily replenished, an attacker could stake
 		// a minimum amount, then at the very beginning of each epoch, stake a tiny additional amount,
 		// thus preventing replenishment when "last_replenished_at" is checked on the next provider's
 		// message.

--- a/pallets/capacity/src/types.rs
+++ b/pallets/capacity/src/types.rs
@@ -158,40 +158,73 @@ impl<Balance: Saturating + Copy + CheckedAdd> StakingTargetDetails<Balance> {
 #[derive(PartialEq, Eq, Clone, Default, Encode, Decode, RuntimeDebug, TypeInfo, MaxEncodedLen)]
 pub struct CapacityDetails<Balance, EpochNumber> {
 	/// The Capacity remaining for the `last_replenished_epoch`.
-	pub remaining: Balance,
+	pub remaining_capacity: Balance,
 	/// The amount of tokens staked to an MSA.
 	pub total_tokens_staked: Balance,
 	/// The total Capacity issued to an MSA.
-	pub total_available: Balance,
+	pub total_capacity_issued: Balance,
 	/// The last Epoch that an MSA was replenished with Capacity.
 	pub last_replenished_epoch: EpochNumber,
 }
 
-impl<Balance: Saturating + Copy + CheckedAdd, EpochNumber> CapacityDetails<Balance, EpochNumber> {
-	/// Increase a targets Capacity balance by an amount.
-	pub fn deposit(&mut self, amount: Balance, replenish_at: EpochNumber) -> Option<()> {
-		self.remaining = amount.checked_add(&self.remaining)?;
+impl<Balance, EpochNumber> CapacityDetails<Balance, EpochNumber>
+where
+	Balance: Saturating + Copy + CheckedAdd + CheckedSub,
+	EpochNumber: Clone + PartialOrd + PartialEq,
+{
+	/// Increase a targets total Tokens staked and Capacity total issuance by an amount.
+	pub fn deposit(&mut self, amount: &Balance) -> Option<()> {
+		self.remaining_capacity = amount.checked_add(&self.remaining_capacity)?;
 		self.total_tokens_staked = amount.checked_add(&self.total_tokens_staked)?;
-		self.total_available = amount.checked_add(&self.total_available)?;
-		self.last_replenished_epoch = replenish_at;
+		self.total_capacity_issued = amount.checked_add(&self.total_capacity_issued)?;
 
+		// We do not touch last_replenished epoch here, because it would create a DoS vulnerability.
+		// Somce capacity is lazily replenished, an attacker could stake
+		// a minimum amount, then at the very beginning of each epoch, stake a tiny additional amount,
+		// thus preventing replenishment when "last_replenished_at" is checked on the next provider's
+		// message.
 		Some(())
+	}
+
+	/// Return whether capacity can be replenished, given the current epoch.
+	pub fn can_replenish(&self, current_epoch: EpochNumber) -> bool {
+		self.last_replenished_epoch.lt(&current_epoch)
+	}
+
+	/// Completely refill all available capacity.
+	/// To be called lazily when a Capacity message is sent in a new epoch.
+	pub fn replenish_all(&mut self, current_epoch: &EpochNumber) {
+		let replenish_by = self.total_capacity_issued.saturating_sub(self.remaining_capacity);
+		self.replenish_by_amount(replenish_by, current_epoch);
+	}
+
+	/// Replenish remaining capacity by the provided amount and
+	/// touch last_replenished_epoch with the current epoch.
+	pub fn replenish_by_amount(&mut self, amount: Balance, current_epoch: &EpochNumber) {
+		self.remaining_capacity = amount.saturating_add(self.remaining_capacity);
+		self.last_replenished_epoch = current_epoch.clone();
+	}
+
+	/// Deduct the given amount from the remaining capacity that can be used to pay for messages.
+	pub fn deduct_capacity_by_amount(&mut self, amount: Balance) -> Result<(), ArithmeticError> {
+		let new_remaining =
+			self.remaining_capacity.checked_sub(&amount).ok_or(ArithmeticError::Underflow)?;
+		self.remaining_capacity = new_remaining;
+		Ok(())
 	}
 
 	/// Decrease a target's total available capacity.
 	pub fn withdraw(&mut self, capacity_deduction: Balance, tokens_staked_deduction: Balance) {
 		self.total_tokens_staked = self.total_tokens_staked.saturating_sub(tokens_staked_deduction);
-		self.total_available = self.total_available.saturating_sub(capacity_deduction);
+		self.total_capacity_issued = self.total_capacity_issued.saturating_sub(capacity_deduction);
 	}
 }
 
 /// The type for storing details about an epoch.
+/// May evolve to store other needed data such as epoch_end.
 #[derive(
 	PartialEq, Eq, Clone, Default, PartialOrd, Encode, Decode, RuntimeDebug, TypeInfo, MaxEncodedLen,
 )]
-
-/// Information about the current epoch.
-/// May evolve to store other needed data such as epoch_end.
 pub struct EpochInfo<BlockNumber> {
 	/// The block number when this epoch started.
 	pub epoch_start: BlockNumber,

--- a/pallets/capacity/src/types_tests.rs
+++ b/pallets/capacity/src/types_tests.rs
@@ -1,6 +1,6 @@
 use super::*;
 use crate::mock::*;
-use frame_support::{assert_noop, BoundedVec};
+use frame_support::{assert_err, assert_noop, assert_ok, BoundedVec};
 
 type UnlockBVec<T> = BoundedVec<
 	UnlockChunk<BalanceOf<T>, <T as Config>::EpochNumber>,
@@ -96,19 +96,20 @@ fn impl_staking_target_details_increase_by() {
 }
 
 #[test]
-fn impl_staking_capacity_details_increase_by() {
+fn impl_staking_capacity_details_deposit() {
 	new_test_ext().execute_with(|| {
 		let mut capacity_details =
 			CapacityDetails::<BalanceOf<Test>, <Test as Config>::EpochNumber>::default();
-		assert_eq!(capacity_details.deposit(10, 1), Some(()));
+
+		assert_eq!(capacity_details.deposit(&10), Some(()));
 
 		assert_eq!(
 			capacity_details,
 			CapacityDetails::<BalanceOf<Test>, <Test as Config>::EpochNumber> {
-				remaining: BalanceOf::<Test>::from(10u64),
+				remaining_capacity: BalanceOf::<Test>::from(10u64),
 				total_tokens_staked: BalanceOf::<Test>::from(10u64),
-				total_available: BalanceOf::<Test>::from(10u64),
-				last_replenished_epoch: <Test as Config>::EpochNumber::from(1u32)
+				total_capacity_issued: BalanceOf::<Test>::from(10u64),
+				last_replenished_epoch: <Test as Config>::EpochNumber::from(0u32)
 			}
 		)
 	});
@@ -197,13 +198,13 @@ fn staking_target_details_withdraw_reduces_staking_and_capacity_amounts() {
 }
 
 #[test]
-fn staking_capacity_details_withdraw_reduces_total_tokens_staked_and_total_tokens_available() {
+fn staking_target_details_withdraw_reduces_total_tokens_staked_and_total_tokens_available() {
 	new_test_ext().execute_with(|| {
 		let mut capacity_details =
 			CapacityDetails::<BalanceOf<Test>, <Test as Config>::EpochNumber> {
-				remaining: BalanceOf::<Test>::from(10u64),
+				remaining_capacity: BalanceOf::<Test>::from(10u64),
 				total_tokens_staked: BalanceOf::<Test>::from(10u64),
-				total_available: BalanceOf::<Test>::from(10u64),
+				total_capacity_issued: BalanceOf::<Test>::from(10u64),
 				last_replenished_epoch: <Test as Config>::EpochNumber::from(0u32),
 			};
 		capacity_details.withdraw(4, 5);
@@ -211,11 +212,73 @@ fn staking_capacity_details_withdraw_reduces_total_tokens_staked_and_total_token
 		assert_eq!(
 			capacity_details,
 			CapacityDetails::<BalanceOf<Test>, <Test as Config>::EpochNumber> {
-				remaining: BalanceOf::<Test>::from(10u64),
+				remaining_capacity: BalanceOf::<Test>::from(10u64),
 				total_tokens_staked: BalanceOf::<Test>::from(5u64),
-				total_available: BalanceOf::<Test>::from(6u64),
+				total_capacity_issued: BalanceOf::<Test>::from(6u64),
 				last_replenished_epoch: <Test as Config>::EpochNumber::from(0u32)
 			}
 		)
+	});
+}
+
+#[test]
+fn staking_target_details_replenish_all_resets_remaining_capacity_to_total_capacity_issued() {
+	new_test_ext().execute_with(|| {
+		let mut capacity_details =
+			CapacityDetails::<BalanceOf<Test>, <Test as Config>::EpochNumber> {
+				total_tokens_staked: BalanceOf::<Test>::from(22u64),
+				total_capacity_issued: BalanceOf::<Test>::from(12u64),
+				remaining_capacity: BalanceOf::<Test>::from(10u64),
+				last_replenished_epoch: <Test as Config>::EpochNumber::from(3u32),
+			};
+		let current_epoch: u32 = 5;
+		capacity_details.replenish_all(&current_epoch);
+
+		assert_eq!(12u64, capacity_details.total_capacity_issued);
+		assert_eq!(capacity_details.total_capacity_issued, capacity_details.remaining_capacity);
+		assert_eq!(current_epoch, capacity_details.last_replenished_epoch);
+		assert_eq!(22u64, capacity_details.total_tokens_staked);
+	})
+}
+
+#[test]
+fn staking_target_details_replenish_by_amount_sets_new_capacity_and_touches_last_replenished_epoch()
+{
+	new_test_ext().execute_with(|| {
+		let mut capacity_details =
+			CapacityDetails::<BalanceOf<Test>, <Test as Config>::EpochNumber> {
+				total_tokens_staked: BalanceOf::<Test>::from(65_000u64),
+				total_capacity_issued: BalanceOf::<Test>::from(32_500u64),
+				remaining_capacity: BalanceOf::<Test>::from(1_000u64),
+				last_replenished_epoch: <Test as Config>::EpochNumber::from(3_000u32),
+			};
+		let current_epoch: u32 = 3434;
+		capacity_details.replenish_by_amount(2001, &current_epoch);
+
+		assert_eq!(32_500u64, capacity_details.total_capacity_issued);
+		assert_eq!(3_001u64, capacity_details.remaining_capacity);
+		assert_eq!(current_epoch, capacity_details.last_replenished_epoch);
+		assert_eq!(65_000u64, capacity_details.total_tokens_staked);
+	})
+}
+
+#[test]
+fn staking_target_details_deduct_capacity_by_amount_can_do_math() {
+	new_test_ext().execute_with(|| {
+		let mut capacity_details =
+			CapacityDetails::<BalanceOf<Test>, <Test as Config>::EpochNumber> {
+				total_tokens_staked: BalanceOf::<Test>::from(5u64),
+				total_capacity_issued: BalanceOf::<Test>::from(7u64),
+				remaining_capacity: BalanceOf::<Test>::from(6u64),
+				last_replenished_epoch: <Test as Config>::EpochNumber::from(2u32),
+			};
+		assert_ok!(capacity_details.deduct_capacity_by_amount(2u64));
+
+		assert_eq!(5u64, capacity_details.total_tokens_staked);
+		assert_eq!(7u64, capacity_details.total_capacity_issued);
+		assert_eq!(4u64, capacity_details.remaining_capacity);
+		assert_eq!(2u32, capacity_details.last_replenished_epoch);
+
+		assert_err!(capacity_details.deduct_capacity_by_amount(99u64), ArithmeticError::Underflow);
 	});
 }

--- a/pallets/frequency-tx-payment/src/lib.rs
+++ b/pallets/frequency-tx-payment/src/lib.rs
@@ -240,7 +240,7 @@ where
 						|_| -> TransactionValidityError { InvalidTransaction::Payment.into() },
 					)?;
 
-					T::Capacity::withdraw(msa_id, fee.into()).map_err(
+					T::Capacity::deduct(msa_id, fee.into()).map_err(
 						|_| -> TransactionValidityError { InvalidTransaction::Payment.into() },
 					)?;
 

--- a/pallets/frequency-tx-payment/src/mock.rs
+++ b/pallets/frequency-tx-payment/src/mock.rs
@@ -338,6 +338,6 @@ fn create_msa_account(account_id: <Test as frame_system::Config>::AccountId) -> 
 
 fn create_capacity_for(target: MessageSourceId, amount: u64) {
 	let mut capacity_details = Capacity::get_capacity_for(target).unwrap_or_default();
-	capacity_details.deposit(amount, Capacity::get_current_epoch()).unwrap();
+	capacity_details.deposit(&amount).unwrap();
 	Capacity::set_capacity_for(target, capacity_details);
 }

--- a/pallets/msa/src/weights.rs
+++ b/pallets/msa/src/weights.rs
@@ -64,7 +64,7 @@ pub trait WeightInfo {
 	fn create_provider() -> Weight;
 	fn create_provider_via_governance() -> Weight;
 	fn propose_to_be_provider() -> Weight;
-	fn  on_initialize(m: u32, ) -> Weight;
+	fn on_initialize(m: u32, ) -> Weight;
 	fn grant_schema_permissions(s: u32, ) -> Weight;
 	fn revoke_schema_permissions(s: u32, ) -> Weight;
 }

--- a/pallets/msa/src/weights.rs
+++ b/pallets/msa/src/weights.rs
@@ -64,7 +64,7 @@ pub trait WeightInfo {
 	fn create_provider() -> Weight;
 	fn create_provider_via_governance() -> Weight;
 	fn propose_to_be_provider() -> Weight;
-	fn on_initialize(m: u32, ) -> Weight;
+	fn  on_initialize(m: u32, ) -> Weight;
 	fn grant_schema_permissions(s: u32, ) -> Weight;
 	fn revoke_schema_permissions(s: u32, ) -> Weight;
 }


### PR DESCRIPTION
# Goal
The goals of this PR:
1. Fix a DoS vulnerability/bug
2. Push some logic into CapacityDetails
3. Rename some functions and members to be clearer and self-consistent.

Closes <!-- issue # -->

# Discussion
The `deposit` function was really a "replenish_by_amount" function when I would have thought it would call `CapacityDetails::deposit`.  It was only ever being used by `replenish_by_amount` anyway. 

Additionally, a lot of work was being done outside of `CapacityDetails` struct that it ought to do. I added some functions that have the same name as the functions we want in Replenishable.

Now the Capacity impl of `Replenishable`, all each function does is try to fetch the `CapacityDetails` for the MSA, then calls the function of the same name on the retrieved `CapacityDetails`, and sets the new value in storage.

In the process of updating these things, I found a bug in `deposit` which created a DoS vulnerability, which is that we should not be updating "`last_replenished_at`" on a deposit.  A deposit is done when someone stakes for a target.  By touching "`last_replenished_at`" on a deposit, it behaves the same as "`replenish_all`" in that sense.  This created a DoS vulnerability:
1. Epoch N, Provider has used up all their capacity. 
2. User stakes minimum amount and targets Provider MSA 1.
3. Provider is effectively replenished by minimum amount.
4. Epoch N+1 begins
5. Immediately afterward, User stakes just a tiny bit more - but less than needed for a message, updating "`last_replenished_at`" to the current epoch.
6. Provider tries to send a message and cannot because they don't have enough Capacity, and they will not be replenished because the current epoch is the same as "`last_replenished_at`."
7. Repeat steps 4-6 ad infinitum

# Checklist
- [x] Design doc(s) updated
- [x] Tests added

# N/A
- Chain spec updated
- Custom RPC OR Runtime API added/changed? Updated js/api-augment.
- Benchmarks added
- Weights updated
