### PR TITLE
feat(stateful-signed-extension): add nonce to page content hash for r…

### DIFF
--- a/common/primitives/src/stateful_storage.rs
+++ b/common/primitives/src/stateful_storage.rs
@@ -13,6 +13,8 @@ use utils::*;
 pub type PageId = u16;
 /// PageHash is the type/size of hash of the page content.
 pub type PageHash = u32;
+/// PageNonce is the type/size of a nonce value embedded into a Page
+pub type PageNonce = u16;
 
 /// A type to expose paginated type of stateful storage
 #[cfg_attr(feature = "std", derive(Serialize, Deserialize))]
@@ -26,6 +28,8 @@ pub struct PaginatedStorageResponse {
 	pub schema_id: SchemaId,
 	/// Hash of the page content
 	pub content_hash: PageHash,
+	/// Nonce of the page
+	pub nonce: PageNonce,
 	/// Serialized data in a the schemas.
 	#[cfg_attr(feature = "std", serde(with = "as_hex", default))]
 	pub payload: Vec<u8>,
@@ -41,6 +45,8 @@ pub struct ItemizedStoragePageResponse {
 	pub schema_id: SchemaId,
 	/// Hash of the page content
 	pub content_hash: PageHash,
+	/// Nonce of the page
+	pub nonce: PageNonce,
 	/// Items in a page
 	pub items: Vec<ItemizedStorageResponse>,
 }
@@ -62,10 +68,18 @@ impl PaginatedStorageResponse {
 		index_number: u16,
 		msa_id: MessageSourceId,
 		schema_id: SchemaId,
-		payload: Vec<u8>,
 		content_hash: PageHash,
+		nonce: PageNonce,
+		payload: Vec<u8>,
 	) -> Self {
-		PaginatedStorageResponse { page_id: index_number, msa_id, schema_id, payload, content_hash }
+		PaginatedStorageResponse {
+			page_id: index_number,
+			msa_id,
+			schema_id,
+			payload,
+			content_hash,
+			nonce,
+		}
 	}
 }
 
@@ -82,8 +96,9 @@ impl ItemizedStoragePageResponse {
 		msa_id: MessageSourceId,
 		schema_id: SchemaId,
 		content_hash: PageHash,
+		nonce: PageNonce,
 		items: Vec<ItemizedStorageResponse>,
 	) -> Self {
-		ItemizedStoragePageResponse { msa_id, schema_id, content_hash, items }
+		ItemizedStoragePageResponse { msa_id, schema_id, content_hash, items, nonce }
 	}
 }

--- a/integration-tests/package-lock.json
+++ b/integration-tests/package-lock.json
@@ -697,7 +697,7 @@
         "node_modules/@frequency-chain/api-augment": {
             "version": "0.0.0",
             "resolved": "file:../js/api-augment/dist/frequency-chain-api-augment-0.0.0.tgz",
-            "integrity": "sha512-uYRHM02BTbRK7jqO7fxFxUORftrK3LmU7dimnr0TLpUPIFXzBbbEhS+Vt9FmEnYIc/Lc6wVb+02WzE0UWILSOg==",
+            "integrity": "sha512-ps22BD8DC6WDvlOFlW6jw2v7eLNLXoYhZtLOQiNOXPyX47HifZTawqLYVaTg+awSS7gbsb9ZAwGKYMAAIPJtSQ==",
             "license": "Apache-2.0",
             "dependencies": {
                 "@polkadot/api": "^9.14.2",

--- a/js/api-augment/definitions/statefulStorage.ts
+++ b/js/api-augment/definitions/statefulStorage.ts
@@ -32,6 +32,7 @@ export default {
   types: {
     PageId: "u16",
     PageHash: "u32",
+    PageNonce: "u16",
     ItemizedStorageResponse: {
       index: "u16",
       payload: "Vec<u8>",
@@ -41,12 +42,14 @@ export default {
       msa_id: "MessageSourceId",
       schema_id: "SchemaId",
       content_hash: "PageHash",
+      nonce: "PageNonce",
       payload: "Vec<u8>",
     },
     ItemizedStoragePageResponse: {
       msa_id: "MessageSourceId",
       schema_id: "SchemaId",
       content_hash: "PageHash",
+      nonce: "PageNonce",
       items: "Vec<ItemizedStorageResponse>",
     },
   },

--- a/pallets/stateful-storage/src/rpc/src/tests/mod.rs
+++ b/pallets/stateful-storage/src/rpc/src/tests/mod.rs
@@ -11,6 +11,7 @@ use substrate_test_runtime_client::runtime::Block;
 
 const SUCCESSFUL_SCHEMA_ID: u16 = 1;
 const SUCCESSFUL_MSA_ID: MessageSourceId = 1;
+const NONCE: PageNonce = 1;
 const SUCCESSFUL_PAYLOAD: &[u8; 33] = b"{'body':827, 'val':'another val'}";
 const DUMMY_STATE_HASH: u32 = 32767;
 
@@ -23,8 +24,10 @@ sp_api::mock_impl_runtime_apis! {
 					0,
 					msa_id,
 					schema_id,
+					DUMMY_STATE_HASH,
+					NONCE,
 					SUCCESSFUL_PAYLOAD.to_vec(),
-					DUMMY_STATE_HASH)]),
+					)]),
 				_ => Err(DispatchError::Other("some error")),
 			}
 		}
@@ -35,6 +38,7 @@ sp_api::mock_impl_runtime_apis! {
 					msa_id,
 					schema_id,
 					DUMMY_STATE_HASH,
+					NONCE,
 					vec![ItemizedStorageResponse::new(0,SUCCESSFUL_PAYLOAD.to_vec())])),
 				_ => Err(DispatchError::Other("some error")),
 			}
@@ -87,6 +91,7 @@ async fn get_paginated_storage_with_success() {
 	assert_eq!(0, page.page_id);
 	assert_eq!(SUCCESSFUL_MSA_ID, page.msa_id);
 	assert_eq!(SUCCESSFUL_SCHEMA_ID, page.schema_id);
+	assert_eq!(NONCE, page.nonce);
 	assert_eq!(SUCCESSFUL_PAYLOAD.to_vec(), page.payload);
 }
 
@@ -131,6 +136,7 @@ async fn get_itemized_storage_with_success() {
 	assert_eq!(1, items.len());
 	assert_eq!(SUCCESSFUL_MSA_ID, page.msa_id);
 	assert_eq!(SUCCESSFUL_SCHEMA_ID, page.schema_id);
+	assert_eq!(NONCE, page.nonce);
 	assert_eq!(DUMMY_STATE_HASH, page.content_hash);
 	assert_eq!(ItemizedStorageResponse::new(0, SUCCESSFUL_PAYLOAD.to_vec()), items[0]);
 }

--- a/pallets/stateful-storage/src/tests.rs
+++ b/pallets/stateful-storage/src/tests.rs
@@ -6,7 +6,7 @@ use crate::{
 use codec::{Decode, Encode, MaxEncodedLen};
 use common_primitives::{
 	schema::{ModelType, PayloadLocation, SchemaId},
-	stateful_storage::{PageHash, PageId},
+	stateful_storage::{PageHash, PageId, PageNonce},
 	utils::wrap_binary_data,
 };
 use frame_support::{assert_err, assert_ok, assert_storage_noop, traits::Len, BoundedVec};
@@ -33,15 +33,27 @@ fn generate_payload_bytes<T: Get<u32>>(id: Option<u8>) -> BoundedVec<u8, T> {
 		.unwrap()
 }
 
+fn generate_page<T: Get<u32>>(in_nonce: Option<PageNonce>, id: Option<u8>) -> Page<T> {
+	let nonce = in_nonce.unwrap_or_default();
+	Page::<T> { nonce, data: generate_payload_bytes(id) }
+}
+
+fn add_itemized_payload_to_buffer<T: Config>(buffer: &mut Vec<u8>, payload: &[u8]) {
+	buffer.extend_from_slice(&ItemHeader { payload_len: payload.len() as u16 }.encode()[..]);
+	buffer.extend_from_slice(payload);
+}
+
 fn create_itemized_page_from<T: pallet::Config>(
+	nonce_in: Option<PageNonce>,
 	payloads: &[BoundedVec<u8, ItemizedBlobSize>],
 ) -> ItemizedPage<T> {
+	let nonce = nonce_in.unwrap_or_default();
 	let mut buffer: Vec<u8> = vec![];
 	for p in payloads {
-		buffer.extend_from_slice(&ItemHeader { payload_len: p.len() as u16 }.encode()[..]);
-		buffer.extend_from_slice(p.as_slice());
+		add_itemized_payload_to_buffer::<T>(&mut buffer, p.as_slice());
 	}
-	ItemizedPage::<T>::try_from(buffer).unwrap()
+	let data = BoundedVec::<u8, T::MaxItemizedPageSizeBytes>::try_from(buffer).unwrap();
+	ItemizedPage::<T> { nonce, data }
 }
 
 fn hash_payload(data: &[u8]) -> PageHash {
@@ -212,7 +224,7 @@ fn upsert_existing_page_with_bad_state_hash_errors() {
 		let caller_1 = test_public(msa_id);
 		let schema_id = PAGINATED_SCHEMA;
 		let page_id = 1;
-		let payload = generate_payload_bytes::<PaginatedPageSize>(Some(100));
+		let page = generate_page::<PaginatedPageSize>(None, Some(100));
 
 		let key = (schema_id, page_id);
 		<StatefulChildTree>::write(
@@ -220,7 +232,7 @@ fn upsert_existing_page_with_bad_state_hash_errors() {
 			PALLET_STORAGE_PREFIX,
 			PAGINATED_STORAGE_PREFIX,
 			&key,
-			&payload,
+			&page,
 		);
 
 		assert_err!(
@@ -230,7 +242,7 @@ fn upsert_existing_page_with_bad_state_hash_errors() {
 				schema_id,
 				page_id,
 				0u32,
-				payload
+				page.data,
 			),
 			Error::<Test>::StalePageState
 		)
@@ -258,15 +270,16 @@ fn upsert_new_page_succeeds() {
 		));
 
 		let keys = (schema_id, page_id);
-		let new_page = <StatefulChildTree>::try_read(
+		let new_page: PaginatedPage<Test> = <StatefulChildTree>::try_read(
 			&msa_id,
 			PALLET_STORAGE_PREFIX,
 			PAGINATED_STORAGE_PREFIX,
 			&keys,
 		)
-		.unwrap();
-		assert_eq!(new_page.is_some(), true, "new page is empty");
-		assert_eq!(page, new_page.unwrap(), "new page contents incorrect");
+		.unwrap()
+		.expect("new page is empty");
+		assert_eq!(page.data, new_page.data, "new page contents incorrect");
+		assert_eq!(new_page.nonce, 1, "new page nonce incorrect");
 	})
 }
 
@@ -458,16 +471,15 @@ fn delete_existing_page_with_bad_hash_errors() {
 		let caller_1 = test_public(msa_id);
 		let schema_id = PAGINATED_SCHEMA;
 		let page_id = 11;
-		let payload = generate_payload_bytes::<PaginatedPageSize>(None);
-		let page: PaginatedPage<Test> = payload.into();
+		let page: PaginatedPage<Test> = generate_page(None, None);
 
 		let keys = (schema_id, page_id);
-		<StatefulChildTree>::write::<_, Vec<u8>>(
+		<StatefulChildTree>::write(
 			&msa_id,
 			PALLET_STORAGE_PREFIX,
 			PAGINATED_STORAGE_PREFIX,
 			&keys,
-			page.data.into(),
+			&page,
 		);
 
 		assert_err!(
@@ -491,18 +503,17 @@ fn delete_existing_page_succeeds() {
 		let caller_1 = test_public(msa_id);
 		let schema_id = PAGINATED_SCHEMA;
 		let page_id = 11;
-		let payload = generate_payload_bytes::<PaginatedPageSize>(None);
-		let page: PaginatedPage<Test> = payload.clone().into();
+		let page: PaginatedPage<Test> = generate_page(None, None);
 		let page_hash = page.get_hash();
+		let keys = (schema_id, page_id);
 
-		assert_ok!(StatefulStoragePallet::upsert_page(
-			RuntimeOrigin::signed(caller_1.clone()),
-			msa_id,
-			schema_id,
-			page_id,
-			NONEXISTENT_PAGE_HASH,
-			payload.into(),
-		));
+		<StatefulChildTree>::write(
+			&msa_id,
+			PALLET_STORAGE_PREFIX,
+			PAGINATED_STORAGE_PREFIX,
+			&keys,
+			&page,
+		);
 
 		assert_ok!(StatefulStoragePallet::delete_page(
 			RuntimeOrigin::signed(caller_1),
@@ -512,7 +523,6 @@ fn delete_existing_page_succeeds() {
 			page_hash
 		));
 
-		let keys = (schema_id, page_id);
 		let page: Option<PaginatedPage<Test>> = <StatefulChildTree>::try_read(
 			&msa_id,
 			PALLET_STORAGE_PREFIX,
@@ -531,7 +541,7 @@ fn parsing_a_well_formed_item_page_should_work() {
 		generate_payload_bytes::<ItemizedBlobSize>(Some(1)),
 		generate_payload_bytes::<ItemizedBlobSize>(Some(2)),
 	];
-	let page = create_itemized_page_from::<Test>(&payloads);
+	let page = create_itemized_page_from::<Test>(None, &payloads);
 
 	// act
 	let parsed = ItemizedOperations::<Test>::try_parse(&page, true);
@@ -576,8 +586,8 @@ fn applying_delete_action_with_existing_index_should_delete_item() {
 		generate_payload_bytes::<ItemizedBlobSize>(Some(2)),
 		generate_payload_bytes::<ItemizedBlobSize>(Some(4)),
 	];
-	let page = create_itemized_page_from::<Test>(payloads.as_slice());
-	let expecting_page = create_itemized_page_from::<Test>(&payloads[1..]);
+	let page = create_itemized_page_from::<Test>(None, payloads.as_slice());
+	let expecting_page = create_itemized_page_from::<Test>(None, &payloads[1..]);
 	let actions = vec![ItemAction::Delete { index: 0 }];
 
 	// act
@@ -592,11 +602,15 @@ fn applying_delete_action_with_existing_index_should_delete_item() {
 #[test]
 fn applying_add_action_should_add_item_to_the_end_of_the_page() {
 	// arrange
-	let payload1 = vec![generate_payload_bytes::<ItemizedBlobSize>(Some(2))];
-	let page = create_itemized_page_from::<Test>(payload1.as_slice());
-	let payload2 = vec![generate_payload_bytes::<ItemizedBlobSize>(Some(4))];
-	let expecting_page =
-		create_itemized_page_from::<Test>(&vec![payload1[0].clone(), payload2[0].clone()][..]);
+	let payload1 =
+		vec![generate_payload_bytes::<<Test as Config>::MaxItemizedBlobSizeBytes>(Some(2))];
+	let page = create_itemized_page_from::<Test>(None, payload1.as_slice());
+	let payload2 =
+		vec![generate_payload_bytes::<<Test as Config>::MaxItemizedBlobSizeBytes>(Some(4))];
+	let expecting_page = create_itemized_page_from::<Test>(
+		None,
+		&vec![payload1[0].clone(), payload2[0].clone()][..],
+	);
 	let actions = vec![ItemAction::Add { data: payload2[0].clone().into() }];
 
 	// act
@@ -615,7 +629,7 @@ fn applying_delete_action_with_non_existing_index_should_fail() {
 		generate_payload_bytes::<ItemizedBlobSize>(Some(2)),
 		generate_payload_bytes::<ItemizedBlobSize>(Some(4)),
 	];
-	let page = create_itemized_page_from::<Test>(payloads.as_slice());
+	let page = create_itemized_page_from::<Test>(None, payloads.as_slice());
 	let actions = vec![ItemAction::Delete { index: 2 }];
 
 	// act
@@ -628,19 +642,18 @@ fn applying_delete_action_with_non_existing_index_should_fail() {
 #[test]
 fn applying_add_action_with_full_page_should_fail() {
 	// arrange
-	let new_payload = generate_payload_bytes::<ItemizedBlobSize>(Some(2));
-	let page_len =
-		ItemizedPageSize::get() as usize - ItemHeader::max_encoded_len() - new_payload.len();
-	let mut current_data = 0;
-	let mut items = vec![];
-	while current_data < page_len {
-		let item: BoundedVec<u8, ItemizedBlobSize> =
-			BoundedVec::try_from(vec![1u8; ItemizedBlobSize::get() as usize]).unwrap();
-		items.push(item);
-		current_data = create_itemized_page_from::<Test>(&items[..]).data.len();
+	let payload: Vec<u8> = vec![1u8; ItemizedBlobSize::get() as usize];
+	let size_to_fill = (<Test as Config>::MaxItemizedPageSizeBytes::get() as usize) -
+		sp_std::mem::size_of::<PageNonce>();
+	let mut item_buffer = Vec::<u8>::with_capacity(size_to_fill);
+	while (size_to_fill as i32).saturating_sub(item_buffer.len().try_into().unwrap()) >
+		ItemizedBlobSize::get().try_into().unwrap()
+	{
+		add_itemized_payload_to_buffer::<Test>(&mut item_buffer, &payload.as_slice());
 	}
-	let page = create_itemized_page_from::<Test>(&items[..]);
-	let actions = vec![ItemAction::Add { data: new_payload.clone().into() }];
+	let page: ItemizedPage<Test> =
+		ItemizedPage::<Test> { nonce: 0, data: item_buffer.try_into().unwrap() };
+	let actions = vec![ItemAction::Add { data: payload.try_into().unwrap() }];
 
 	// act
 	let result = ItemizedOperations::<Test>::apply_item_actions(&page, &actions[..]);
@@ -651,14 +664,15 @@ fn applying_add_action_with_full_page_should_fail() {
 
 #[test]
 fn is_empty_false_for_non_empty_page() {
-	let page: ItemizedPage<Test> = vec![1].try_into().unwrap();
+	let page: ItemizedPage<Test> =
+		create_itemized_page_from::<Test>(None, &[generate_payload_bytes(None)]);
 
 	assert_eq!(page.is_empty(), false);
 }
 
 #[test]
 fn is_empty_true_for_empty_page() {
-	let page: ItemizedPage<Test> = Vec::<u8>::new().try_into().unwrap();
+	let page: ItemizedPage<Test> = create_itemized_page_from::<Test>(None, &[]);
 
 	assert_eq!(page.is_empty(), true);
 }
@@ -890,14 +904,15 @@ fn apply_item_actions_with_corrupted_state_should_fail() {
 		let caller_1 = test_public(msa_id);
 		let schema_id = ITEMIZED_SCHEMA;
 		let payload = vec![1; 5];
+		let page: ItemizedPage<Test> = generate_page(None, None);
 		let actions1 = vec![ItemAction::Add { data: payload.clone().try_into().unwrap() }];
 		let key = (schema_id,);
-		StatefulChildTree::<<Test as Config>::KeyHasher>::write::<_, Vec<u8>>(
+		StatefulChildTree::<<Test as Config>::KeyHasher>::write(
 			&msa_id,
 			PALLET_STORAGE_PREFIX,
 			ITEMIZED_STORAGE_PREFIX,
 			&key,
-			payload,
+			&page,
 		);
 		let previous_page: ItemizedPage<Test> =
 			StatefulChildTree::<<Test as Config>::KeyHasher>::try_read(
@@ -960,14 +975,16 @@ fn apply_item_actions_existing_page_with_stale_hash_should_fail() {
 
 		let page = ItemizedPage::<Test>::default();
 		let page_hash = page.get_hash();
-		let page = ItemizedOperations::<Test>::apply_item_actions(&page, &actions1).unwrap();
+		let mut new_page =
+			ItemizedOperations::<Test>::apply_item_actions(&page, &actions1).unwrap();
+		new_page.nonce = 1;
 		let key = (schema_id,);
-		<StatefulChildTree>::write::<_, Vec<u8>>(
+		<StatefulChildTree>::write(
 			&msa_id,
 			PALLET_STORAGE_PREFIX,
 			ITEMIZED_STORAGE_PREFIX,
 			&key,
-			page.data.into(),
+			&new_page,
 		);
 
 		// act
@@ -1035,19 +1052,18 @@ fn apply_item_actions_existing_page_with_valid_input_should_update_storage() {
 		let caller_1 = test_public(msa_id);
 		let schema_id = ITEMIZED_SCHEMA;
 		let payload = vec![1; 5];
-		let actions = vec![ItemAction::Add { data: payload.try_into().unwrap() }];
-		let page = ItemizedPage::<Test>::default();
-		let page = ItemizedOperations::<Test>::apply_item_actions(&page, &actions).unwrap();
+		let actions = vec![ItemAction::Add { data: payload.clone().try_into().unwrap() }];
+		let page = create_itemized_page_from::<Test>(None, &[payload.try_into().unwrap()]);
 		let prev_content_hash = page.get_hash();
 		let key = (schema_id,);
 
 		// act
-		<StatefulChildTree>::write::<_, Vec<u8>>(
+		<StatefulChildTree>::write(
 			&msa_id,
 			PALLET_STORAGE_PREFIX,
 			ITEMIZED_STORAGE_PREFIX,
 			&key,
-			page.data.into(),
+			&page,
 		);
 		assert_ok!(StatefulStoragePallet::apply_item_actions(
 			RuntimeOrigin::signed(caller_1),
@@ -1443,12 +1459,12 @@ fn apply_item_actions_with_signature_having_page_with_stale_hash_should_fail() {
 		let page_hash = page.get_hash();
 		let page = ItemizedOperations::<Test>::apply_item_actions(&page, &actions).unwrap();
 		let key = (schema_id,);
-		<StatefulChildTree>::write::<_, Vec<u8>>(
+		<StatefulChildTree>::write(
 			&msa_id,
 			PALLET_STORAGE_PREFIX,
 			ITEMIZED_STORAGE_PREFIX,
 			&key,
-			page.data.into(),
+			page,
 		);
 		let payload = ItemizedSignaturePayload {
 			actions: BoundedVec::try_from(actions).unwrap(),
@@ -1552,14 +1568,15 @@ fn apply_item_actions_with_signature_having_corrupted_state_should_fail() {
 		let delegator_key = pair.public();
 		let schema_id = ITEMIZED_SCHEMA;
 		let payload = vec![1; 5];
+		let page: ItemizedPage<Test> = generate_page(None, None);
 		let actions = vec![ItemAction::Add { data: payload.clone().try_into().unwrap() }];
 		let key = (schema_id,);
-		StatefulChildTree::<<Test as Config>::KeyHasher>::write::<_, Vec<u8>>(
+		StatefulChildTree::<<Test as Config>::KeyHasher>::write(
 			&msa_id,
 			PALLET_STORAGE_PREFIX,
 			ITEMIZED_STORAGE_PREFIX,
 			&key,
-			payload,
+			&page,
 		);
 		let previous_page: ItemizedPage<Test> =
 			StatefulChildTree::<<Test as Config>::KeyHasher>::try_read(
@@ -1938,22 +1955,23 @@ fn upsert_page_with_signature_having_valid_inputs_should_work() {
 
 		// assert
 		let keys = (schema_id, page_id);
-		let new_page = <StatefulChildTree>::try_read(
+		let new_page: PaginatedPage<Test> = <StatefulChildTree>::try_read(
 			&msa_id,
 			PALLET_STORAGE_PREFIX,
 			PAGINATED_STORAGE_PREFIX,
 			&keys,
 		)
-		.unwrap();
-		assert_eq!(new_page.is_some(), true, "new page is empty");
-		assert_eq!(page, new_page.unwrap(), "new page contents incorrect");
+		.expect("new page could not be read")
+		.expect("new page is empty");
+		assert_eq!(page.data, new_page.data, "new page contents incorrect");
+		assert_eq!(new_page.nonce, 1, "new page nonce incorrect");
 		System::assert_last_event(
 			StatefulEvent::PaginatedPageUpdated {
 				msa_id,
 				schema_id,
 				page_id,
 				prev_content_hash: PageHash::default(),
-				curr_content_hash: page.get_hash(),
+				curr_content_hash: new_page.get_hash(),
 			}
 			.into(),
 		);
@@ -2304,16 +2322,14 @@ fn delete_page_with_signature_having_valid_inputs_should_remove_page() {
 		let delegator_key = pair.public();
 		let schema_id = PAGINATED_SCHEMA;
 		let page_id = 1;
-		let payload = generate_payload_bytes::<PaginatedPageSize>(Some(100));
-		let page: PaginatedPage<Test> = payload.clone().into();
-		assert_ok!(StatefulStoragePallet::upsert_page(
-			RuntimeOrigin::signed(caller_1.clone()),
-			msa_id,
-			schema_id,
-			page_id,
-			NONEXISTENT_PAGE_HASH,
-			payload.into(),
-		));
+		let page = generate_page::<PaginatedPageSize>(Some(1), Some(100));
+		<StatefulChildTree>::write(
+			&msa_id,
+			PALLET_STORAGE_PREFIX,
+			PAGINATED_STORAGE_PREFIX,
+			&(schema_id, page_id),
+			&page,
+		);
 
 		let payload = PaginatedDeleteSignaturePayload {
 			target_hash: page.get_hash(),
@@ -2479,4 +2495,139 @@ fn insert_page_fails_for_signature_schema() {
 			Error::<Test>::UnsupportedOperationForSchema
 		);
 	});
+}
+
+#[test]
+fn signature_replay_on_existing_page_errors() {
+	new_test_ext().execute_with(|| {
+		// Setup
+		let caller_1 = test_public(1);
+		let (msa_id, pair) = get_signature_account();
+		let delegator_key = pair.public();
+		let schema_id = PAGINATED_SCHEMA;
+		let page_id = 1;
+		let keys = (schema_id, page_id);
+		let page_a: PaginatedPage<Test> = generate_page(Some(1), Some(1));
+		let page_b: PaginatedPage<Test> = generate_page(Some(2), Some(2));
+		let payload_a_to_b = PaginatedUpsertSignaturePayload {
+			msa_id,
+			expiration: 10,
+			schema_id,
+			page_id,
+			target_hash: page_a.get_hash(),
+			payload: page_b.data.clone(),
+		};
+
+		// Set up initial state A
+		<StatefulChildTree>::write(
+			&msa_id,
+			PALLET_STORAGE_PREFIX,
+			PAGINATED_STORAGE_PREFIX,
+			&keys,
+			&page_a,
+		);
+
+		// Make sure we successfully apply state transition A -> B
+		let encoded_payload = wrap_binary_data(payload_a_to_b.encode());
+		let owner_a_to_b_signature: MultiSignature = pair.sign(&encoded_payload).into();
+		assert_ok!(StatefulStoragePallet::upsert_page_with_signature(
+			RuntimeOrigin::signed(caller_1.clone()),
+			delegator_key.into(),
+			owner_a_to_b_signature.clone(),
+			payload_a_to_b.clone()
+		));
+
+		// Read back page state & get hash
+		let current_page: PaginatedPage<Test> =
+			StatefulChildTree::<<Test as Config>::KeyHasher>::try_read(
+				&msa_id,
+				PALLET_STORAGE_PREFIX,
+				PAGINATED_STORAGE_PREFIX,
+				&keys,
+			)
+			.unwrap()
+			.expect("no page read");
+
+		// Make sure we successfully apply state transition B -> A
+		assert_ok!(StatefulStoragePallet::upsert_page(
+			RuntimeOrigin::signed(caller_1.clone()),
+			msa_id,
+			schema_id,
+			page_id,
+			current_page.get_hash(),
+			page_a.data
+		));
+
+		// Signature replay A -> B should fail
+		assert_err!(
+			StatefulStoragePallet::upsert_page_with_signature(
+				RuntimeOrigin::signed(caller_1),
+				delegator_key.into(),
+				owner_a_to_b_signature,
+				payload_a_to_b
+			),
+			Error::<Test>::StalePageState
+		);
+	})
+}
+
+// NOTE: This is a known issue. When it's fixed, this test will start failing & we can change the test assertion.
+#[test]
+fn signature_replay_on_deleted_page_check() {
+	new_test_ext().execute_with(|| {
+		// Setup
+		let caller_1 = test_public(1);
+		let (msa_id, pair) = get_signature_account();
+		let delegator_key = pair.public();
+		let schema_id = PAGINATED_SCHEMA;
+		let page_id = 1;
+		let keys = (schema_id, page_id);
+		let page_a: PaginatedPage<Test> = generate_page(Some(1), Some(1));
+		let payload_null_to_a = PaginatedUpsertSignaturePayload {
+			msa_id,
+			expiration: 10,
+			schema_id,
+			page_id,
+			target_hash: NONEXISTENT_PAGE_HASH,
+			payload: page_a.data.clone(),
+		};
+
+		// Make sure we successfully apply state transition Null -> A
+		let encoded_payload = wrap_binary_data(payload_null_to_a.encode());
+		let owner_null_to_a_signature: MultiSignature = pair.sign(&encoded_payload).into();
+		assert_ok!(StatefulStoragePallet::upsert_page_with_signature(
+			RuntimeOrigin::signed(caller_1.clone()),
+			delegator_key.into(),
+			owner_null_to_a_signature.clone(),
+			payload_null_to_a.clone()
+		));
+
+		// Read back page state & get hash
+		let current_page: PaginatedPage<Test> =
+			StatefulChildTree::<<Test as Config>::KeyHasher>::try_read(
+				&msa_id,
+				PALLET_STORAGE_PREFIX,
+				PAGINATED_STORAGE_PREFIX,
+				&keys,
+			)
+			.unwrap()
+			.expect("no page read");
+
+		// Make sure we successfully delete the page
+		assert_ok!(StatefulStoragePallet::delete_page(
+			RuntimeOrigin::signed(caller_1.clone()),
+			msa_id,
+			schema_id,
+			page_id,
+			current_page.get_hash(),
+		));
+
+		// Signature replay A -> B (change assertion when this vulnerability is fixed)
+		assert_ok!(StatefulStoragePallet::upsert_page_with_signature(
+			RuntimeOrigin::signed(caller_1.clone()),
+			delegator_key.into(),
+			owner_null_to_a_signature,
+			payload_null_to_a
+		));
+	})
 }


### PR DESCRIPTION
# Goal
The goal of this PR is to add a nonce to the Stateful Storage page content hash, in order to prevent signature replay attacks. Specifically, the following scenario:
* Signed payload A submitted changes page state from A -> B
* (some intervening state transitions)
* Some state transition B -> A
* Replay signed payload A to transition A -> B

NOTE: Known exception, this will not close the following:
* Signed payload A changes page state from (no page) -> A
* (some intervening transitions)
* Page deleted
* Replay signed payload A to transition (no page) -> A

Closes #1206 


