### PR TITLE
feat(capacity): allow p.g tx's to pay with capacity

### DIFF
--- a/pallets/frequency-tx-payment/src/capacity_stable_weights.rs
+++ b/pallets/frequency-tx-payment/src/capacity_stable_weights.rs
@@ -61,6 +61,13 @@ pub trait WeightInfo {
 	// Messages
 	fn add_onchain_message(n: u32, ) -> Weight;
 	fn add_ipfs_message() -> Weight;
+	// Stateful-storage
+	fn apply_item_actions(n: u32, ) -> Weight;
+	fn upsert_page(s: u32, ) -> Weight;
+	fn delete_page() -> Weight;
+	fn apply_item_actions_with_signature(s: u32, ) -> Weight;
+	fn upsert_page_with_signature(s: u32, ) -> Weight;
+	fn delete_page_with_signature() -> Weight;
 }
 
 /// Weights for pallet_msa using the Substrate node and recommended hardware.
@@ -132,5 +139,63 @@ impl<T: frame_system::Config> WeightInfo for SubstrateWeight<T> {
 			.saturating_add(T::DbWeight::get().reads(3 as u64))
 			.saturating_add(T::DbWeight::get().writes(1 as u64))
 	}
+	// Storage: Schemas Schemas (r:1 w:0)
+	// Storage: Msa PublicKeyToMsaId (r:1 w:0)
+	// Storage: Msa DelegatorAndProviderToDelegation (r:1 w:0)
+	// Storage: unknown [0xbd1557c8db6bd8599a811a7175fbc2fc6400] (r:1 w:1)
+	fn apply_item_actions(s: u32, ) -> Weight {
+		Weight::from_ref_time(66_026_301 as u64)
+			// Standard Error: 161
+			.saturating_add(Weight::from_ref_time(2_145 as u64).saturating_mul(s as u64))
+			.saturating_add(T::DbWeight::get().reads(4 as u64))
+			.saturating_add(T::DbWeight::get().writes(1 as u64))
+	}
+	// Storage: Schemas Schemas (r:1 w:0)
+	// Storage: Msa PublicKeyToMsaId (r:1 w:0)
+	// Storage: Msa DelegatorAndProviderToDelegation (r:1 w:0)
+	// Storage: unknown [0x0763c98381dc89abe38627fe2f98cb7af1577fbf1d628fdddb4ebfc6e8d95fb1] (r:1 w:1)
+	fn upsert_page(s: u32, ) -> Weight {
+		Weight::from_ref_time(23_029_186 as u64)
+			// Standard Error: 53
+			.saturating_add(Weight::from_ref_time(339 as u64).saturating_mul(s as u64))
+			.saturating_add(T::DbWeight::get().reads(4 as u64))
+			.saturating_add(T::DbWeight::get().writes(1 as u64))
+	}
+	// Storage: Schemas Schemas (r:1 w:0)
+	// Storage: Msa PublicKeyToMsaId (r:1 w:0)
+	// Storage: Msa DelegatorAndProviderToDelegation (r:1 w:0)
+	// Storage: unknown [0x0763c98381dc89abe38627fe2f98cb7af1577fbf1d628fdddb4ebfc6e8d95fb1] (r:1 w:1)
+	fn delete_page() -> Weight {
+		Weight::from_ref_time(26_000_000 as u64)
+			.saturating_add(T::DbWeight::get().reads(4 as u64))
+			.saturating_add(T::DbWeight::get().writes(1 as u64))
+	}
+	// Storage: Msa PublicKeyToMsaId (r:1 w:0)
+	// Storage: Schemas Schemas (r:1 w:0)
+	// Storage: unknown [0xbd1557c8db6bd8599a811a7175fbc2fc6400] (r:1 w:1)
+	fn apply_item_actions_with_signature(s: u32, ) -> Weight {
+		Weight::from_ref_time(105_921_191 as u64)
+			// Standard Error: 267
+			.saturating_add(Weight::from_ref_time(6_150 as u64).saturating_mul(s as u64))
+			.saturating_add(T::DbWeight::get().reads(3 as u64))
+			.saturating_add(T::DbWeight::get().writes(1 as u64))
+	}
+	// Storage: Msa PublicKeyToMsaId (r:1 w:0)
+	// Storage: Schemas Schemas (r:1 w:0)
+	// Storage: unknown [0x0763c98381dc89abe38627fe2f98cb7af1577fbf1d628fdddb4ebfc6e8d95fb1] (r:1 w:1)
+	fn upsert_page_with_signature(s: u32, ) -> Weight {
+		Weight::from_ref_time(61_324_707 as u64)
+			// Standard Error: 249
+			.saturating_add(Weight::from_ref_time(4_406 as u64).saturating_mul(s as u64))
+			.saturating_add(T::DbWeight::get().reads(3 as u64))
+			.saturating_add(T::DbWeight::get().writes(1 as u64))
+	}
+	// Storage: Msa PublicKeyToMsaId (r:1 w:0)
+	// Storage: Schemas Schemas (r:1 w:0)
+	// Storage: unknown [0x0763c98381dc89abe38627fe2f98cb7af1577fbf1d628fdddb4ebfc6e8d95fb1] (r:1 w:1)
+	fn delete_page_with_signature() -> Weight {
+		Weight::from_ref_time(65_000_000 as u64)
+			.saturating_add(T::DbWeight::get().reads(3 as u64))
+			.saturating_add(T::DbWeight::get().writes(1 as u64))
+	}
 }
-

--- a/pallets/stateful-storage/src/lib.rs
+++ b/pallets/stateful-storage/src/lib.rs
@@ -261,12 +261,7 @@ pub mod pallet {
 		/// * [`Event::ItemizedPageDeleted`]
 		///
 		#[pallet::call_index(0)]
-		#[pallet::weight(T::WeightInfo::apply_item_actions(
-			actions.iter().fold(0, |acc, a| acc.saturating_add(match a {
-				ItemAction::Add { data } => data.len() as u32,
-				_ => 0,
-			}))
-		))]
+		#[pallet::weight(T::WeightInfo::apply_item_actions(Pallet::<T>::sum_add_actions_bytes(actions)))]
 		pub fn apply_item_actions(
 			origin: OriginFor<T>,
 			#[pallet::compact] state_owner_msa_id: MessageSourceId,
@@ -352,10 +347,7 @@ pub mod pallet {
 		///
 		#[pallet::call_index(3)]
 		#[pallet::weight(T::WeightInfo::apply_item_actions_with_signature(
-			payload.actions.iter().fold(0, |acc, a| acc.saturating_add(match a {
-				ItemAction::Add { data } => data.len() as u32,
-				_ => 0,
-			}))
+			Pallet::<T>::sum_add_actions_bytes(&payload.actions)
 		))]
 		pub fn apply_item_actions_with_signature(
 			origin: OriginFor<T>,
@@ -456,6 +448,21 @@ pub mod pallet {
 }
 
 impl<T: Config> Pallet<T> {
+	/// Sums the total bytes of each item actions
+	pub fn sum_add_actions_bytes(
+		actions: &BoundedVec<
+			ItemAction<<T as Config>::MaxItemizedBlobSizeBytes>,
+			<T as Config>::MaxItemizedActionsCount,
+		>,
+	) -> u32 {
+		actions.iter().fold(0, |acc, a| {
+			acc.saturating_add(match a {
+				ItemAction::Add { data } => data.len() as u32,
+				_ => 0,
+			})
+		})
+	}
+
 	/// This function returns all the paginated storage associated with `msa_id` and `schema_id`
 	///
 	/// Warning: since this function iterates over all the potential keys it should never called

--- a/runtime/frequency/src/lib.rs
+++ b/runtime/frequency/src/lib.rs
@@ -891,6 +891,7 @@ impl pallet_transaction_payment::Config for Runtime {
 
 use pallet_messages::Call as MessagesCall;
 use pallet_msa::Call as MsaCall;
+use pallet_stateful_storage::Call as StatefulStorageCall;
 
 pub struct CapacityEligibleCalls;
 impl GetStableWeight<RuntimeCall, Weight> for CapacityEligibleCalls {
@@ -904,6 +905,12 @@ impl GetStableWeight<RuntimeCall, Weight> for CapacityEligibleCalls {
 			RuntimeCall::Msa(MsaCall::grant_delegation { add_provider_payload, .. }) => Some(capacity_stable_weights::SubstrateWeight::<Runtime>::grant_delegation(add_provider_payload.schema_ids.len() as u32)),
 			RuntimeCall::Messages(MessagesCall::add_ipfs_message { .. }) => Some(capacity_stable_weights::SubstrateWeight::<Runtime>::add_ipfs_message()),
 			RuntimeCall::Messages(MessagesCall::add_onchain_message { payload, .. }) => Some(capacity_stable_weights::SubstrateWeight::<Runtime>::add_onchain_message(payload.len() as u32)),
+			RuntimeCall::StatefulStorage(StatefulStorageCall::apply_item_actions { actions, ..}) => Some(capacity_stable_weights::SubstrateWeight::<Runtime>::apply_item_actions(StatefulStorage::sum_add_actions_bytes(actions))),
+			RuntimeCall::StatefulStorage(StatefulStorageCall::upsert_page { payload, ..}) => Some(capacity_stable_weights::SubstrateWeight::<Runtime>::upsert_page(payload.len() as u32)),
+			RuntimeCall::StatefulStorage(StatefulStorageCall::delete_page { .. }) => Some(capacity_stable_weights::SubstrateWeight::<Runtime>::delete_page()),
+			RuntimeCall::StatefulStorage(StatefulStorageCall::apply_item_actions_with_signature { payload, ..}) => Some(capacity_stable_weights::SubstrateWeight::<Runtime>::apply_item_actions_with_signature(StatefulStorage::sum_add_actions_bytes(&payload.actions))),
+			RuntimeCall::StatefulStorage(StatefulStorageCall::upsert_page_with_signature { payload, ..}) => Some(capacity_stable_weights::SubstrateWeight::<Runtime>::upsert_page_with_signature(payload.payload.len() as u32 )),
+			RuntimeCall::StatefulStorage(StatefulStorageCall::delete_page_with_signature { .. }) => Some(capacity_stable_weights::SubstrateWeight::<Runtime>::delete_page_with_signature()),
 			_ => None,
 		}
 	}


### PR DESCRIPTION
# Goal
Allow for the following private-graph calls to pay transaction fees with capacity:
- apply_item_actions
- upsert_page
- delete_page
- apply_item_actions_with_signature
- upsert_page_with_signature
- delete_page_with_signature

The fees for these transactions in Capacity are fixed to this point in time by
not allowing new benchmarks to affect the weight of these transactions.

issue-1266