### PR TITLE
[Capacity] integration tests for transacting #889

### DIFF
--- a/integration-tests/capacity/transactions.test.ts
+++ b/integration-tests/capacity/transactions.test.ts
@@ -7,6 +7,7 @@ import { devAccounts, log, createKeys, createAndFundKeypair, createMsaAndProvide
          generateDelegationPayload, signPayloadSr25519, stakeToProvider, fundKeypair }
     from "../scaffolding/helpers";
 import { firstValueFrom } from "rxjs";
+import { AVRO_GRAPH_CHANGE } from "../schemas/fixtures/avroGraphChangeSchemaType";
 
 describe("Capacity Transaction Tests", function () {
     const TEST_EPOCH_LENGTH = 25;
@@ -82,39 +83,7 @@ describe("Capacity Transaction Tests", function () {
         assert.notEqual(MsaCreatedEvent, undefined, "should have returned MsaCreated event");
 
         // Create schemas for testing with Grant Delegation to test pay_with_capacity
-        // Borrowed from integration-tests/grantDelegation.test.ts, might be a candidate for refactoring
-        const createSchemaOp = ExtrinsicHelper.createSchema(stakeKeys, {
-            type: "record",
-            name: "Post",
-            fields: [
-                {
-                    name: "title",
-                    type: {
-                        name: "Title",
-                        type: "string"
-                    }
-                },
-                {
-                    name: "content",
-                    type: {
-                        name: "Content",
-                        type: "string"
-                    }
-                },
-                {
-                    name: "fromId",
-                    type: {
-                        name: "DSNPId",
-                        type: "fixed",
-                        size: 8,
-                    },
-                },
-                {
-                    name: "objectId",
-                    type: "DSNPId",
-                },
-            ]
-        }, "AvroBinary", "OnChain");
+        const createSchemaOp = ExtrinsicHelper.createSchema(stakeKeys, AVRO_GRAPH_CHANGE, "AvroBinary", "OnChain");
         const [createSchemaEvent] = await createSchemaOp.fundAndSend();
         assert.notEqual(createSchemaEvent, undefined, "setup should return SchemaCreated event");
         if (createSchemaEvent && ExtrinsicHelper.api.events.schemas.SchemaCreated.is(createSchemaEvent)) {

--- a/integration-tests/capacity/transactions.test.ts
+++ b/integration-tests/capacity/transactions.test.ts
@@ -3,9 +3,11 @@ import { KeyringPair } from "@polkadot/keyring/types";
 import { u64, u16 } from "@polkadot/types";
 import assert from "assert";
 import { AddProviderPayload, ExtrinsicHelper } from "../scaffolding/extrinsicHelpers";
-import { devAccounts, log, createKeys, createAndFundKeypair, createMsaAndProvider, generateDelegationPayload, signPayloadSr25519 } from "../scaffolding/helpers";
-import { firstValueFrom} from "rxjs";
-import { Call } from "@polkadot/types/interfaces";
+import { devAccounts, log, createKeys, createAndFundKeypair, createMsaAndProvider,
+         generateDelegationPayload, signPayloadSr25519, stakeToProvider }
+    from "../scaffolding/helpers";
+import { firstValueFrom } from "rxjs";
+// import { Call } from "@polkadot/types/interfaces";
 
 // REMOVE: .only for testing
 describe.only("Capacity Transaction Tests", function () {
@@ -24,7 +26,7 @@ describe.only("Capacity Transaction Tests", function () {
     let schemaId: u16;
     let defaultPayload: AddProviderPayload;
 
-    let stakeAmount: bigint = 10000000n;
+    let stakeAmount: bigint = 20000000n;
 
     before(async function () {
         // Set the Maximum Epoch Length to TEST_EPOCH_LENGTH blocks
@@ -62,12 +64,14 @@ describe.only("Capacity Transaction Tests", function () {
         // Create and fund a keypair with EXISTENTIAL_DEPOSIT
         // Use this keypair for other operations
         otherProviderKeys = createKeys("OtherProviderKeys");
-        otherProviderId = await createMsaAndProvider(otherProviderKeys, "OtherProvider");
+        otherProviderId = await createMsaAndProvider(otherProviderKeys, "OtherProvider", stakeAmount);
         assert.equal(otherProviderId, 4, "should populate otherProviderId");
 
         // Create a keypair with no tokens
         emptyKeys = await createAndFundKeypair();
 
+        // Create schemas for testing with Grant Delegation to test pay_with_capacity
+        // Borrowed from integration-tests/grantDelegation.test.ts, might be a candidate for refactoring
         const createSchemaOp = ExtrinsicHelper.createSchema(stakeKeys, {
             type: "record",
             name: "Post",
@@ -108,30 +112,158 @@ describe.only("Capacity Transaction Tests", function () {
         assert.notEqual(schemaId, undefined, "setup should populate schemaId");
     });
     
-    describe("pay_with_capacity testing", function () {
-        it("should successfully stake the minimum amount for Staked event", async function () {
-            const stakeObj = ExtrinsicHelper.stake(stakeKeys, stakeProviderId, 4000000);
-            const [stakeEvent] = await stakeObj.fundAndSend();
-            assert.notEqual(stakeEvent, undefined, "should return a Stake event");
 
-            if (stakeEvent && ExtrinsicHelper.api.events.capacity.Staked.is(stakeEvent)) {
-                let stakedCapacity = stakeEvent.data.capacity;
-                assert.equal(stakedCapacity, 4000000, "should return a Stake event with 4M capacity");
-            }
-            else {
-                assert.fail("should return a capacity.Staked.is(stakeEvent) event");
-            }
+    describe("stake-unstake-withdraw_unstaked testing", function () {
+
+        it("should successfully stake the minimum amount for Staked event", async function () {
+            await stakeToProvider(stakeKeys, stakeProviderId, 1000000n);
 
             // Confirm that the tokens were locked in the stakeKeys account using the query API
             const stakedAcctInfo = await ExtrinsicHelper.getAccountInfo(stakeKeys.address);
-            // assert.equal(stakedAcctInfo.data.miscFrozen, 1000000, "should return an account with 1,000,000 miscFrozen balance");
-            // assert.equal(stakedAcctInfo.data.feeFrozen,  1000000, "should return an account with 1,000,000 feeFrozen balance");
+            assert.equal(stakedAcctInfo.data.miscFrozen, 1000000, "should return an account with 1M miscFrozen balance");
+            assert.equal(stakedAcctInfo.data.feeFrozen,  1000000, "should return an account with 1M feeFrozen balance");
 
             // Confirm that the capacity was added to the stakeProviderId using the query API
             const capacityStaked = (await firstValueFrom(ExtrinsicHelper.api.query.capacity.capacityLedger(stakeProviderId))).unwrap();
-            // assert.equal(capacityStaked.remainingCapacity,   1000000, "should return a capacityLedger with 1000000 remainingCapacity");
-            // assert.equal(capacityStaked.totalTokensStaked,   1000000, "should return a capacityLedger with 1000000 total tokens staked");
-            // assert.equal(capacityStaked.totalCapacityIssued, 1000000, "should return a capacityLedger with 1000000 issued capacity");
+            assert.equal(capacityStaked.remainingCapacity,   1000000, "should return a capacityLedger with 1M remainingCapacity");
+            assert.equal(capacityStaked.totalTokensStaked,   1000000, "should return a capacityLedger with 1M total tokens staked");
+            assert.equal(capacityStaked.totalCapacityIssued, 1000000, "should return a capacityLedger with 1M issued capacity");
+        });
+
+        it("should successfully unstake the minimum amount", async function () {
+            const stakeObj = ExtrinsicHelper.unstake(stakeKeys, stakeProviderId, 1000000);
+            const [unStakeEvent] = await stakeObj.fundAndSend();
+            assert.notEqual(unStakeEvent, undefined, "should return an UnStaked event");
+
+            if (unStakeEvent && ExtrinsicHelper.api.events.capacity.UnStaked.is(unStakeEvent)) {
+                let unstakedCapacity = unStakeEvent.data.capacity;
+                assert.equal(unstakedCapacity, 1000000, "should return an UnStaked event with 1000000 reduced capacity");
+            }
+            else {
+                assert.fail("should return an capacity.UnStaked.is(unStakeEvent) event");
+            }
+            // Confirm that the tokens were unstaked in the stakeProviderId account using the query API
+            const capacityStaked = (await firstValueFrom(ExtrinsicHelper.api.query.capacity.capacityLedger(stakeProviderId))).unwrap();
+            assert.equal(capacityStaked.remainingCapacity,   0, "should return a capacityLedger with 0 remainingCapacity");
+            assert.equal(capacityStaked.totalTokensStaked,   0, "should return a capacityLedger with 0 total tokens staked");
+            assert.equal(capacityStaked.totalCapacityIssued, 0, "should return a capacityLedger with 0 capacity issued");
+        });
+
+        it("withdraws the unstaked amount", async function () {
+            // Mine enough blocks to pass the unstake period
+            for (let index = 0; index < 2*TEST_EPOCH_LENGTH; index++) {
+                await ExtrinsicHelper.createBlock();
+            }
+
+            const withdrawObj = ExtrinsicHelper.withdrawUnstaked(stakeKeys);
+            const [withdrawEvent] = await withdrawObj.fundAndSend();
+            assert.notEqual(withdrawEvent, undefined, "should return a StakeWithdrawn event");
+
+            if (withdrawEvent && ExtrinsicHelper.api.events.capacity.StakeWithdrawn.is(withdrawEvent)) {
+                let amount = withdrawEvent.data.amount;
+                assert.equal(amount, 1000000, "should return a StakeWithdrawn event with 1M amount");
+            }
+            // Confirm that the tokens were unstaked in the stakeKeys account using the query API
+            const unStakedAcctInfo = await ExtrinsicHelper.getAccountInfo(stakeKeys.address);
+            assert.equal(unStakedAcctInfo.data.miscFrozen, 0, "should return an account with 0 miscFrozen balance");
+            assert.equal(unStakedAcctInfo.data.feeFrozen,  0, "should return an account with 0 feeFrozen balance");
+
+            // Confirm that the staked capacity was removed from the stakeProviderId account using the query API
+            const capacityStaked = (await firstValueFrom(ExtrinsicHelper.api.query.capacity.capacityLedger(stakeProviderId))).unwrap();
+            assert.equal(capacityStaked.remainingCapacity,   0, "should return a capacityLedger with 0 remainingCapacity");
+            assert.equal(capacityStaked.totalTokensStaked,   0, "should return a capacityLedger with 0 total tokens staked");
+            assert.equal(capacityStaked.totalCapacityIssued, 0, "should return a capacityLedger with 0 capacity issued");
+        });
+    });
+
+    describe("increase stake testing", function () {
+        it("should successfully increase stake for stakeProviderId", async function () {
+            // Now starting from zero again with stakeProviderId, Stake 1M capacity
+            await stakeToProvider(stakeKeys, stakeProviderId, 1000000n);
+
+            // Increase stake by 2M capacity
+            await stakeToProvider(stakeKeys, stakeProviderId, 2000000n);
+
+            // Confirm that the tokens were staked in the stakeKeys account using the query API
+            const stakedAcctInfo = await ExtrinsicHelper.getAccountInfo(stakeKeys.address);
+            assert.equal(stakedAcctInfo.data.miscFrozen, 3000000, "should return an account with 3M miscFrozen balance");
+            assert.equal(stakedAcctInfo.data.feeFrozen,  3000000, "should return an account with 3M feeFrozen balance");
+
+            // Confirm that the staked capacity was added to the stakeProviderId account using the query API,
+            // 1M original stake, + 2M additional stake = 3M total
+            const capacityStaked = (await firstValueFrom(ExtrinsicHelper.api.query.capacity.capacityLedger(stakeProviderId))).unwrap();
+            assert.equal(capacityStaked.remainingCapacity,   3000000, "should return a capacityLedger with 3M remainingCapacity");
+            assert.equal(capacityStaked.totalTokensStaked,   3000000, "should return a capacityLedger with 3M total staked");
+            assert.equal(capacityStaked.totalCapacityIssued, 3000000, "should return a capacityLedger with 3M capacity issued");
+        });
+
+        it("staking to otherProviderId does not change stakeProviderId amounts", async function () {
+            // Increase stake by 1000000 capacity to a different provider
+            await stakeToProvider(stakeKeys, otherProviderId, 1000000n);
+
+            // Confirm that the staked capacity of the original stakeProviderId account is unchanged
+            // stakeProviderId should still have 3M from first test case in this describe.
+            // otherProvider should now have 1M
+            const origStaked = (await firstValueFrom(ExtrinsicHelper.api.query.capacity.capacityLedger(stakeProviderId))).unwrap();
+            assert.equal(origStaked.remainingCapacity,   3000000, "should return a capacityLedger with 3M remainingCapacity");
+            assert.equal(origStaked.totalTokensStaked,   3000000, "should return a capacityLedger with 3M total tokens staked");
+            assert.equal(origStaked.totalCapacityIssued, 3000000, "should return a capacityLedger with 3M capacity issued");
+
+            // Confirm that the staked capacity was added to the otherProviderId account using the query API
+            const capacityStaked = (await firstValueFrom(ExtrinsicHelper.api.query.capacity.capacityLedger(otherProviderId))).unwrap();
+            assert.equal(capacityStaked.remainingCapacity,   1000000, "should return a capacityLedger with 1M remainingCapacity");
+            assert.equal(capacityStaked.totalTokensStaked,   1000000, "should return a capacityLedger with 1M total tokens staked");
+            assert.equal(capacityStaked.totalCapacityIssued, 1000000, "should return a capacityLedger with 1M capacity issued");
+        });
+    });
+
+    describe("stake testing-invalid paths", function () {
+        it("should fail to stake for InvalidTarget", async function () {
+            const failStakeObj = ExtrinsicHelper.stake(stakeKeys, 99, 1000000);
+            await assert.rejects(failStakeObj.fundAndSend(), { name: "InvalidTarget" });
+        });
+
+        // Need to use a different account that is not already staked
+        it("should fail to stake for InsufficientStakingAmount", async function () {
+            const failStakeObj = ExtrinsicHelper.stake(otherProviderKeys, otherProviderId, 1000);
+            await assert.rejects(failStakeObj.fundAndSend(), { name: "InsufficientStakingAmount" });
+        });
+
+        it("should fail to stake for ZeroAmountNotAllowed", async function () {
+            const failStakeObj = ExtrinsicHelper.stake(stakeKeys, stakeProviderId, 0);
+            await assert.rejects(failStakeObj.fundAndSend(), { name: "ZeroAmountNotAllowed" });
+        });
+    });
+
+    describe("unstake testing", function () {
+        it("should fail to unstake for UnstakedAmountIsZero", async function () {
+            const failUnstakeObj = ExtrinsicHelper.unstake(unstakeKeys, unstakeProviderId, 0);
+            await assert.rejects(failUnstakeObj.fundAndSend(), { name: "UnstakedAmountIsZero" });
+        });
+        it("should fail to unstake for StakingAccountNotFound", async function () {
+            const failUnstakeObj = ExtrinsicHelper.unstake(otherProviderKeys, unstakeProviderId, 1000000);
+            await assert.rejects(failUnstakeObj.fundAndSend(), { name: "StakingAccountNotFound" });
+        });
+    });
+
+    describe("withdraw_unstaked testing", function () {
+        it("should fail to withdraw the unstaked amount", async function () {
+            const stakeObj = ExtrinsicHelper.stake(withdrawKeys, withdrawProviderId, 1000000);
+            const [stakeEvent] = await stakeObj.fundAndSend();
+            assert.notEqual(stakeEvent, undefined, "should return a Stake event");
+
+            const withdrawObj = ExtrinsicHelper.withdrawUnstaked(withdrawKeys);
+            assert.rejects(withdrawObj.fundAndSend(), { name: "NoUnstakedTokensAvailable" });
+            // Advance to the next block to eliminate nonce collision
+            await ExtrinsicHelper.createBlock();
+        });
+    });
+
+    describe("pay_with_capacity testing", function () {
+        it("should successfully stake 9M", async function () {
+            // Advance to the next block to eliminate nonce collision
+            await ExtrinsicHelper.createBlock();
+            await stakeToProvider(stakeKeys, stakeProviderId, 9000000n);
         });
         it("should pay for a transaction with available capacity", async function () {
             // REMOVE:  
@@ -186,7 +318,10 @@ describe.only("Capacity Transaction Tests", function () {
                 "1010: Invalid Transaction: Custom error: 0" });
         });
         it("should fail to pay for a transaction with no msaId", async function () {
-            const payload = await generateDelegationPayload({});
+            const payload = await generateDelegationPayload({
+                authorizedMsaId: withdrawProviderId,
+                schemaIds: [schemaId],
+            });
             const addProviderData = ExtrinsicHelper.api.registry.createType("PalletMsaAddProvider", payload);
             const grantDelegationOp = ExtrinsicHelper.grantDelegation(emptyKeys, withdrawKeys, 
                 signPayloadSr25519(emptyKeys, addProviderData), payload);
@@ -194,152 +329,15 @@ describe.only("Capacity Transaction Tests", function () {
                 "1010: Invalid Transaction: Custom error: 1" });
         });
     });
-
-    /*
-    describe("stake-unstake-withdraw_unstaked testing", function () {
-
-        it("should successfully stake the minimum amount for Staked event", async function () {
-            const stakeObj = ExtrinsicHelper.stake(stakeKeys, stakeProviderId, 1000000);
-            const [stakeEvent] = await stakeObj.fundAndSend();
-            assert.notEqual(stakeEvent, undefined, "should return a Stake event");
-
-            if (stakeEvent && ExtrinsicHelper.api.events.capacity.Staked.is(stakeEvent)) {
-                let stakedCapacity = stakeEvent.data.capacity;
-                assert.equal(stakedCapacity, 1000000, "should return a Stake event with 1000000 capacity");
-            }
-            else {
-                assert.fail("should return a capacity.Staked.is(stakeEvent) event");
-            }
-
-            // Confirm that the tokens were locked in the stakeKeys account using the query API
-            const stakedAcctInfo = await ExtrinsicHelper.getAccountInfo(stakeKeys.address);
-            assert.equal(stakedAcctInfo.data.miscFrozen, 1000000, "should return an account with 1,000,000 miscFrozen balance");
-            assert.equal(stakedAcctInfo.data.feeFrozen,  1000000, "should return an account with 1,000,000 feeFrozen balance");
-
-            // Confirm that the capacity was added to the stakeProviderId using the query API
-            const capacityStaked = (await firstValueFrom(ExtrinsicHelper.api.query.capacity.capacityLedger(stakeProviderId))).unwrap();
-            assert.equal(capacityStaked.remainingCapacity,   1000000, "should return a capacityLedger with 1000000 remainingCapacity");
-            assert.equal(capacityStaked.totalTokensStaked,   1000000, "should return a capacityLedger with 1000000 total tokens staked");
-            assert.equal(capacityStaked.totalCapacityIssued, 1000000, "should return a capacityLedger with 1000000 issued capacity");
-        });
-
-        it("should successfully unstake the minimum amount", async function () {
-            const stakeObj = ExtrinsicHelper.unstake(stakeKeys, stakeProviderId, 1000000);
-            const [unStakeEvent] = await stakeObj.fundAndSend();
-            assert.notEqual(unStakeEvent, undefined, "should return an UnStaked event");
-
-            if (unStakeEvent && ExtrinsicHelper.api.events.capacity.UnStaked.is(unStakeEvent)) {
-                let unstakedCapacity = unStakeEvent.data.capacity;
-                assert.equal(unstakedCapacity, 1000000, "should return an UnStaked event with 1000000 reduced capacity");
-            }
-            else {
-                assert.fail("should return an capacity.UnStaked.is(unStakeEvent) event");
-            }
-            // Confirm that the tokens were unstaked in the stakeProviderId account using the query API
-            const capacityStaked = (await firstValueFrom(ExtrinsicHelper.api.query.capacity.capacityLedger(stakeProviderId))).unwrap();
-            assert.equal(capacityStaked.remainingCapacity,   0, "should return a capacityLedger with 0 remainingCapacity");
-            assert.equal(capacityStaked.totalTokensStaked,   0,       "should return a capacityLedger with 0 total tokens staked");
-            assert.equal(capacityStaked.totalCapacityIssued, 0,       "should return a capacityLedger with 0 capacity issued");
-        });
-
-        it("withdraws the unstaked amount", async function () {
-            // Mine enough blocks to pass the unstake period
-            for (let index = 0; index < 2*TEST_EPOCH_LENGTH; index++) {
-                await ExtrinsicHelper.createBlock();
-            }
-
-            const withdrawObj = ExtrinsicHelper.withdrawUnstaked(stakeKeys);
-            const [withdrawEvent] = await withdrawObj.fundAndSend();
-            assert.notEqual(withdrawEvent, undefined, "should return a StakeWithdrawn event");
-
-            if (withdrawEvent && ExtrinsicHelper.api.events.capacity.StakeWithdrawn.is(withdrawEvent)) {
-                let amount = withdrawEvent.data.amount;
-                assert.equal(amount, 1000000, "should return a StakeWithdrawn event with 1000000 amount");
-            }
-            // Confirm that the tokens were unstaked in the stakeKeys account using the query API
-            const unStakedAcctInfo = await ExtrinsicHelper.getAccountInfo(stakeKeys.address);
-            assert.equal(unStakedAcctInfo.data.miscFrozen, 0, "should return an account with 0 miscFrozen balance");
-            assert.equal(unStakedAcctInfo.data.feeFrozen,  0, "should return an account with 0 feeFrozen balance");
-
-            // Confirm that the staked capacity was removed from the stakeProviderId account using the query API
-            const capacityStaked = (await firstValueFrom(ExtrinsicHelper.api.query.capacity.capacityLedger(stakeProviderId))).unwrap();
-            assert.equal(capacityStaked.remainingCapacity,   0, "should return a capacityLedger with 0 remainingCapacity");
-            assert.equal(capacityStaked.totalTokensStaked,   0,       "should return a capacityLedger with 0 total tokens staked");
-            assert.equal(capacityStaked.totalCapacityIssued, 0,       "should return a capacityLedger with 0 capacity issued");
-        });
-    });
-
-    describe("increase stake testing", function () {
-        it("should successfully increase stake for stakeProviderId", async function () {
-            // Now starting from zero again with stakeProviderId, Stake 1M capacity
-            const stakeObj = ExtrinsicHelper.stake(stakeKeys, stakeProviderId, 1000000);
-            const [stakeEvent] = await stakeObj.fundAndSend();
-            assert.notEqual(stakeEvent, undefined, "should return a Staked event");
-
-            if (stakeEvent && ExtrinsicHelper.api.events.capacity.Staked.is(stakeEvent)) {
-                let stakedCapacity = stakeEvent.data.capacity;
-                assert.equal(stakedCapacity, 1000000, "should return a Staked event with 1M capacity");
-            }
-
-            // Increase stake by 2M capacity
-            const increaseStakeObj = ExtrinsicHelper.stake(stakeKeys, stakeProviderId, 2000000);
-            const [increaseStakeEvent] = await increaseStakeObj.fundAndSend();
-            assert.notEqual(increaseStakeEvent, undefined, "should return a Staked event");
-
-            if (increaseStakeEvent && ExtrinsicHelper.api.events.capacity.Staked.is(increaseStakeEvent)) {
-                let stakedAmount = increaseStakeEvent.data.amount;
-                let stakedCapacity = increaseStakeEvent.data.capacity;
-                assert.equal(stakedAmount,   2000000, "should return a Staked event with 2000000 Amount");
-                assert.equal(stakedCapacity, 2000000, "should return a Staked event with 2000000 capacity");
-            }
-
-            // Confirm that the tokens were staked in the stakeKeys account using the query API
-            const stakedAcctInfo = await ExtrinsicHelper.getAccountInfo(stakeKeys.address);
-            assert.equal(stakedAcctInfo.data.miscFrozen, 3000000, "should return an account with 3000000 miscFrozen balance");
-            assert.equal(stakedAcctInfo.data.feeFrozen,  3000000, "should return an account with 3000000 feeFrozen balance");
-
-            // Confirm that the staked capacity was added to the stakeProviderId account using the query API,
-            // 1M original stake, + 2M additional stake = 3M total
-            const capacityStaked = (await firstValueFrom(ExtrinsicHelper.api.query.capacity.capacityLedger(stakeProviderId))).unwrap();
-            assert.equal(capacityStaked.remainingCapacity,   3000000, "should return a capacityLedger with 3000000 remainingCapacity");
-            assert.equal(capacityStaked.totalTokensStaked,   3000000, "should return a capacityLedger with 3000000 total staked");
-            assert.equal(capacityStaked.totalCapacityIssued, 3000000, "should return a capacityLedger with 3000000 capacity issued");
-        });
-
-        it("staking to otherProviderId does not change stakeProviderId amounts", async function () {
-            // Increase stake by 1000000 capacity to a different provider
-            const increaseStakeObj = ExtrinsicHelper.stake(stakeKeys, otherProviderId, 1000000);
-            const [increaseStakeEvent] = await increaseStakeObj.fundAndSend();
-            assert.notEqual(increaseStakeEvent, undefined, "should return a Staked event");
-
-            if (increaseStakeEvent && ExtrinsicHelper.api.events.capacity.Staked.is(increaseStakeEvent)) {
-                let increaseStakedAmount = increaseStakeEvent.data.amount;
-                let increaseStakedCapacity = increaseStakeEvent.data.capacity;
-                assert.equal(increaseStakedAmount,   1000000, "should return a (increased) Staked event with 1000000 Amount");
-                assert.equal(increaseStakedCapacity, 1000000, "should return a (increased) Staked event with 1000000 capacity");
-            }
-            // Confirm that the staked capacity of the original stakeProviderId account is unchanged
-            // stakeProviderId should still have 3M from first test case in this describe.
-            // otherProvider should now have 1M
-            const origStaked = (await firstValueFrom(ExtrinsicHelper.api.query.capacity.capacityLedger(stakeProviderId))).unwrap();
-            assert.equal(origStaked.remainingCapacity,   3000000, "should return a capacityLedger with 3000000 remainingCapacity");
-            assert.equal(origStaked.totalTokensStaked,   3000000, "should return a capacityLedger with 3000000 total tokens staked");
-            assert.equal(origStaked.totalCapacityIssued, 3000000, "should return a capacityLedger with 3000000 capacity issued");
-
-            // Confirm that the staked capacity was added to the otherProviderId account using the query API
-            const capacityStaked = (await firstValueFrom(ExtrinsicHelper.api.query.capacity.capacityLedger(otherProviderId))).unwrap();
-            assert.equal(capacityStaked.remainingCapacity,   1000000, "should return a capacityLedger with 1000000 remainingCapacity");
-            assert.equal(capacityStaked.totalTokensStaked,   1000000, "should return a capacityLedger with 1000000 total tokens staked");
-            assert.equal(capacityStaked.totalCapacityIssued, 1000000, "should return a capacityLedger with 1000000 capacity issued");
-        });
-    });
-
     describe("empty capacity testing", function () {
+        // When a user does not have enough capacity to pay for the transaction fee
+        // and is NOT eligible to replenish Capacity, it should error and be dropped
+        // from the transaction pool.
         it("should fail to pay for a transaction with empty capacity", async function () {
-            const payload = await generateDelegationPayload({});
-            //     authorizedMsaId: providerId,
-            //     schemaIds: [schemaId],
-            // });
+            const payload = await generateDelegationPayload({
+                authorizedMsaId: withdrawProviderId,
+                schemaIds: [schemaId],
+            });
             const addProviderData = ExtrinsicHelper.api.registry.createType("PalletMsaAddProvider", payload);
             const grantDelegationOp = ExtrinsicHelper.grantDelegation(otherProviderKeys, withdrawKeys, 
                 signPayloadSr25519(withdrawKeys, addProviderData), payload);
@@ -347,45 +345,4 @@ describe.only("Capacity Transaction Tests", function () {
                 "1010: Invalid Transaction: Inability to pay some fees , e.g. account balance too low" });
         });
     });
-
-    describe("stake testing-invalid paths", function () {
-        it("should fail to stake for InvalidTarget", async function () {
-            const failStakeObj = ExtrinsicHelper.stake(stakeKeys, 99, 1000000);
-            await assert.rejects(failStakeObj.fundAndSend(), { name: "InvalidTarget" });
-        });
-
-        // Need to use a different account that is not already staked
-        it("should fail to stake for InsufficientStakingAmount", async function () {
-            const failStakeObj = ExtrinsicHelper.stake(otherProviderKeys, otherProviderId, 1000);
-            await assert.rejects(failStakeObj.fundAndSend(), { name: "InsufficientStakingAmount" });
-        });
-
-        it("should fail to stake for ZeroAmountNotAllowed", async function () {
-            const failStakeObj = ExtrinsicHelper.stake(stakeKeys, stakeProviderId, 0);
-            await assert.rejects(failStakeObj.fundAndSend(), { name: "ZeroAmountNotAllowed" });
-        });
-    });
-
-    describe("unstake testing", function () {
-        it("should fail to unstake for UnstakedAmountIsZero", async function () {
-            const failUnstakeObj = ExtrinsicHelper.unstake(unstakeKeys, unstakeProviderId, 0);
-            await assert.rejects(failUnstakeObj.fundAndSend(), { name: "UnstakedAmountIsZero" });
-        });
-        it("should fail to unstake for StakingAccountNotFound", async function () {
-            const failUnstakeObj = ExtrinsicHelper.unstake(otherProviderKeys, unstakeProviderId, 1000000);
-            await assert.rejects(failUnstakeObj.fundAndSend(), { name: "StakingAccountNotFound" });
-        });
-    });
-
-    describe("withdraw_unstaked testing", function () {
-        it("should fail to withdraw the unstaked amount", async function () {
-            const stakeObj = ExtrinsicHelper.stake(withdrawKeys, withdrawProviderId, 1000000);
-            const [stakeEvent] = await stakeObj.fundAndSend();
-            assert.notEqual(stakeEvent, undefined, "should return a Stake event");
-
-            const withdrawObj = ExtrinsicHelper.withdrawUnstaked(withdrawKeys);
-            assert.rejects(withdrawObj.fundAndSend(), { name: "NoUnstakedTokensAvailable" });
-        });
-    });
-*/
 })

--- a/integration-tests/package-lock.json
+++ b/integration-tests/package-lock.json
@@ -697,12 +697,12 @@
         "node_modules/@frequency-chain/api-augment": {
             "version": "0.0.0",
             "resolved": "file:../js/api-augment/dist/frequency-chain-api-augment-0.0.0.tgz",
-            "integrity": "sha512-S0OzAtPqwx3L8BQwVhFfg5xheU2Dkv4n9ahQKhWVx9oW/EDkc9UERrBeTj0qISydGcUS56Jm1RtNLNJ67l2Gjg==",
+            "integrity": "sha512-Mr21sHhGlpOgwh65TEMco8oW6+t0ogk9+hDc5SuXaBZrVq4O6kQ1Pe6Hr1lcaixFu/AOc5tJTOdDHTYeCzd9RQ==",
             "license": "Apache-2.0",
             "dependencies": {
-                "@polkadot/api": "^9.13.2",
-                "@polkadot/rpc-provider": "^9.13.2",
-                "@polkadot/types": "^9.13.2"
+                "@polkadot/api": "^9.14.2",
+                "@polkadot/rpc-provider": "^9.14.2",
+                "@polkadot/types": "^9.14.2"
             }
         },
         "node_modules/@grpc/grpc-js": {

--- a/integration-tests/scaffolding/extrinsicHelpers.ts
+++ b/integration-tests/scaffolding/extrinsicHelpers.ts
@@ -7,7 +7,7 @@ import { AnyNumber, AnyTuple, Codec, IEvent, ISubmittableResult } from "@polkado
 import { firstValueFrom, filter, map, pipe, tap } from "rxjs";
 import { devAccounts, log, Sr25519Signature } from "./helpers";
 import { connect, connectPromise } from "./apiConnection";
-import { Call, CreatedBlock, DispatchError, Event, SignedBlock } from "@polkadot/types/interfaces";
+import { CreatedBlock, DispatchError, Event, SignedBlock } from "@polkadot/types/interfaces";
 import { IsEvent } from "@polkadot/types/metadata/decorate/types";
 
 export type AddKeyData = { msaId?: u64; expiration?: any; newPublicKey?: any; }
@@ -268,9 +268,4 @@ export class ExtrinsicHelper {
     public static withdrawUnstaked(keys: KeyringPair): Extrinsic {
         return new Extrinsic(() => ExtrinsicHelper.api.tx.capacity.withdrawUnstaked(), keys, ExtrinsicHelper.api.events.capacity.StakeWithdrawn);
     }
-
-    /** Pay With Capacity Extrinsics **/
-    // public static payWithCapacity(keys: KeyringPair, call: string | Uint8Array | Call): Extrinsic {
-    //     return new Extrinsic(() => ExtrinsicHelper.api.tx.frequencyTxPayment.payWithCapacity(call), keys, ExtrinsicHelper.api.events.capacity.CapacityPaid);
-    // }
 }

--- a/integration-tests/scaffolding/helpers.ts
+++ b/integration-tests/scaffolding/helpers.ts
@@ -90,14 +90,29 @@ export async function createMsaAndProvider(keys: KeyringPair, providerName: stri
     await fundKeypair(devAccounts[0].keys, keys, amount);
     const createMsaOp = ExtrinsicHelper.createMsa(keys);
     const [MsaCreatedEvent] = await createMsaOp.fundAndSend();
-    assert.notEqual(MsaCreatedEvent, undefined, 'should have returned MsaCreated event');
+    assert.notEqual(MsaCreatedEvent, undefined, 'createMsaAndProvider: should have returned MsaCreated event');
 
     const createProviderOp = ExtrinsicHelper.createProvider(keys, providerName);
     const [ProviderCreatedEvent] = await createProviderOp.fundAndSend();
-    assert.notEqual(ProviderCreatedEvent, undefined, 'should have returned ProviderCreated event');
+    assert.notEqual(ProviderCreatedEvent, undefined, 'createMsaAndProvider: should have returned ProviderCreated event');
 
     if (ProviderCreatedEvent && ExtrinsicHelper.api.events.msa.ProviderCreated.is(ProviderCreatedEvent)) {
         return ProviderCreatedEvent.data.providerId;
     }
-    return Promise.reject('ProviderCreatedEvent should be ExtrinsicHelper.api.events.msa.ProviderCreated');
+    return Promise.reject('createMsaAndProvider: ProviderCreatedEvent should be ExtrinsicHelper.api.events.msa.ProviderCreated');
+}
+
+// Stakes the given amount of tokens from the given keys to the given provider
+export async function stakeToProvider(keys: KeyringPair, providerId: u64, amount: bigint): Promise<void> {
+    const stakeOp = ExtrinsicHelper.stake(keys, providerId, amount);
+    const [stakeEvent] = await stakeOp.fundAndSend();
+    assert.notEqual(stakeEvent, undefined, 'stakeToProvider: should have returned Stake event');
+
+    if (stakeEvent && ExtrinsicHelper.api.events.capacity.Staked.is(stakeEvent)) {
+        let stakedCapacity = stakeEvent.data.capacity;
+        assert.equal(stakedCapacity, amount, 'stakeToProvider: staked capacity should be equal to amount: ' + amount);
+    }
+    else {
+        return Promise.reject('stakeToProvider: stakeEvent should be ExtrinsicHelper.api.events.capacity.Staked');
+    }
 }


### PR DESCRIPTION
# Goal
The goal of this PR is to implement integration tests for transacting with capacity.
Closes #889 

Acceptance Criteria
- [x] When a user does not have enough capacity to pay for the transaction fee and is NOT eligible to replenish Capacity, it should error and be dropped from the transaction pool.
- [x] When a user attempts to pay for a non-capacity transaction with Capacity, it should error and drop the transaction from the transaction pool.
- [x] When Capacity has withdrawn an event CapacityWithdrawn is emitted.
- [x] When a user is not a registered provider and attempts to pay with Capacity, it should error with InvalidTransaction::Payment.
- [x] Integration test and manual test. A registered provider with Capacity but no tokens associated with the key should still be able to use polkadot UI to submit a capacity transaction.
- [x] Token transactions should not be affected by supporting Capacity transactions.
# Discussion
1. Should all capacity-eligible transactions be tested for success with pay_with_capacity()?

# Checklist
- [x] Tests added

# N/A
- [ ] Chain spec updated
- [ ] Custom RPC OR Runtime API added/changed? Updated js/api-augment.
- [ ] Design doc(s) updated
- [ ] Benchmarks added
- [ ] Weights updated