### PR TITLE
Bugs/bad withdraw behavior

### DIFF
--- a/designdocs/capacity.md
+++ b/designdocs/capacity.md
@@ -380,12 +380,12 @@ The type for storing Registered Provider Capacity balance:
 pub struct CapacityDetails<Balance> {
   /// The Capacity remaining for the `last_replenished_epoch`.
   pub remaining_capacity: Balance,
-    /// The amount of tokens staked to an MSA.
-    pub total_tokens_staked: Balance,
-    /// The total Capacity issued to an MSA.
-    pub total_capacity_issued: Balance,
-    /// The last Epoch that an MSA was replenished with Capacity.
-    pub last_replenished_epoch: EpochNumber,
+  /// The amount of tokens staked to an MSA.
+  pub total_tokens_staked: Balance,
+  /// The total Capacity issued to an MSA.
+  pub total_capacity_issued: Balance,
+  /// The last Epoch that an MSA was replenished with Capacity.
+  pub last_replenished_epoch: EpochNumber,
 }
 
 ```

--- a/designdocs/capacity.md
+++ b/designdocs/capacity.md
@@ -141,12 +141,12 @@ Acceptance Criteria are listed below but can evolve:
    - `CapacityReduction =
          TotalCapacity * (1 - (UnstakingAmount / TotalStakedAmount))`
 
-
-5. The amount unstaked cannot exceed the amount staked.
-6. If the result of the unstaking would be to leave a balance below `config::MinimumStakingAmount`, the entire amount will be unstaked to avoid leaving dust.
-7. when an account has never been a staking account and an attempt to call unstake an error message of NotAStakingAccount should be returned.
-8. If you have a staking account and your active balance is zero, then an error message of AmountToUnstakeExceedsAmountStaked should be returned (the test should include unlocking).
-9. Emits Unstake event.
+5. Remaining Capacity is reduced by the same amount as above.
+6. The amount unstaked cannot exceed the amount staked.
+7. If the result of the unstaking would be to leave a balance below `config::MinimumStakingAmount`, the entire amount will be unstaked to avoid leaving dust.
+8. when an account has never been a staking account and an attempt to call unstake an error message of NotAStakingAccount should be returned.
+9. If you have a staking account and your active balance is zero, then an error message of AmountToUnstakeExceedsAmountStaked should be returned (the test should include unlocking).
+10. Emits Unstake event.
 
 **withdraw_unstaked**
 
@@ -379,11 +379,13 @@ The type for storing Registered Provider Capacity balance:
 
 pub struct CapacityDetails<Balance> {
   /// The Capacity remaining for the `last_replenished_epoch`.
-  pub remaining: Balance,
-  /// The total Capacity issued to an MSA.
-  pub total_available: Balance,
-  /// The last Epoch that an MSA's Capacity was replenished.
-  pub last_replenished_epoch: u32,
+  pub remaining_capacity: Balance,
+    /// The amount of tokens staked to an MSA.
+    pub total_tokens_staked: Balance,
+    /// The total Capacity issued to an MSA.
+    pub total_capacity_issued: Balance,
+    /// The last Epoch that an MSA was replenished with Capacity.
+    pub last_replenished_epoch: EpochNumber,
 }
 
 ```

--- a/integration-tests/capacity/transactions.test.ts
+++ b/integration-tests/capacity/transactions.test.ts
@@ -100,7 +100,7 @@ describe("Capacity Transaction Tests", function () {
             }
             // Confirm that the tokens were unstaked in the stakeProviderId account using the query API
             const capacityStaked = (await firstValueFrom(ExtrinsicHelper.api.query.capacity.capacityLedger(stakeProviderId))).unwrap();
-            assert.equal(capacityStaked.remainingCapacity,   1000000, "should return a capacityLedger with 1000000 remainingCapacity");
+            assert.equal(capacityStaked.remainingCapacity,   0, "should return a capacityLedger with 0 remainingCapacity");
             assert.equal(capacityStaked.totalTokensStaked,   0,       "should return a capacityLedger with 0 total tokens staked");
             assert.equal(capacityStaked.totalCapacityIssued, 0,       "should return a capacityLedger with 0 capacity issued");
         });
@@ -126,25 +126,25 @@ describe("Capacity Transaction Tests", function () {
 
             // Confirm that the staked capacity was removed from the stakeProviderId account using the query API
             const capacityStaked = (await firstValueFrom(ExtrinsicHelper.api.query.capacity.capacityLedger(stakeProviderId))).unwrap();
-            assert.equal(capacityStaked.remainingCapacity,   1000000, "should return a capacityLedger with 1000000 remainingCapacity");
+            assert.equal(capacityStaked.remainingCapacity,   0, "should return a capacityLedger with 0 remainingCapacity");
             assert.equal(capacityStaked.totalTokensStaked,   0,       "should return a capacityLedger with 0 total tokens staked");
             assert.equal(capacityStaked.totalCapacityIssued, 0,       "should return a capacityLedger with 0 capacity issued");
         });
     });
 
     describe("increase stake testing", function () {
-        it("should successfully increase stake", async function () {
-            // Stake 1000000 capacity
+        it("increases stake for stakeProviderId", async function () {
+            // Now starting from zero again with stakeProviderId, Stake 1M capacity
             const stakeObj = ExtrinsicHelper.stake(stakeKeys, stakeProviderId, 1000000);
             const [stakeEvent] = await stakeObj.fundAndSend();
             assert.notEqual(stakeEvent, undefined, "should return a Staked event");
 
             if (stakeEvent && ExtrinsicHelper.api.events.capacity.Staked.is(stakeEvent)) {
                 let stakedCapacity = stakeEvent.data.capacity;
-                assert.equal(stakedCapacity, 1000000, "should return a Staked event with 1000000 capacity");
+                assert.equal(stakedCapacity, 1000000, "should return a Staked event with 1M capacity");
             }
 
-            // Increase stake by 2000000 capacity
+            // Increase stake by 2M capacity
             const increaseStakeObj = ExtrinsicHelper.stake(stakeKeys, stakeProviderId, 2000000);
             const [increaseStakeEvent] = await increaseStakeObj.fundAndSend();
             assert.notEqual(increaseStakeEvent, undefined, "should return a Staked event");
@@ -161,17 +161,15 @@ describe("Capacity Transaction Tests", function () {
             assert.equal(stakedAcctInfo.data.miscFrozen, 3000000, "should return an account with 3000000 miscFrozen balance");
             assert.equal(stakedAcctInfo.data.feeFrozen,  3000000, "should return an account with 3000000 feeFrozen balance");
 
-            // Confirm that the staked capacity was added to the stakeProviderId account using the query API
-            // Capacity calculation:
-            // 1000000 (initial test case) + 1000000 + 2000000 (this test case) = 4000000 capacity
-            // - 1000000 (unstaked) = 3000000 staked tokens
+            // Confirm that the staked capacity was added to the stakeProviderId account using the query API,
+            // 1M original stake, + 2M additional stake = 3M total
             const capacityStaked = (await firstValueFrom(ExtrinsicHelper.api.query.capacity.capacityLedger(stakeProviderId))).unwrap();
-            assert.equal(capacityStaked.remainingCapacity,   4000000, "should return a capacityLedger with 4000000 remainingCapacity");
+            assert.equal(capacityStaked.remainingCapacity,   3000000, "should return a capacityLedger with 3000000 remainingCapacity");
             assert.equal(capacityStaked.totalTokensStaked,   3000000, "should return a capacityLedger with 3000000 total staked");
             assert.equal(capacityStaked.totalCapacityIssued, 3000000, "should return a capacityLedger with 3000000 capacity issued");
         });
 
-        it("should successfully increase stake to a different provider", async function () {
+        it("staking to otherProviderId does not change stakeProviderId amounts", async function () {
             // Increase stake by 1000000 capacity to a different provider
             const increaseStakeObj = ExtrinsicHelper.stake(stakeKeys, otherProviderId, 1000000);
             const [increaseStakeEvent] = await increaseStakeObj.fundAndSend();
@@ -184,13 +182,13 @@ describe("Capacity Transaction Tests", function () {
                 assert.equal(increaseStakedCapacity, 1000000, "should return a (increased) Staked event with 1000000 capacity");
             }
             // Confirm that the staked capacity of the original stakeProviderId account is unchanged
-            // Capacity calculation:
-            // 1000000 (initial test case) + 1000000 + 2000000 (2nd test case) = 4000000 capacity
-            // - 1000000 (unstaked) = 3000000 staked tokens
+            // stakeProviderId should still have 3M from first test case in this describe.
+            // otherProvider should now have 1M
             const origStaked = (await firstValueFrom(ExtrinsicHelper.api.query.capacity.capacityLedger(stakeProviderId))).unwrap();
-            assert.equal(origStaked.remainingCapacity,   4000000, "should return a capacityLedger with 4000000 remainingCapacity");
+            assert.equal(origStaked.remainingCapacity,   3000000, "should return a capacityLedger with 4000000 remainingCapacity");
             assert.equal(origStaked.totalTokensStaked,   3000000, "should return a capacityLedger with 3000000 total tokens staked");
             assert.equal(origStaked.totalCapacityIssued, 3000000, "should return a capacityLedger with 3000000 capacity issued");
+
             // Confirm that the staked capacity was added to the otherProviderId account using the query API
             const capacityStaked = (await firstValueFrom(ExtrinsicHelper.api.query.capacity.capacityLedger(otherProviderId))).unwrap();
             assert.equal(capacityStaked.remainingCapacity,   1000000, "should return a capacityLedger with 1000000 remainingCapacity");

--- a/integration-tests/capacity/transactions.test.ts
+++ b/integration-tests/capacity/transactions.test.ts
@@ -105,7 +105,7 @@ describe("Capacity Transaction Tests", function () {
             assert.equal(capacityStaked.totalCapacityIssued, 0,       "should return a capacityLedger with 0 capacity issued");
         });
 
-        it("should successfully withdraw the unstaked amount", async function () {
+        it("withdraws the unstaked amount", async function () {
             // Mine enough blocks to pass the unstake period
             for (let index = 0; index < 2*TEST_EPOCH_LENGTH; index++) {
                 await ExtrinsicHelper.createBlock();
@@ -133,7 +133,7 @@ describe("Capacity Transaction Tests", function () {
     });
 
     describe("increase stake testing", function () {
-        it("increases stake for stakeProviderId", async function () {
+        it("should successfully increase stake for stakeProviderId", async function () {
             // Now starting from zero again with stakeProviderId, Stake 1M capacity
             const stakeObj = ExtrinsicHelper.stake(stakeKeys, stakeProviderId, 1000000);
             const [stakeEvent] = await stakeObj.fundAndSend();
@@ -185,7 +185,7 @@ describe("Capacity Transaction Tests", function () {
             // stakeProviderId should still have 3M from first test case in this describe.
             // otherProvider should now have 1M
             const origStaked = (await firstValueFrom(ExtrinsicHelper.api.query.capacity.capacityLedger(stakeProviderId))).unwrap();
-            assert.equal(origStaked.remainingCapacity,   3000000, "should return a capacityLedger with 4000000 remainingCapacity");
+            assert.equal(origStaked.remainingCapacity,   3000000, "should return a capacityLedger with 3000000 remainingCapacity");
             assert.equal(origStaked.totalTokensStaked,   3000000, "should return a capacityLedger with 3000000 total tokens staked");
             assert.equal(origStaked.totalCapacityIssued, 3000000, "should return a capacityLedger with 3000000 capacity issued");
 

--- a/integration-tests/package-lock.json
+++ b/integration-tests/package-lock.json
@@ -697,12 +697,12 @@
         "node_modules/@frequency-chain/api-augment": {
             "version": "0.0.0",
             "resolved": "file:../js/api-augment/dist/frequency-chain-api-augment-0.0.0.tgz",
-            "integrity": "sha512-S0OzAtPqwx3L8BQwVhFfg5xheU2Dkv4n9ahQKhWVx9oW/EDkc9UERrBeTj0qISydGcUS56Jm1RtNLNJ67l2Gjg==",
+            "integrity": "sha512-Mr21sHhGlpOgwh65TEMco8oW6+t0ogk9+hDc5SuXaBZrVq4O6kQ1Pe6Hr1lcaixFu/AOc5tJTOdDHTYeCzd9RQ==",
             "license": "Apache-2.0",
             "dependencies": {
-                "@polkadot/api": "^9.13.2",
-                "@polkadot/rpc-provider": "^9.13.2",
-                "@polkadot/types": "^9.13.2"
+                "@polkadot/api": "^9.14.2",
+                "@polkadot/rpc-provider": "^9.14.2",
+                "@polkadot/types": "^9.14.2"
             }
         },
         "node_modules/@grpc/grpc-js": {

--- a/integration-tests/package-lock.json
+++ b/integration-tests/package-lock.json
@@ -697,12 +697,12 @@
         "node_modules/@frequency-chain/api-augment": {
             "version": "0.0.0",
             "resolved": "file:../js/api-augment/dist/frequency-chain-api-augment-0.0.0.tgz",
-            "integrity": "sha512-Mr21sHhGlpOgwh65TEMco8oW6+t0ogk9+hDc5SuXaBZrVq4O6kQ1Pe6Hr1lcaixFu/AOc5tJTOdDHTYeCzd9RQ==",
+            "integrity": "sha512-S0OzAtPqwx3L8BQwVhFfg5xheU2Dkv4n9ahQKhWVx9oW/EDkc9UERrBeTj0qISydGcUS56Jm1RtNLNJ67l2Gjg==",
             "license": "Apache-2.0",
             "dependencies": {
-                "@polkadot/api": "^9.14.2",
-                "@polkadot/rpc-provider": "^9.14.2",
-                "@polkadot/types": "^9.14.2"
+                "@polkadot/api": "^9.13.2",
+                "@polkadot/rpc-provider": "^9.13.2",
+                "@polkadot/types": "^9.13.2"
             }
         },
         "node_modules/@grpc/grpc-js": {

--- a/pallets/capacity/src/extrinsics_tests.rs
+++ b/pallets/capacity/src/extrinsics_tests.rs
@@ -440,7 +440,7 @@ fn unstake_happy_path() {
 		assert_eq!(
 			capacity_details,
 			CapacityDetails::<BalanceOf<Test>, <Test as Config>::EpochNumber> {
-				remaining_capacity: BalanceOf::<Test>::from(10u64),
+				remaining_capacity: BalanceOf::<Test>::from(6u64),
 				total_tokens_staked: BalanceOf::<Test>::from(6u64),
 				total_capacity_issued: BalanceOf::<Test>::from(6u64),
 				last_replenished_epoch: <Test as Config>::EpochNumber::from(0u32),

--- a/pallets/capacity/src/mock.rs
+++ b/pallets/capacity/src/mock.rs
@@ -145,8 +145,6 @@ impl pallet_msa::Config for Test {
 	type MaxProviderNameSize = ConstU32<16>;
 	type SchemaValidator = Schemas;
 	type MortalityWindowSize = ConstU32<100>;
-	type MaxSignaturesPerBucket = ConstU32<4000>;
-	type NumberOfBuckets = ConstU32<2>;
 	type Proposal = RuntimeCall;
 	type ProposalProvider = CouncilProposalProvider;
 	type CreateProviderViaGovernanceOrigin = EnsureSigned<u64>;

--- a/pallets/capacity/src/types.rs
+++ b/pallets/capacity/src/types.rs
@@ -173,6 +173,7 @@ where
 	EpochNumber: Clone + PartialOrd + PartialEq,
 {
 	/// Increase a targets total Tokens staked and Capacity total issuance by an amount.
+	/// To be called on a stake
 	pub fn deposit(&mut self, amount: &Balance) -> Option<()> {
 		self.remaining_capacity = amount.checked_add(&self.remaining_capacity)?;
 		self.total_tokens_staked = amount.checked_add(&self.total_tokens_staked)?;
@@ -206,6 +207,7 @@ where
 	}
 
 	/// Deduct the given amount from the remaining capacity that can be used to pay for messages.
+	/// To be called when a message is paid for with capacity.
 	pub fn deduct_capacity_by_amount(&mut self, amount: Balance) -> Result<(), ArithmeticError> {
 		let new_remaining =
 			self.remaining_capacity.checked_sub(&amount).ok_or(ArithmeticError::Underflow)?;
@@ -214,9 +216,11 @@ where
 	}
 
 	/// Decrease a target's total available capacity.
+	/// To be called on an unstake.
 	pub fn withdraw(&mut self, capacity_deduction: Balance, tokens_staked_deduction: Balance) {
 		self.total_tokens_staked = self.total_tokens_staked.saturating_sub(tokens_staked_deduction);
 		self.total_capacity_issued = self.total_capacity_issued.saturating_sub(capacity_deduction);
+		self.remaining_capacity = self.remaining_capacity.saturating_sub(capacity_deduction);
 	}
 }
 

--- a/pallets/capacity/src/types_tests.rs
+++ b/pallets/capacity/src/types_tests.rs
@@ -212,7 +212,7 @@ fn staking_target_details_withdraw_reduces_total_tokens_staked_and_total_tokens_
 		assert_eq!(
 			capacity_details,
 			CapacityDetails::<BalanceOf<Test>, <Test as Config>::EpochNumber> {
-				remaining_capacity: BalanceOf::<Test>::from(10u64),
+				remaining_capacity: BalanceOf::<Test>::from(6u64),
 				total_tokens_staked: BalanceOf::<Test>::from(5u64),
 				total_capacity_issued: BalanceOf::<Test>::from(6u64),
 				last_replenished_epoch: <Test as Config>::EpochNumber::from(0u32)

--- a/pallets/frequency-tx-payment/src/mock.rs
+++ b/pallets/frequency-tx-payment/src/mock.rs
@@ -114,8 +114,6 @@ impl pallet_msa::Config for Test {
 	type MaxProviderNameSize = ConstU32<16>;
 	type SchemaValidator = Schemas;
 	type MortalityWindowSize = ConstU32<100>;
-	type MaxSignaturesPerBucket = ConstU32<4000>;
-	type NumberOfBuckets = ConstU32<2>;
 	type Proposal = RuntimeCall;
 	type ProposalProvider = CouncilProposalProvider;
 	type CreateProviderViaGovernanceOrigin = EnsureSigned<u64>;


### PR DESCRIPTION
# Goal
The goal of this PR is to fix a bug where CapacityDetails.remaining capacity was never being decreased on a withdraw.  This meant that even if somebody unstaked, the provider's remaining capacity would stay the same forever.

Also fixes broken mocks because of the rebase (sorry), and updates Capacity Design Doc to reflect the CapacityDetails new names and fields (also sorry, I missed it in the last rename somehow).

# Discussion
This affected a number of tests that assumed the behavior was correct.

# Checklist
- [x] Design doc(s) updated
- [x] Tests <del>added</del> updated
