### PR TITLE
Stateful storage signed extension

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2747,6 +2747,7 @@ dependencies = [
  "log",
  "pallet-balances",
  "pallet-msa",
+ "pallet-stateful-storage",
  "pallet-transaction-payment",
  "parity-scale-codec",
  "polkadot-cli",

--- a/integration-tests/package-lock.json
+++ b/integration-tests/package-lock.json
@@ -697,7 +697,7 @@
         "node_modules/@frequency-chain/api-augment": {
             "version": "0.0.0",
             "resolved": "file:../js/api-augment/dist/frequency-chain-api-augment-0.0.0.tgz",
-            "integrity": "sha512-A653d75diX2MnknWC5x1Q6iKkVatFNt4QPrD1rAniTg2PVSIFSMzYedSUdZMK7a42gEb6ioqMBBAvdi+TNjArw==",
+            "integrity": "sha512-5lq2PZity1d9Uz+iKFYByeuTpHhRn9ddfXmzhm3OQxXTf27s9a3M5xvYu36yTOX/bSLAK/GYCgFzKlzJACHNsQ==",
             "license": "Apache-2.0",
             "dependencies": {
                 "@polkadot/api": "^9.14.2",

--- a/integration-tests/stateful-pallet-storage/handleAppendOnly.test.ts
+++ b/integration-tests/stateful-pallet-storage/handleAppendOnly.test.ts
@@ -10,69 +10,69 @@ import { KeyringPair } from "@polkadot/keyring/types";
 import { ExtrinsicHelper } from "../scaffolding/extrinsicHelpers";
 import { AVRO_CHAT_MESSAGE } from "./fixtures/itemizedSchemaType";
 import { MessageSourceId, SchemaId } from "@frequency-chain/api-augment/interfaces";
-import {Bytes, u16} from "@polkadot/types";
+import { Bytes, u16 } from "@polkadot/types";
 
 describe("📗 Stateful Pallet Storage AppendOnly Schemas", () => {
-    let itemizedSchemaId: SchemaId;
-    let msa_id: MessageSourceId;
-    let providerId: MessageSourceId;
-    let providerKeys: KeyringPair;
-    let sudoKey: KeyringPair;
+  let itemizedSchemaId: SchemaId;
+  let msa_id: MessageSourceId;
+  let providerId: MessageSourceId;
+  let providerKeys: KeyringPair;
+  let sudoKey: KeyringPair;
 
-    before(async function () {
-        // Using Alice as sudoKey
-        sudoKey = devAccounts[0].keys;
+  before(async function () {
+    // Using Alice as sudoKey
+    sudoKey = devAccounts[0].keys;
 
-        // Create a provider for the MSA, the provider will be used to grant delegation
-        [providerKeys, providerId] = await createProviderKeysAndId();
-        assert.notEqual(providerId, undefined, "setup should populate providerId");
-        assert.notEqual(providerKeys, undefined, "setup should populate providerKeys");
+    // Create a provider for the MSA, the provider will be used to grant delegation
+    [providerKeys, providerId] = await createProviderKeysAndId();
+    assert.notEqual(providerId, undefined, "setup should populate providerId");
+    assert.notEqual(providerKeys, undefined, "setup should populate providerKeys");
 
-        // Create a schema for Itemized PayloadLocation
-        const createSchema = ExtrinsicHelper.createSchemaWithSettingsGov(providerKeys, sudoKey, AVRO_CHAT_MESSAGE, "AvroBinary", "Itemized", "AppendOnly");
-        const [event] = await createSchema.sudoSignAndSend();
-        if (event && createSchema.api.events.schemas.SchemaCreated.is(event)) {
-            itemizedSchemaId = event.data.schemaId;
-        }
-        assert.notEqual(itemizedSchemaId, undefined, "setup should populate schemaId");
+    // Create a schema for Itemized PayloadLocation
+    const createSchema = ExtrinsicHelper.createSchemaWithSettingsGov(providerKeys, sudoKey, AVRO_CHAT_MESSAGE, "AvroBinary", "Itemized", "AppendOnly");
+    const [event] = await createSchema.sudoSignAndSend();
+    if (event && createSchema.api.events.schemas.SchemaCreated.is(event)) {
+      itemizedSchemaId = event.data.schemaId;
+    }
+    assert.notEqual(itemizedSchemaId, undefined, "setup should populate schemaId");
 
-        // Create a MSA for the delegator and delegate to the provider for the itemized schema
-        [, msa_id] = await createDelegatorAndDelegation(itemizedSchemaId, providerId, providerKeys);
-        assert.notEqual(msa_id, undefined, "setup should populate msa_id");
-    });
+    // Create a MSA for the delegator and delegate to the provider for the itemized schema
+    [, msa_id] = await createDelegatorAndDelegation(itemizedSchemaId, providerId, providerKeys);
+    assert.notEqual(msa_id, undefined, "setup should populate msa_id");
+  });
 
-    describe("Itemized With AppendOnly Storage Tests", () => {
+  describe("Itemized With AppendOnly Storage Tests", () => {
 
-      it("should not be able to call delete action", async function () {
+    it("should not be able to call delete action", async function () {
 
-        // Add and update actions
-        let payload_1 = new Bytes(ExtrinsicHelper.api.registry, "Hello World From Frequency");
+      // Add and update actions
+      let payload_1 = new Bytes(ExtrinsicHelper.api.registry, "Hello World From Frequency");
 
-        const add_action = {
-          "Add": payload_1
-        }
+      const add_action = {
+        "Add": payload_1
+      }
 
-        let payload_2 = new Bytes(ExtrinsicHelper.api.registry, "Hello World Again From Frequency");
+      let payload_2 = new Bytes(ExtrinsicHelper.api.registry, "Hello World Again From Frequency");
 
-        const update_action = {
-          "Add": payload_2
-        }
+      const update_action = {
+        "Add": payload_2
+      }
 
-        const idx_1: u16 = new u16(ExtrinsicHelper.api.registry, 1)
+      const idx_1: u16 = new u16(ExtrinsicHelper.api.registry, 1)
 
-        const delete_action = {
-          "Delete": idx_1
-        }
-        const target_hash = await getCurrentItemizedHash(msa_id, itemizedSchemaId);
+      const delete_action = {
+        "Delete": idx_1
+      }
+      const target_hash = await getCurrentItemizedHash(msa_id, itemizedSchemaId);
 
-        let add_actions = [add_action, update_action, delete_action];
+      let add_actions = [add_action, update_action, delete_action];
 
-        let itemized_add_result_1 = ExtrinsicHelper.applyItemActions(providerKeys, itemizedSchemaId, msa_id, add_actions, target_hash);
-        await assert.rejects(async () => {
-          await itemized_add_result_1.fundAndSend();
-        }, {
-          name: 'UnsupportedOperationForSchema',
-          section: 'statefulStorage',
+      let itemized_add_result_1 = ExtrinsicHelper.applyItemActions(providerKeys, itemizedSchemaId, msa_id, add_actions, target_hash);
+      await assert.rejects(async () => {
+        await itemized_add_result_1.fundAndSend();
+      }, {
+        name: 'RpcError',
+        message: /Custom error: 3/, // UnsupportedOperationForSchema
       });
     });
   });

--- a/integration-tests/stateful-pallet-storage/handleItemized.test.ts
+++ b/integration-tests/stateful-pallet-storage/handleItemized.test.ts
@@ -1,7 +1,7 @@
 // Integration tests for pallets/stateful-pallet-storage/handleItemized.ts
 import "@frequency-chain/api-augment";
 import assert from "assert";
-import {createDelegatorAndDelegation, createProviderKeysAndId, getCurrentItemizedHash} from "../scaffolding/helpers";
+import { createDelegatorAndDelegation, createProviderKeysAndId, getCurrentItemizedHash } from "../scaffolding/helpers";
 import { KeyringPair } from "@polkadot/keyring/types";
 import { ExtrinsicHelper } from "../scaffolding/extrinsicHelpers";
 import { AVRO_CHAT_MESSAGE } from "../stateful-pallet-storage/fixtures/itemizedSchemaType";
@@ -83,8 +83,8 @@ describe("📗 Stateful Pallet Storage", () => {
             await assert.rejects(async () => {
                 await itemized_add_result_1.fundAndSend();
             }, {
-                name: 'InvalidSchemaId',
-                section: 'statefulStorage',
+                name: 'RpcError',
+                message: /Custom error: 2/, // InvalidSchemaId
             });
         }).timeout(10000);
 
@@ -99,8 +99,8 @@ describe("📗 Stateful Pallet Storage", () => {
             await assert.rejects(async () => {
                 await itemized_add_result_1.fundAndSend();
             }, {
-                name: 'SchemaPayloadLocationMismatch',
-                section: 'statefulStorage',
+                name: 'RpcError',
+                message: /Custom error: 4/, // SchemaPayloadLocationMismatch
             });
         }).timeout(10000);
 
@@ -139,7 +139,10 @@ describe("📗 Stateful Pallet Storage", () => {
 
             let add_actions = [add_action, update_action];
             let itemized_add_result_1 = ExtrinsicHelper.applyItemActions(providerKeys, schemaId_deletable, msa_id, add_actions, 0);
-            await assert.rejects(itemized_add_result_1.fundAndSend(), { name: 'StalePageState' });
+            await assert.rejects(itemized_add_result_1.fundAndSend(), {
+                name: 'RpcError',
+                message: /Custom error: 9/, // StalePageState
+            });
         }).timeout(10000);
     });
 
@@ -175,8 +178,8 @@ describe("📗 Stateful Pallet Storage", () => {
             await assert.rejects(async () => {
                 await itemized_remove_result_1.fundAndSend();
             }, {
-                name: 'InvalidSchemaId',
-                section: 'statefulStorage',
+                name: 'RpcError',
+                message: /Custom error: 2/, // InvalidSchemaId
             });
         }).timeout(10000);
 
@@ -190,8 +193,8 @@ describe("📗 Stateful Pallet Storage", () => {
             await assert.rejects(async () => {
                 await itemized_remove_result_1.fundAndSend();
             }, {
-                name: 'SchemaPayloadLocationMismatch',
-                section: 'statefulStorage',
+                name: 'RpcError',
+                message: /Custom error: 4/, // SchemaPayloadLocationMismatch
             });
         }).timeout(10000);
 
@@ -218,7 +221,10 @@ describe("📗 Stateful Pallet Storage", () => {
             }
             let remove_actions = [remove_action];
             let op = ExtrinsicHelper.applyItemActions(providerKeys, schemaId_deletable, msa_id, remove_actions, 0);
-            await assert.rejects(op.fundAndSend(), { name: 'StalePageState' })
+            await assert.rejects(op.fundAndSend(), {
+                name: 'RpcError',
+                message: /Custom error: 9/, // StalePageState
+            })
         }).timeout(10000);
     });
 

--- a/node/cli/Cargo.toml
+++ b/node/cli/Cargo.toml
@@ -23,6 +23,7 @@ common-runtime = { package = "common-runtime", path = "../../runtime/common", de
 frequency-runtime = { package = "frequency-runtime", path = "../../runtime/frequency", default-features = false }
 frequency-service = { package = "frequency-service", path = "../service", default-features = false, optional = true }
 pallet-msa = { package = "pallet-msa", path = "../../pallets/msa", default-features = false }
+pallet-stateful-storage = { package = "pallet-stateful-storage", path = "../../pallets/stateful-storage", default-features = false }
 # Substrate
 frame-benchmarking-cli = { git = "https://github.com/paritytech/substrate", optional = true, branch = "polkadot-v0.9.36" }
 frame-support = { git = "https://github.com/paritytech/substrate", default-features = false, branch = "polkadot-v0.9.36" }
@@ -85,4 +86,3 @@ all-frequency-features = [
   "frequency-rococo-testnet",
   "frequency-service/all-frequency-features"
 ]
-

--- a/node/cli/src/benchmarking.rs
+++ b/node/cli/src/benchmarking.rs
@@ -14,6 +14,7 @@ use sp_runtime::{OpaqueExtrinsic, SaturatedConversion};
 
 use pallet_balances::Call as BalancesCall;
 use pallet_msa;
+use pallet_stateful_storage;
 use pallet_transaction_payment;
 use sp_inherents::InherentDataProvider;
 use sp_timestamp;
@@ -129,6 +130,7 @@ pub fn create_benchmark_extrinsic(
 		frame_system::CheckWeight::<runtime::Runtime>::new(),
 		pallet_transaction_payment::ChargeTransactionPayment::<runtime::Runtime>::from(0),
 		pallet_msa::CheckFreeExtrinsicUse::<runtime::Runtime>::new(),
+		pallet_stateful_storage::StatefulSignedExtension::<runtime::Runtime>::new(),
 	);
 
 	let raw_payload = sp_runtime::generic::SignedPayload::from_raw(
@@ -140,6 +142,7 @@ pub fn create_benchmark_extrinsic(
 			runtime::VERSION.transaction_version,
 			genesis_hash,
 			best_hash,
+			(),
 			(),
 			(),
 			(),

--- a/pallets/stateful-storage/src/stateful_signed_extension.rs
+++ b/pallets/stateful-storage/src/stateful_signed_extension.rs
@@ -162,7 +162,11 @@ impl<T: Config> StatefulStorageValidate<T> for Pallet<T> {
 /// Map a module DispatchError to an InvalidTransaction::Custom error
 pub fn map_dispatch_error(err: DispatchError) -> InvalidTransaction {
 	InvalidTransaction::Custom(match err {
-		DispatchError::Module(module_err) => module_err.index,
+		DispatchError::Module(module_err) =>
+			<u32 as Decode>::decode(&mut module_err.error.as_slice())
+				.unwrap_or_default()
+				.try_into()
+				.unwrap_or_default(),
 		_ => 255u8,
 	})
 }

--- a/pallets/stateful-storage/src/stateful_signed_extension.rs
+++ b/pallets/stateful-storage/src/stateful_signed_extension.rs
@@ -1,0 +1,294 @@
+//! Substrate Signed Extension for validating requests to the stateful-storage pallet
+use crate::{types::ItemAction, Call, Config, Pallet};
+use core::marker::PhantomData;
+
+use codec::{Decode, Encode};
+use common_primitives::{
+	msa::MessageSourceId,
+	schema::{PayloadLocation, SchemaId},
+	stateful_storage::{PageHash, PageId},
+};
+use frame_support::{
+	dispatch::{DispatchInfo, Dispatchable},
+	pallet_prelude::ValidTransaction,
+	traits::IsSubType,
+	BoundedVec,
+};
+use scale_info::TypeInfo;
+use sp_runtime::{
+	traits::{DispatchInfoOf, SignedExtension},
+	transaction_validity::{InvalidTransaction, TransactionValidity, TransactionValidityError},
+	DispatchError,
+};
+
+/// The SignedExtension trait is implemented on CheckFreeExtrinsicUse to validate that a provider
+/// has not already been revoked if the calling extrinsic is revoking a provider to an MSA. The
+/// purpose of this is to ensure that the revoke_delegation_by_delegator extrinsic cannot be
+/// repeatedly called and flood the network.
+#[derive(Encode, Decode, Clone, Eq, PartialEq, TypeInfo)]
+#[scale_info(skip_type_params(T))]
+pub struct StatefulSignedExtension<T: Config + Send + Sync>(PhantomData<T>);
+
+/// Validator trait to be used in validating Stateful Storage
+/// requests from a Signed Extension.
+pub trait StatefulStorageValidate<C: Config> {
+	/// Validates the parameters to an Itemized extrinsic call
+	fn validate_itemized(
+		msa_id: &MessageSourceId,
+		schema_id: &SchemaId,
+		actions: &BoundedVec<ItemAction<C::MaxItemizedBlobSizeBytes>, C::MaxItemizedActionsCount>,
+		is_payload_signed: bool,
+		target_hash: &PageHash,
+	) -> TransactionValidity;
+
+	/// Validates the parameters to a Paginated extrinsic call
+	fn validate_paginated(
+		msa_id: &MessageSourceId,
+		schema_id: &SchemaId,
+		page_id: &PageId,
+		is_payload_signed: bool,
+		page_delete: bool,
+		target_hash: &PageHash,
+	) -> TransactionValidity;
+}
+
+impl<T: Config> StatefulStorageValidate<T> for Pallet<T> {
+	/// Validates the following criteria for an Itemized Stateful Storage extrinsic:
+	///
+	/// * schema_id represents a valid schema
+	/// * schema `PayloadLocation` is `Paginated`
+	/// * schema allows signed payloads if `is_payload_signed` == true
+	/// * schema is not `AppendOnly` if `page_delete` == true
+	/// * page can be read/parsed
+	/// * known page state hash matches provided target hash
+	///
+	/// Returns a `ValidTransaction` or wrapped [`pallet::Error`]
+	///
+	/// # Arguments:
+	/// * account_id: the account id associated with the MSA owning the storage
+	/// * msa_id: the `MessageSourceAccount`
+	/// * schema_id: the `SchemaId` for the Paginated storage
+	/// * actions: Array of `ItemAction` representing adds/deletes to Itemized storage
+	/// * is_payload_signed: whether we were called with a signed payload
+	/// * target_hash: the content hash representing the known state of the Paginated storage.
+	///
+	/// # Errors (as u8 wrapped by `InvalidTransaction::Custom`)
+	/// * [`Error::InvalidSchemaId`]
+	/// * [`Error::SchemaPayloadLocationMismatch`]
+	/// * [`Error::SchemaNotSupported`]
+	/// * [`Error::CorruptedState`]
+	/// * [`Error::StalePageState`]
+	///
+	fn validate_itemized(
+		msa_id: &MessageSourceId,
+		schema_id: &SchemaId,
+		actions: &BoundedVec<ItemAction<T::MaxItemizedBlobSizeBytes>, T::MaxItemizedActionsCount>,
+		is_payload_signed: bool,
+		target_hash: &PageHash,
+	) -> TransactionValidity {
+		const TAG_PREFIX: &str = "StatefulStorageItemized";
+		let is_pruning = actions.iter().any(|a| matches!(a, ItemAction::Delete { .. }));
+
+		Self::check_schema_for_write(
+			*schema_id,
+			PayloadLocation::Itemized,
+			is_payload_signed,
+			is_pruning,
+		)
+		.map_err(|e| map_dispatch_error(e))?;
+
+		Self::get_checked_itemized_page(msa_id, schema_id, target_hash)
+			.map_err(|e| map_dispatch_error(e))?;
+
+		return ValidTransaction::with_tag_prefix(TAG_PREFIX)
+			.and_provides((msa_id, schema_id))
+			.build()
+	}
+
+	/// Validates the following criteria for a Paginated Stateful Storage extrinsic:
+	///
+	/// * schema_id represents a valid schema
+	/// * schema `PayloadLocation` is `Paginated`
+	/// * schema allows signed payloads if `is_payload_signed` == true
+	/// * schema is not `AppendOnly` if `page_delete` == true
+	/// * page can be read
+	/// * known page state hash matches provided target hash
+	///
+	/// Returns a `ValidTransaction` or wrapped [`pallet::Error`]
+	///
+	/// # Arguments:
+	/// * account_id: the account id associated with the MSA owning the storage
+	/// * msa_id: the `MessageSourceAccount`
+	/// * schema_id: the `SchemaId` for the Paginated storage
+	/// * page_id: the `PageId` to be validated
+	/// * is_payload_signed: whether we were called with a signed payload
+	/// * page_delete: whether the invoking operation is a page deletion
+	/// * target_hash: the content hash representing the known state of the Paginated storage.
+	///
+	/// # Errors (as u8 wrapped by `InvalidTransaction::Custom`)
+	/// * [`Error::InvalidSchemaId`]
+	/// * [`Error::SchemaPayloadLocationMismatch`]
+	/// * [`Error::SchemaNotSupported`]
+	/// * [`Error::CorruptedState`]
+	/// * [`Error::StalePageState`]
+	///
+	fn validate_paginated(
+		msa_id: &MessageSourceId,
+		schema_id: &SchemaId,
+		page_id: &PageId,
+		is_payload_signed: bool,
+		page_delete: bool,
+		target_hash: &PageHash,
+	) -> TransactionValidity {
+		const TAG_PREFIX: &str = "StatefulStoragePaginated";
+
+		Self::check_schema_for_write(
+			*schema_id,
+			PayloadLocation::Paginated,
+			is_payload_signed,
+			page_delete,
+		)
+		.map_err(|e| map_dispatch_error(e))?;
+
+		Self::check_paginated_state(msa_id, schema_id, page_id, target_hash)
+			.map_err(|e| map_dispatch_error(e))?;
+
+		return ValidTransaction::with_tag_prefix(TAG_PREFIX)
+			.and_provides((msa_id, schema_id, page_id))
+			.build()
+	}
+}
+
+/// Map a module DispatchError to an InvalidTransaction::Custom error
+pub fn map_dispatch_error(err: DispatchError) -> InvalidTransaction {
+	InvalidTransaction::Custom(match err {
+		DispatchError::Module(module_err) => module_err.index,
+		_ => 255u8,
+	})
+}
+
+impl<T: Config + Send + Sync> StatefulSignedExtension<T> {
+	/// Create new `SignedExtension`.
+	pub fn new() -> Self {
+		Self(sp_std::marker::PhantomData)
+	}
+}
+
+impl<T: Config + Send + Sync> sp_std::fmt::Debug for StatefulSignedExtension<T> {
+	#[cfg(feature = "std")]
+	fn fmt(&self, f: &mut sp_std::fmt::Formatter) -> sp_std::fmt::Result {
+		write!(f, "StatefulSignedExtension<{:?}>", self.0)
+	}
+	#[cfg(not(feature = "std"))]
+	fn fmt(&self, _: &mut sp_std::fmt::Formatter) -> sp_std::fmt::Result {
+		Ok(())
+	}
+}
+
+impl<T: Config + Send + Sync> SignedExtension for StatefulSignedExtension<T>
+where
+	T::RuntimeCall: Dispatchable<Info = DispatchInfo> + IsSubType<Call<T>>,
+{
+	type AccountId = T::AccountId;
+	type Call = T::RuntimeCall;
+	type AdditionalSigned = ();
+	type Pre = ();
+	const IDENTIFIER: &'static str = "StatefulSignedExtension";
+
+	fn additional_signed(&self) -> sp_std::result::Result<(), TransactionValidityError> {
+		Ok(())
+	}
+
+	fn pre_dispatch(
+		self,
+		who: &Self::AccountId,
+		call: &Self::Call,
+		info: &DispatchInfoOf<Self::Call>,
+		len: usize,
+	) -> Result<Self::Pre, TransactionValidityError> {
+		self.validate(who, call, info, len).map(|_| ())
+	}
+
+	/// Frequently called by the transaction queue to validate all free MSA extrinsics:
+	/// Returns a `ValidTransaction` or wrapped [`ValidityError`]
+	/// * revoke_delegation_by_provider
+	/// * revoke_delegation_by_delegator
+	/// * delete_msa_public_key
+	/// * retire_msa
+	/// Validate functions for the above MUST prevent errors in the extrinsic logic to prevent spam.
+	///
+	/// Arguments:
+	/// who: AccountId calling the extrinsic
+	/// call: The pallet extrinsic being called
+	/// unused: _info, _len
+	///
+	fn validate(
+		&self,
+		_who: &Self::AccountId,
+		call: &Self::Call,
+		_info: &DispatchInfoOf<Self::Call>,
+		_len: usize,
+	) -> TransactionValidity {
+		match call.is_sub_type() {
+			Some(Call::apply_item_actions {
+				state_owner_msa_id,
+				schema_id,
+				actions,
+				target_hash,
+				..
+			}) => Pallet::<T>::validate_itemized(
+				state_owner_msa_id,
+				schema_id,
+				actions,
+				false,
+				target_hash,
+			),
+			Some(Call::apply_item_actions_with_signature { payload, .. }) =>
+				Pallet::<T>::validate_itemized(
+					&payload.msa_id,
+					&payload.schema_id,
+					&payload.actions,
+					true,
+					&payload.target_hash,
+				),
+			Some(Call::upsert_page {
+				state_owner_msa_id, schema_id, page_id, target_hash, ..
+			}) => Pallet::<T>::validate_paginated(
+				state_owner_msa_id,
+				schema_id,
+				page_id,
+				false,
+				false,
+				target_hash,
+			),
+			Some(Call::upsert_page_with_signature { payload, .. }) =>
+				Pallet::<T>::validate_paginated(
+					&payload.msa_id,
+					&payload.schema_id,
+					&payload.page_id,
+					true,
+					false,
+					&payload.target_hash,
+				),
+			Some(Call::delete_page { state_owner_msa_id, schema_id, page_id, target_hash }) =>
+				Pallet::<T>::validate_paginated(
+					state_owner_msa_id,
+					schema_id,
+					page_id,
+					false,
+					true,
+					target_hash,
+				),
+			Some(Call::delete_page_with_signature { payload, .. }) =>
+				Pallet::<T>::validate_paginated(
+					&payload.msa_id,
+					&payload.schema_id,
+					&payload.page_id,
+					true,
+					true,
+					&payload.target_hash,
+				),
+			_ => Ok(Default::default()),
+		}
+	}
+}

--- a/runtime/frequency/src/lib.rs
+++ b/runtime/frequency/src/lib.rs
@@ -72,6 +72,7 @@ pub use sp_runtime::BuildStorage;
 
 pub use pallet_msa;
 pub use pallet_schemas;
+pub use pallet_stateful_storage;
 // Polkadot Imports
 use polkadot_runtime_common::{BlockHashCount, SlowAdjustingFeeUpdate};
 
@@ -154,6 +155,7 @@ pub type SignedExtra = (
 	frame_system::CheckWeight<Runtime>,
 	pallet_transaction_payment::ChargeTransactionPayment<Runtime>,
 	pallet_msa::CheckFreeExtrinsicUse<Runtime>,
+	pallet_stateful_storage::StatefulSignedExtension<Runtime>,
 );
 /// A Block signed with a Justification
 pub type SignedBlock = generic::SignedBlock<Block>;


### PR DESCRIPTION
# Goal
The goal of this PR is to create a Signed Extension for the `stateful-storage` pallet that validates basic request parameters (especially page content hash).

Closes #1095 

# Checklist
- [ ] Chain spec updated
- [ ] Custom RPC OR Runtime API added/changed? Updated js/api-augment.
- [ ] Design doc(s) updated
- [ ] Tests added
- [ ] Benchmarks added
- [ ] Weights updated
