### PR TITLE
Fix docker issue with jacogr/polkadot-js-tools

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -428,9 +428,9 @@ jobs:
           echo "Ref. version: $REF_VERSION" >> ${{env.OUTPUT_FILENAME}}
           echo "Test version: $BIN_VERSION" >> ${{env.OUTPUT_FILENAME}}
           echo "----------------------------------------------------------------------" >> ${{env.OUTPUT_FILENAME}}
-      - name: Compare Metadata
+      - name: Compare Metadata # Change back to jacogr/polkadot-js-tools once it is fixed: https://github.com/polkadot-js/tools/issues/455
         run: |
-          CMD="docker run --pull always --network host jacogr/polkadot-js-tools metadata ws://localhost:9946 ws://localhost:9944"
+          CMD="docker run --pull always --network host wilwade/polkadot-js-tools metadata ws://localhost:9946 ws://localhost:9944"
           echo -e "Running:\n$CMD"
           $CMD >> ${{env.OUTPUT_DIR}}/${{env.OUTPUT_FILENAME}}
           sed -z -i 's/\n\n/\n/g' ${{env.OUTPUT_DIR}}/${{env.OUTPUT_FILENAME}}


### PR DESCRIPTION
# Goal
The goal of this PR is to fix an issue with `jacogr/polkadot-js-tools` as it is failing with the latest version.

https://github.com/polkadot-js/tools/issues/455