### PR TITLE
fix(cov): ensure test pass

### DIFF
--- a/pallets/time-release/src/benchmarking.rs
+++ b/pallets/time-release/src/benchmarking.rs
@@ -72,8 +72,7 @@ benchmarks! {
 			schedule.start = i.into();
 			TimeReleasePallet::<T>::transfer(RawOrigin::Signed(from.clone()).into(), to_lookup.clone(), schedule.clone())?;
 		}
-
-		frame_system::Pallet::<T>::set_block_number(schedule.end().unwrap() + 1u32.into());
+		T::BlockNumberProvider::set_block_number(schedule.end().unwrap() + 1u32.into());
 	}: _(RawOrigin::Signed(to.clone()))
 	verify {
 		assert_eq!(

--- a/pallets/time-release/src/mock.rs
+++ b/pallets/time-release/src/mock.rs
@@ -125,6 +125,7 @@ pub struct ExtBuilder;
 impl ExtBuilder {
 	pub fn build() -> sp_io::TestExternalities {
 		let mut t = frame_system::GenesisConfig::default().build_storage::<Runtime>().unwrap();
+		MockBlockNumberProvider::set(0);
 
 		pallet_balances::GenesisConfig::<Runtime> {
 			balances: vec![(ALICE, ALICE_BALANCE), (CHARLIE, CHARLIE_BALANCE)],

--- a/pallets/time-release/src/tests.rs
+++ b/pallets/time-release/src/tests.rs
@@ -340,10 +340,11 @@ fn exceeding_maximum_schedules_should_fail() {
 		let schedule =
 			ReleaseSchedule { start: 0u64, period: 10u64, period_count: 2u32, per_period: 10u64 };
 
-		for _ in 0..50 {
+		for _ in 0..49 {
 			assert_ok!(TimeRelease::transfer(RuntimeOrigin::signed(ALICE), BOB, schedule.clone()));
 		}
-		// assert_ok!(TimeRelease::transfer(RuntimeOrigin::signed(ALICE), BOB, schedule.clone()));
+
+		assert_ok!(TimeRelease::transfer(RuntimeOrigin::signed(ALICE), BOB, schedule.clone()));
 
 		let create = RuntimeCall::TimeRelease(crate::Call::<Runtime>::transfer {
 			dest: BOB,

--- a/pallets/time-release/src/weights.rs
+++ b/pallets/time-release/src/weights.rs
@@ -61,7 +61,7 @@ impl<T: frame_system::Config> WeightInfo for SubstrateWeight<T> {
 	// Storage: ParachainSystem ValidationData (r:1 w:0)
 	// Storage: TimeRelease ReleaseSchedules (r:1 w:1)
 	fn transfer() -> Weight {
-		Weight::from_ref_time(21_747_000 as u64)
+		Weight::from_ref_time(21_677_000 as u64)
 			.saturating_add(T::DbWeight::get().reads(2 as u64))
 			.saturating_add(T::DbWeight::get().writes(1 as u64))
 	}
@@ -69,18 +69,18 @@ impl<T: frame_system::Config> WeightInfo for SubstrateWeight<T> {
 	// Storage: TimeRelease ReleaseSchedules (r:1 w:1)
 	// Storage: Balances Locks (r:1 w:1)
 	fn claim(i: u32, ) -> Weight {
-		Weight::from_ref_time(33_034_065 as u64)
-			// Standard Error: 4_988
-			.saturating_add(Weight::from_ref_time(1_617 as u64).saturating_mul(i as u64))
+		Weight::from_ref_time(33_039_042 as u64)
+			// Standard Error: 5_385
+			.saturating_add(Weight::from_ref_time(3_571 as u64).saturating_mul(i as u64))
 			.saturating_add(T::DbWeight::get().reads(3 as u64))
 			.saturating_add(T::DbWeight::get().writes(2 as u64))
 	}
 	// Storage: System Account (r:1 w:0)
 	// Storage: TimeRelease ReleaseSchedules (r:0 w:1)
 	fn update_release_schedules(i: u32, ) -> Weight {
-		Weight::from_ref_time(18_203_361 as u64)
-			// Standard Error: 2_733
-			.saturating_add(Weight::from_ref_time(55_504 as u64).saturating_mul(i as u64))
+		Weight::from_ref_time(18_098_393 as u64)
+			// Standard Error: 3_121
+			.saturating_add(Weight::from_ref_time(62_485 as u64).saturating_mul(i as u64))
 			.saturating_add(T::DbWeight::get().reads(1 as u64))
 			.saturating_add(T::DbWeight::get().writes(1 as u64))
 	}
@@ -91,7 +91,7 @@ impl WeightInfo for () {
 	// Storage: ParachainSystem ValidationData (r:1 w:0)
 	// Storage: TimeRelease ReleaseSchedules (r:1 w:1)
 	fn transfer() -> Weight {
-		Weight::from_ref_time(21_747_000 as u64)
+		Weight::from_ref_time(21_677_000 as u64)
 			.saturating_add(RocksDbWeight::get().reads(2 as u64))
 			.saturating_add(RocksDbWeight::get().writes(1 as u64))
 	}
@@ -99,18 +99,18 @@ impl WeightInfo for () {
 	// Storage: TimeRelease ReleaseSchedules (r:1 w:1)
 	// Storage: Balances Locks (r:1 w:1)
 	fn claim(i: u32, ) -> Weight {
-		Weight::from_ref_time(33_034_065 as u64)
-			// Standard Error: 4_988
-			.saturating_add(Weight::from_ref_time(1_617 as u64).saturating_mul(i as u64))
+		Weight::from_ref_time(33_039_042 as u64)
+			// Standard Error: 5_385
+			.saturating_add(Weight::from_ref_time(3_571 as u64).saturating_mul(i as u64))
 			.saturating_add(RocksDbWeight::get().reads(3 as u64))
 			.saturating_add(RocksDbWeight::get().writes(2 as u64))
 	}
 	// Storage: System Account (r:1 w:0)
 	// Storage: TimeRelease ReleaseSchedules (r:0 w:1)
 	fn update_release_schedules(i: u32, ) -> Weight {
-		Weight::from_ref_time(18_203_361 as u64)
-			// Standard Error: 2_733
-			.saturating_add(Weight::from_ref_time(55_504 as u64).saturating_mul(i as u64))
+		Weight::from_ref_time(18_098_393 as u64)
+			// Standard Error: 3_121
+			.saturating_add(Weight::from_ref_time(62_485 as u64).saturating_mul(i as u64))
 			.saturating_add(RocksDbWeight::get().reads(1 as u64))
 			.saturating_add(RocksDbWeight::get().writes(1 as u64))
 	}


### PR DESCRIPTION
# Goal
Running the test with llvm-cov fails because the
state for mock BlockNumberProvider is modified
between tests and not reset.

Ensure that the state for the mock is reset
before running a test.
