### PR TITLE
Ensure that handles consist of characters in supported unicode character sets

### DIFF
--- a/pallets/handles/src/lib.rs
+++ b/pallets/handles/src/lib.rs
@@ -140,6 +140,8 @@ pub mod pallet {
 		HandleIsNotAllowed,
 		/// The handle contains characters that are not allowed
 		HandleContainsBlockedCharacters,
+		/// The handle does not contain characters in the supported ranges of unicode characters
+		HandleDoesNotConsistOfSupportedCharacterSets,
 		/// Suffixes exhausted
 		SuffixesExhausted,
 		/// Invalid MSA
@@ -311,8 +313,12 @@ pub mod pallet {
 				Error::<T>::InvalidHandleCharacterLength
 			);
 
-			// Validation: The handle must not contain reserved words or blocked characters
+			// Validation: The handle must consist of characters contained not contain reserved words oblocked characters
 			let handle_validator = HandleValidator::new();
+			ensure!(
+				handle_validator.consists_of_supported_unicode_character_sets(base_handle_str),
+				Error::<T>::HandleDoesNotConsistOfSupportedCharacterSets
+			);
 			ensure!(
 				!handle_validator.is_reserved_handle(base_handle_str),
 				Error::<T>::HandleIsNotAllowed

--- a/pallets/handles/src/tests/validator_tests.rs
+++ b/pallets/handles/src/tests/validator_tests.rs
@@ -36,3 +36,41 @@ fn test_contains_blocked_characters_negative() {
 		assert!(!handle_validator.contains_blocked_characters(handle));
 	}
 }
+
+#[test]
+fn test_consists_of_supported_unicode_character_sets_happy_path() {
+	let strings_containing_characters_in_supported_unicode_character_sets = Vec::from([
+		"John",                  // Basic Latin
+		"Álvaro",               // Latin-1 Supplement
+		"가영",                // Hangul Syllables
+		"가나다",             // Hangul Syllables
+		"アキラ",             // Katakana
+		"あいこ",             // Hiragana
+		"李明",                // CJK Unified Ideographs
+		"严勇",                // CJK Unified Ideographs
+		"龍",                   // CJK Unified Ideographs
+		"অমিত",          // Bengali
+		"आरव",             // Devanagari
+		"Александр",    // Cyrillic
+		"Αλέξανδρος",  // Greek and Coptic
+		"Ἀναξαγόρας", // Greek Extended
+		"กัญญา",       // Thai
+	]);
+
+	let handle_validator = HandleValidator::new();
+	for string in strings_containing_characters_in_supported_unicode_character_sets {
+		assert!(handle_validator.consists_of_supported_unicode_character_sets(string));
+	}
+}
+
+#[test]
+fn test_consists_of_supported_unicode_character_sets_rejects_emojis() {
+	let handle_validator = HandleValidator::new();
+
+	// Constructing a string that with the smiling face emoji
+	let string_containing_emojis = format!("John{}", '\u{1F600}');
+
+	assert!(
+		!handle_validator.consists_of_supported_unicode_character_sets(&string_containing_emojis)
+	);
+}

--- a/pallets/handles/src/utils/validator.rs
+++ b/pallets/handles/src/utils/validator.rs
@@ -10,6 +10,7 @@ use sp_std::prelude::Vec;
 pub struct HandleValidator<'string_lifetime> {
 	reserved_handles: Vec<&'string_lifetime str>,
 	blocked_characters: Vec<char>,
+	allowed_unicode_character_ranges: Vec<(u32, u32)>,
 }
 
 impl<'string_lifetime> HandleValidator<'string_lifetime> {
@@ -18,8 +19,26 @@ impl<'string_lifetime> HandleValidator<'string_lifetime> {
 		// This intialization data *could* be passed into the constructor and set as a pallet constant
 		let reserved_handles: Vec<&str> = Vec::from(["admin", "everyone", "all"]);
 		let blocked_characters: Vec<char> = Vec::from(['@', '#', ':', '.', '`']);
-
-		Self { reserved_handles, blocked_characters }
+		let allowed_unicode_character_ranges: Vec<(u32, u32)> = Vec::from([
+			(0x0020, 0x007F), // Basic Latin
+			(0x0080, 0x00FF), // Latin-1 Supplement
+			(0x0100, 0x017F), // Latin Extended-A
+			(0x1100, 0x11FF), // Hangul Jamo
+			(0xAC00, 0xD7AF), // Hangul Syllables
+			(0x30A0, 0x30FF), // Katakana
+			(0x3040, 0x309F), // Hiragana
+			(0x4E00, 0x9FFF), // CJK Unified Ideographs
+			(0x3400, 0x4DBF), // CJK Unified Ideographs Extension A
+			(0xF900, 0xFAFF), // CJK Compatibility Ideographs
+			(0x0980, 0x09FF), // Bengali
+			(0x0900, 0x097F), // Devanagari
+			(0x0400, 0x04FF), // Cyrillic
+			(0x0500, 0x052F), // Cyrillic Supplementary
+			(0x0370, 0x03FF), // Greek and Coptic
+			(0x1F00, 0x1FFF), // Greek Extended
+			(0x0E00, 0x0E7F), // Thai
+		]);
+		Self { reserved_handles, blocked_characters, allowed_unicode_character_ranges }
 	}
 
 	/// Determines whether a given string is a reserved handle in the current context.
@@ -52,5 +71,28 @@ impl<'string_lifetime> HandleValidator<'string_lifetime> {
 			}
 		}
 		false
+	}
+
+	/// Checks that the given string contains characters within the ranges of supported
+	/// unicode character sets.
+	///
+	/// # Arguments
+	///
+	/// * `string` - A string slice to check for characters within the allowed unicode character sets..
+	pub fn consists_of_supported_unicode_character_sets(&self, string: &str) -> bool {
+		for character in string.chars() {
+			let mut is_valid = false;
+
+			for &(start, end) in &self.allowed_unicode_character_ranges {
+				if character as u32 >= start && character as u32 <= end {
+					is_valid = true;
+					break
+				}
+			}
+			if !is_valid {
+				return false
+			}
+		}
+		true
 	}
 }


### PR DESCRIPTION
# Goal
The goal of this PR is to enforce supported sets of allowable unicode characters that a user handle may consist.

Closes #1255

# Checklist
- [ ] Chain spec updated
- [ ] Custom RPC OR Runtime API added/changed? Updated js/api-augment.
- [ ] Design doc(s) updated
- [x] Tests added
- [ ] Benchmarks added
- [ ] Weights updated
