### PR TITLE
enable release workflow to enter release tag via UI

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -25,26 +25,18 @@ env:
 jobs:
   validate-release-version:
     runs-on: ubuntu-20.04
-    name: Validate Release Version Tag
+    name: Validate Release Version
     steps:
-      - name: XXX Debug
-        run: |
-          echo "NEW_RELEASE_TAG_FROM_UI: $NEW_RELEASE_TAG_FROM_UI"
-          echo "NEW_RELEASE_TAG: $NEW_RELEASE_TAG"
-          echo "RELEASE_BRANCH_NAME: $RELEASE_BRANCH_NAME"
-          echo "TEST_RUN: $TEST_RUN"
       - name: Validate
         if: env.NEW_RELEASE_TAG_FROM_UI != ''
         shell: bash
         run: |
           version=${{env.NEW_RELEASE_TAG_FROM_UI}}
-          echo "Release version: $version"
+          echo "Release version entered in UI: $version"
           regex='^v(0|[1-9]\d*)\.(0|[1-9]\d*)\.(0|[1-9]\d*)(-rc[1-9]\d*)?$'
-          if [[ $version =~ $regex ]]; then
-            echo "The $version version is valid"
-            exit 0
-          else
-            echo "ERROR. The $version is not a valid version."
+          if [[ ! $version =~ $regex ]]; then
+            echo "ERROR: Entered version $version is not valid."
+            echo "Please use v#.#.#[-rc#] format."
             exit 1
           fi
 


### PR DESCRIPTION
# Goal
The goal of this PR is allow non-technical folks to kick off release workflow via UI in: https://github.com/LibertyDSNP/frequency/actions/workflows/release.yml. Please see screenshot below.

Unfortunately, I can't test changes in this PR until it's merged to `main`. 

Part of #1277 

![Screenshot 2023-03-28 at 4 20 46 PM](https://user-images.githubusercontent.com/4452412/228390272-b85954ed-e011-4bfb-a03e-b7dcc537c9b5.png)

