### PR TITLE
Added "mach" crate to cargo deny ignore list.

### DIFF
--- a/.cargo-deny.toml
+++ b/.cargo-deny.toml
@@ -92,6 +92,8 @@ ignore = [
     # Substrate depednency
     #    Windows issue, does not effect Frequency
     "RUSTSEC-2021-0145",
+    # There is no suitable replacement for mach and the mach2 crate has not been vetted.
+    "RUSTSEC-2020-0168",
 ]
 # Threshold for security vulnerabilities, any vulnerability with a CVSS score
 # lower than the range specified will be ignored. Note that ignored advisories


### PR DESCRIPTION
# Goal
The goal of this PR is to temporarily work around `mach` crate security issue.

Closes #1228
