### PR TITLE
Update design docs and address PR comments for #827: remove CurrentEpochUsedCapacity

### DIFF
--- a/pallets/capacity/src/benchmarking.rs
+++ b/pallets/capacity/src/benchmarking.rs
@@ -33,7 +33,6 @@ pub fn set_up_epoch<T: Config>(current_block: T::BlockNumber, current_epoch: T::
 	CurrentEpoch::<T>::set(current_epoch);
 	let epoch_start = current_block.saturating_sub(Capacity::<T>::get_epoch_length());
 	CurrentEpochInfo::<T>::set(EpochInfo { epoch_start });
-	CurrentEpochUsedCapacity::<T>::set(450_000u32.into());
 }
 
 benchmarks! {
@@ -81,7 +80,6 @@ benchmarks! {
 	} verify {
 		assert_eq!(current_epoch.saturating_add(1u32.into()), Capacity::<T>::get_current_epoch());
 		assert_eq!(current_block, CurrentEpochInfo::<T>::get().epoch_start);
-		assert!(Capacity::<T>::get_current_epoch_used_capacity().eq(&0u32.into()));
 	}
 	unstake {
 		let caller: T::AccountId = create_funded_account::<T>("account", SEED, 5u32);

--- a/pallets/capacity/src/lib.rs
+++ b/pallets/capacity/src/lib.rs
@@ -185,11 +185,6 @@ pub mod pallet {
 	#[pallet::getter(fn get_current_epoch_info)]
 	pub type CurrentEpochInfo<T: Config> = StorageValue<_, EpochInfo<T::BlockNumber>, ValueQuery>;
 
-	/// Storage for the current epoch number
-	#[pallet::storage]
-	#[pallet::getter(fn get_current_epoch_used_capacity)]
-	pub type CurrentEpochUsedCapacity<T: Config> = StorageValue<_, BalanceOf<T>, ValueQuery>;
-
 	#[pallet::type_value]
 	/// EpochLength defaults to 100 blocks when not set
 	pub fn EpochLengthDefault<T: Config>() -> T::BlockNumber {
@@ -579,8 +574,6 @@ impl<T: Config> Pallet<T> {
 			let current_epoch = Self::get_current_epoch();
 			CurrentEpoch::<T>::set(current_epoch.saturating_add(1u32.into()));
 			CurrentEpochInfo::<T>::set(EpochInfo { epoch_start: current_block });
-			CurrentEpochUsedCapacity::<T>::set(0u32.into());
-			// add 1 read + 1 write for whitelisted storage CurrentEpoch
 			T::WeightInfo::on_initialize()
 				.saturating_add(RocksDbWeight::get().reads(1))
 				.saturating_add(RocksDbWeight::get().writes(1))

--- a/pallets/capacity/src/tests/other_tests.rs
+++ b/pallets/capacity/src/tests/other_tests.rs
@@ -4,8 +4,8 @@ use sp_runtime::traits::Zero;
 use common_primitives::{capacity::Nontransferable, msa::MessageSourceId};
 
 use crate::{
-	BalanceOf, CapacityDetails, Config, CurrentEpoch, CurrentEpochInfo, CurrentEpochUsedCapacity,
-	EpochInfo, StakingAccountDetails, StakingTargetDetails,
+	BalanceOf, CapacityDetails, Config, CurrentEpoch, CurrentEpochInfo, EpochInfo,
+	StakingAccountDetails, StakingTargetDetails,
 };
 
 use super::{mock::*, testing_utils::*};
@@ -16,7 +16,6 @@ struct TestCase<T: Config> {
 	epoch_start_block: <T>::BlockNumber,
 	expected_epoch: <T>::EpochNumber,
 	expected_epoch_start_block: <T>::BlockNumber,
-	expected_capacity: u64,
 	at_block: <T>::BlockNumber,
 }
 
@@ -31,7 +30,6 @@ fn start_new_epoch_works() {
 				epoch_start_block: 201,
 				expected_epoch: 3,
 				expected_epoch_start_block: 301,
-				expected_capacity: 0,
 				at_block: 301,
 			},
 			TestCase {
@@ -41,14 +39,12 @@ fn start_new_epoch_works() {
 				epoch_start_block: 201,
 				expected_epoch: 2,
 				expected_epoch_start_block: 201,
-				expected_capacity: 45,
 				at_block: 215,
 			},
 		];
 		for tc in test_cases {
 			CurrentEpoch::<Test>::set(tc.starting_epoch.clone());
 			CurrentEpochInfo::<Test>::set(EpochInfo { epoch_start: tc.epoch_start_block });
-			CurrentEpochUsedCapacity::<Test>::set(45); // just some non-zero value
 			Capacity::start_new_epoch_if_needed(tc.at_block);
 			assert_eq!(
 				tc.expected_epoch,
@@ -60,12 +56,6 @@ fn start_new_epoch_works() {
 				tc.expected_epoch_start_block,
 				CurrentEpochInfo::<Test>::get().epoch_start,
 				"{}: had wrong epoch start block",
-				tc.name
-			);
-			assert_eq!(
-				tc.expected_capacity,
-				Capacity::get_current_epoch_used_capacity(),
-				"{}: had wrong used capacity",
 				tc.name
 			);
 		}


### PR DESCRIPTION
# Goal
The goal of this PR is to address comments for PR #827, specifically to update the design docs, which includes removing the unused storage for `CurrentEpochUsedCapacity` and fixing the affected unit tests and benchmarking.

