### PR TITLE
feat(FrqTxPayment): ensure that keys have deposit

### DIFF
--- a/integration-tests/capacity/staking.test.ts
+++ b/integration-tests/capacity/staking.test.ts
@@ -12,9 +12,9 @@ import {
 import { firstValueFrom } from "rxjs";
 
 describe("Capacity Transaction Tests", function () {
-    let cents = 1000000n
-    let dollars = 100n * cents;
-    let accountBalance: bigint = 200n * dollars;
+    let CENTS = 1000000n;
+    let DOLLARS = 100n * CENTS;
+    let accountBalance: bigint = 200n * DOLLARS;
 
     before(async function () {
         await setEpochLength(devAccounts[0].keys, TEST_EPOCH_LENGTH);
@@ -29,28 +29,28 @@ describe("Capacity Transaction Tests", function () {
         });
 
         it("successfully stakes the minimum amount", async function () {
-            await assert.doesNotReject(stakeToProvider(stakeKeys, stakeProviderId, 1n * cents));
+            await assert.doesNotReject(stakeToProvider(stakeKeys, stakeProviderId, 1n * CENTS));
 
             // Confirm that the tokens were locked in the stakeKeys account using the query API
             const stakedAcctInfo = await ExtrinsicHelper.getAccountInfo(stakeKeys.address);
-            assert.equal(stakedAcctInfo.data.miscFrozen, 1n * cents, "should return an account with 1M miscFrozen balance");
-            assert.equal(stakedAcctInfo.data.feeFrozen, 1n * cents, "should return an account with 1M feeFrozen balance");
+            assert.equal(stakedAcctInfo.data.miscFrozen, 1n * CENTS, "should return an account with 1M miscFrozen balance");
+            assert.equal(stakedAcctInfo.data.feeFrozen, 1n * CENTS, "should return an account with 1M feeFrozen balance");
 
             // Confirm that the capacity was added to the stakeProviderId using the query API
             const capacityStaked = (await firstValueFrom(ExtrinsicHelper.api.query.capacity.capacityLedger(stakeProviderId))).unwrap();
-            assert.equal(capacityStaked.remainingCapacity, 1n * cents, "should return a capacityLedger with 1M remainingCapacity");
-            assert.equal(capacityStaked.totalTokensStaked, 1n * cents, "should return a capacityLedger with 1M total tokens staked");
-            assert.equal(capacityStaked.totalCapacityIssued, 1n * cents, "should return a capacityLedger with 1M issued capacity");
+            assert.equal(capacityStaked.remainingCapacity, 1n * CENTS, "should return a capacityLedger with 1M remainingCapacity");
+            assert.equal(capacityStaked.totalTokensStaked, 1n * CENTS, "should return a capacityLedger with 1M total tokens staked");
+            assert.equal(capacityStaked.totalCapacityIssued, 1n * CENTS, "should return a capacityLedger with 1M issued capacity");
         });
 
         it("successfully unstakes the minimum amount", async function () {
-            const stakeObj = ExtrinsicHelper.unstake(stakeKeys, stakeProviderId, 1n * cents);
+            const stakeObj = ExtrinsicHelper.unstake(stakeKeys, stakeProviderId, 1n * CENTS);
             const [unStakeEvent] = await stakeObj.fundAndSend();
             assert.notEqual(unStakeEvent, undefined, "should return an UnStaked event");
 
             if (unStakeEvent && ExtrinsicHelper.api.events.capacity.UnStaked.is(unStakeEvent)) {
                 let unstakedCapacity = unStakeEvent.data.capacity;
-                assert.equal(unstakedCapacity, 1n * cents, "should return an UnStaked event with 1M reduced capacity");
+                assert.equal(unstakedCapacity, 1n * CENTS, "should return an UnStaked event with 1M reduced capacity");
             }
             else {
                 assert.fail("should return an capacity.UnStaked.is(unStakeEvent) event");
@@ -73,7 +73,7 @@ describe("Capacity Transaction Tests", function () {
 
             if (withdrawEvent && ExtrinsicHelper.api.events.capacity.StakeWithdrawn.is(withdrawEvent)) {
                 let amount = withdrawEvent.data.amount;
-                assert.equal(amount, 1n * cents, "should return a StakeWithdrawn event with 1M amount");
+                assert.equal(amount, 1n * CENTS, "should return a StakeWithdrawn event with 1M amount");
             }
 
             // Confirm that the tokens were unstaked in the stakeKeys account using the query API
@@ -92,17 +92,17 @@ describe("Capacity Transaction Tests", function () {
             describe("and targeting same provider", async function () {
                 it("successfully increases the amount that was targeted to provider", async function () {
                     // Now starting from zero again with stakeProviderId, Stake 1M capacity
-                    await assert.doesNotReject(stakeToProvider(stakeKeys, stakeProviderId, 1n * cents));
+                    await assert.doesNotReject(stakeToProvider(stakeKeys, stakeProviderId, 1n * CENTS));
 
                     // Confirm that the tokens were staked in the stakeKeys account using the query API
                     const stakedAcctInfo = await ExtrinsicHelper.getAccountInfo(stakeKeys.address);
-                    assert.equal(stakedAcctInfo.data.miscFrozen, 1n * cents, "should return an account with 1M miscFrozen balance");
-                    assert.equal(stakedAcctInfo.data.feeFrozen, 1n * cents, "should return an account with 1M feeFrozen balance");
+                    assert.equal(stakedAcctInfo.data.miscFrozen, 1n * CENTS, "should return an account with 1M miscFrozen balance");
+                    assert.equal(stakedAcctInfo.data.feeFrozen, 1n * CENTS, "should return an account with 1M feeFrozen balance");
 
                     const capacityStaked = (await firstValueFrom(ExtrinsicHelper.api.query.capacity.capacityLedger(stakeProviderId))).unwrap();
-                    assert.equal(capacityStaked.remainingCapacity, 1n * cents, "should return a capacityLedger with 1M remainingCapacity");
-                    assert.equal(capacityStaked.totalTokensStaked, 1n * cents, "should return a capacityLedger with 1M total staked");
-                    assert.equal(capacityStaked.totalCapacityIssued, 1n * cents, "should return a capacityLedger with 1M capacity issued");
+                    assert.equal(capacityStaked.remainingCapacity, 1n * CENTS, "should return a capacityLedger with 1M remainingCapacity");
+                    assert.equal(capacityStaked.totalTokensStaked, 1n * CENTS, "should return a capacityLedger with 1M total staked");
+                    assert.equal(capacityStaked.totalCapacityIssued, 1n * CENTS, "should return a capacityLedger with 1M capacity issued");
                 });
 
                 describe("and targeting different provider", async function () {
@@ -116,22 +116,22 @@ describe("Capacity Transaction Tests", function () {
 
                     it("does not change other targets amounts", async function () {
                         // Increase stake by 1 cent to a different target.
-                        await assert.doesNotReject(stakeToProvider(stakeKeys, otherProviderId, 1n * cents));
+                        await assert.doesNotReject(stakeToProvider(stakeKeys, otherProviderId, 1n * CENTS));
 
 
                         // Confirm that the staked capacity of the original stakeProviderId account is unchanged
                         // stakeProviderId should still have 1M from first test case in this describe.
                         // otherProvider should now have 1M
                         const origStaked = (await firstValueFrom(ExtrinsicHelper.api.query.capacity.capacityLedger(stakeProviderId))).unwrap();
-                        assert.equal(origStaked.remainingCapacity, 1n * cents, "should return a capacityLedger with 1M remainingCapacity");
-                        assert.equal(origStaked.totalTokensStaked, 1n * cents, "should return a capacityLedger with 1M total tokens staked");
-                        assert.equal(origStaked.totalCapacityIssued, 1n * cents, "should return a capacityLedger with 1M capacity issued");
+                        assert.equal(origStaked.remainingCapacity, 1n * CENTS, "should return a capacityLedger with 1M remainingCapacity");
+                        assert.equal(origStaked.totalTokensStaked, 1n * CENTS, "should return a capacityLedger with 1M total tokens staked");
+                        assert.equal(origStaked.totalCapacityIssued, 1n * CENTS, "should return a capacityLedger with 1M capacity issued");
 
                         // Confirm that the staked capacity was added to the otherProviderId account using the query API
                         const capacityStaked = (await firstValueFrom(ExtrinsicHelper.api.query.capacity.capacityLedger(otherProviderId))).unwrap();
-                        assert.equal(capacityStaked.remainingCapacity, 1n * cents, "should return a capacityLedger with 1M remainingCapacity");
-                        assert.equal(capacityStaked.totalTokensStaked, 1n * cents, "should return a capacityLedger with 1M total tokens staked");
-                        assert.equal(capacityStaked.totalCapacityIssued, 1n * cents, "should return a capacityLedger with 1M capacity issued");
+                        assert.equal(capacityStaked.remainingCapacity, 1n * CENTS, "should return a capacityLedger with 1M remainingCapacity");
+                        assert.equal(capacityStaked.totalTokensStaked, 1n * CENTS, "should return a capacityLedger with 1M total tokens staked");
+                        assert.equal(capacityStaked.totalCapacityIssued, 1n * CENTS, "should return a capacityLedger with 1M capacity issued");
                     });
                 });
             });
@@ -141,7 +141,7 @@ describe("Capacity Transaction Tests", function () {
     describe("when staking and targeting an InvalidTarget", async function () {
         it("fails to stake", async function () {
             let stakeKeys = createKeys("StakeKeys");
-            let stakeAmount = 100n * dollars;
+            let stakeAmount = 100n * DOLLARS;
             await fundKeypair(devAccounts[0].keys, stakeKeys, stakeAmount)
 
             const failStakeObj = ExtrinsicHelper.stake(stakeKeys, 99, stakeAmount);
@@ -153,7 +153,7 @@ describe("Capacity Transaction Tests", function () {
         it("should fail to stake for InsufficientStakingAmount", async function () {
             let stakingKeys = createKeys("stakingKeys");
             let providerId = await createMsaAndProvider(stakingKeys, "stakingKeys", accountBalance);
-            let stakeAmount = cents / 2n;
+            let stakeAmount = CENTS / 2n;
 
             const failStakeObj = ExtrinsicHelper.stake(stakingKeys, providerId, stakeAmount);
             await assert.rejects(failStakeObj.fundAndSend(), { name: "InsufficientStakingAmount" });
@@ -172,10 +172,10 @@ describe("Capacity Transaction Tests", function () {
 
     describe("when staking an amount and account balanace is too low", async function () {
         it("fails to stake and errors BalanceTooLowtoStake", async function () {
-            let accountBalance: bigint = 2n * cents;
+            let accountBalance: bigint = 2n * CENTS;
             let stakingKeys = createKeys("stakingKeys");
             let providerId = await createMsaAndProvider(stakingKeys, "stakingKeys", accountBalance);
-            let stakingAmount = 1n * dollars;
+            let stakingAmount = 1n * DOLLARS;
 
             const failStakeObj = ExtrinsicHelper.stake(stakingKeys, providerId, stakingAmount);
             await assert.rejects(failStakeObj.fundAndSend(), { name: "BalanceTooLowtoStake" });
@@ -186,10 +186,10 @@ describe("Capacity Transaction Tests", function () {
     describe("unstake()", function () {
         let unstakeKeys: KeyringPair;
         let providerId: u64;
-        let stakingAmount = 1n * dollars;
+        let stakingAmount = 1n * DOLLARS;
 
         before(async function () {
-            let accountBalance: bigint = 2n * cents;
+            let accountBalance: bigint = 2n * CENTS;
             unstakeKeys = createKeys("stakingKeys");
             providerId = await createMsaAndProvider(unstakeKeys, "stakingKeys", accountBalance);
         });
@@ -212,7 +212,7 @@ describe("Capacity Transaction Tests", function () {
     describe("#withdraw_unstaked", async function () {
         describe("when attempting to call #withdrawUnstake before first calling #unstake", async function () {
             it("errors with NoUnstakedTokensAvailable", async function () {
-                let stakingAmount = 1n * cents;
+                let stakingAmount = 1n * CENTS;
                 let stakingKeys: KeyringPair = createKeys("stakingKeys");
                 let providerId: u64 = await createMsaAndProvider(stakingKeys, "stakingKeys", accountBalance);
 

--- a/pallets/capacity/src/lib.rs
+++ b/pallets/capacity/src/lib.rs
@@ -13,6 +13,9 @@
 //! The network generates Capacity based on a Capacity-generating function that considers usage and network congestion.
 //! When token is staked, the targeted provider MSA receives the Capacity generated.
 //!
+//! This Capacity can be used to pay for transactions given that the key used to pay for those transactions have a minimum balance
+//! of the existential deposit.
+//!
 //! The staked amount may be increased, targeting either the same or a different target to receive the newly generated Capacity.
 //! As a result, every time the network is staked to, the staked tokens are locked until unstaked.
 //!

--- a/pallets/frequency-tx-payment/src/mock.rs
+++ b/pallets/frequency-tx-payment/src/mock.rs
@@ -243,6 +243,7 @@ impl Config for Test {
 	type Capacity = Capacity;
 	type WeightInfo = ();
 	type CapacityCalls = TestCapacityCalls;
+	type OnChargeCapacityTransaction = payment::CapacityAdapter<Balances, Msa>;
 }
 
 pub struct ExtBuilder {
@@ -326,7 +327,9 @@ impl ExtBuilder {
 	}
 }
 
-fn create_msa_account(account_id: <Test as frame_system::Config>::AccountId) -> MessageSourceId {
+pub fn create_msa_account(
+	account_id: <Test as frame_system::Config>::AccountId,
+) -> MessageSourceId {
 	pub const EMPTY_FUNCTION: fn(MessageSourceId) -> DispatchResult = |_| Ok(());
 	let (msa_id, _) = Msa::create_account(account_id, EMPTY_FUNCTION).unwrap();
 

--- a/pallets/frequency-tx-payment/src/payment.rs
+++ b/pallets/frequency-tx-payment/src/payment.rs
@@ -1,0 +1,60 @@
+use common_primitives::msa::MsaValidator;
+use frame_support::traits::tokens::Balance;
+use sp_std::marker::PhantomData;
+
+use super::*;
+use crate::Config;
+
+/// A trait used for the withdrawal of Capacity.
+pub trait OnChargeCapacityTransaction<T: Config> {
+	/// Scalar type for representing balance of an account.
+	type Balance: Balance;
+
+	/// Handles withdrawal of Capacity from an Account.
+	fn withdraw_fee(
+		key: &T::AccountId,
+		fee: Self::Balance,
+	) -> Result<Self::Balance, TransactionValidityError>;
+}
+
+/// A type used to withdraw Capacity from an account.
+pub struct CapacityAdapter<Curr, Msa>(PhantomData<(Curr, Msa)>);
+
+impl<T, Curr, Msa> OnChargeCapacityTransaction<T> for CapacityAdapter<Curr, Msa>
+where
+	T: Config,
+	Curr: Currency<<T as frame_system::Config>::AccountId>,
+	Msa: MsaValidator<AccountId = <T as frame_system::Config>::AccountId>,
+	BalanceOf<T>: Send + Sync + FixedPointOperand + IsType<CapacityBalanceOf<T>> + MaxEncodedLen,
+{
+	type Balance = BalanceOf<T>;
+
+	/// Handle withdrawal of Capacity using a key associated to an MSA.
+	/// It attempts to replenish an account of Capacity before withdrawing the fee.
+	fn withdraw_fee(
+		key: &T::AccountId,
+		fee: Self::Balance,
+	) -> Result<Self::Balance, TransactionValidityError> {
+		ensure!(
+			Curr::free_balance(key) >= Curr::minimum_balance(),
+			ChargeFrqTransactionPaymentError::BelowMinDeposit.into()
+		);
+
+		let msa_id = Msa::ensure_valid_msa_key(key)
+			.map_err(|_| ChargeFrqTransactionPaymentError::InvalidMsaKey.into())?;
+
+		if T::Capacity::can_replenish(msa_id) {
+			ensure!(
+				T::Capacity::replenish_all_for(msa_id).is_ok(),
+				ChargeFrqTransactionPaymentError::TargetCapacityNotFound.into()
+			);
+		}
+
+		ensure!(
+			T::Capacity::deduct(msa_id, fee.into()).is_ok(),
+			TransactionValidityError::Invalid(InvalidTransaction::Payment)
+		);
+
+		Ok(fee)
+	}
+}

--- a/runtime/common/src/weights/block_weights.rs
+++ b/runtime/common/src/weights/block_weights.rs
@@ -1,6 +1,7 @@
+
 //! THIS FILE WAS AUTO-GENERATED USING THE SUBSTRATE BENCHMARK CLI VERSION 4.0.0-dev
-//! DATE: 2023-03-02 (Y/M/D)
-//! HOSTNAME: `ip-10-100-1-141`, CPU: `Intel(R) Xeon(R) Platinum 8375C CPU @ 2.90GHz`
+//! DATE: 2023-04-05 (Y/M/D)
+//! HOSTNAME: `benchmark-runner-p5rt6-vk9q8`, CPU: `Intel(R) Xeon(R) Platinum 8375C CPU @ 2.90GHz`
 //!
 //! SHORT-NAME: `block`, LONG-NAME: `BlockExecution`, RUNTIME: `Frequency Local Testnet`
 //! WARMUPS: `10`, REPEAT: `100`
@@ -26,17 +27,17 @@ parameter_types! {
 	/// Calculated by multiplying the *Average* with `1.0` and adding `0`.
 	///
 	/// Stats nanoseconds:
-	///   Min, Max: 354_078, 409_579
-	///   Average:  363_335
-	///   Median:   358_960
-	///   Std-Dev:  10499.98
+	///   Min, Max: 345_880, 388_273
+	///   Average:  353_721
+	///   Median:   349_815
+	///   Std-Dev:  8610.63
 	///
 	/// Percentiles nanoseconds:
-	///   99th: 396_467
-	///   95th: 386_761
-	///   75th: 365_573
+	///   99th: 379_004
+	///   95th: 371_982
+	///   75th: 355_603
 	pub const BlockExecutionWeight: Weight =
-		Weight::from_ref_time(WEIGHT_REF_TIME_PER_NANOS.saturating_mul(363_335));
+		Weight::from_ref_time(WEIGHT_REF_TIME_PER_NANOS.saturating_mul(353_721));
 }
 
 #[cfg(test)]

--- a/runtime/common/src/weights/extrinsic_weights.rs
+++ b/runtime/common/src/weights/extrinsic_weights.rs
@@ -1,6 +1,7 @@
+
 //! THIS FILE WAS AUTO-GENERATED USING THE SUBSTRATE BENCHMARK CLI VERSION 4.0.0-dev
-//! DATE: 2023-03-02 (Y/M/D)
-//! HOSTNAME: `ip-10-100-1-141`, CPU: `Intel(R) Xeon(R) Platinum 8375C CPU @ 2.90GHz`
+//! DATE: 2023-04-05 (Y/M/D)
+//! HOSTNAME: `benchmark-runner-p5rt6-vk9q8`, CPU: `Intel(R) Xeon(R) Platinum 8375C CPU @ 2.90GHz`
 //!
 //! SHORT-NAME: `extrinsic`, LONG-NAME: `ExtrinsicBase`, RUNTIME: `Frequency Local Testnet`
 //! WARMUPS: `10`, REPEAT: `100`
@@ -26,17 +27,17 @@ parameter_types! {
 	/// Calculated by multiplying the *Average* with `1.0` and adding `0`.
 	///
 	/// Stats nanoseconds:
-	///   Min, Max: 92_162, 92_699
-	///   Average:  92_419
-	///   Median:   92_413
-	///   Std-Dev:  108.42
+	///   Min, Max: 90_148, 102_526
+	///   Average:  90_764
+	///   Median:   90_507
+	///   Std-Dev:  1449.85
 	///
 	/// Percentiles nanoseconds:
-	///   99th: 92_684
-	///   95th: 92_637
-	///   75th: 92_477
+	///   99th: 96_896
+	///   95th: 91_299
+	///   75th: 90_626
 	pub const ExtrinsicBaseWeight: Weight =
-		Weight::from_ref_time(WEIGHT_REF_TIME_PER_NANOS.saturating_mul(92_419));
+		Weight::from_ref_time(WEIGHT_REF_TIME_PER_NANOS.saturating_mul(90_764));
 }
 
 #[cfg(test)]

--- a/runtime/frequency/src/lib.rs
+++ b/runtime/frequency/src/lib.rs
@@ -899,6 +899,7 @@ impl pallet_frequency_tx_payment::Config for Runtime {
 	type Capacity = Capacity;
 	type WeightInfo = pallet_frequency_tx_payment::weights::SubstrateWeight<Runtime>;
 	type CapacityCalls = CapacityEligibleCalls;
+	type OnChargeCapacityTransaction = pallet_frequency_tx_payment::CapacityAdapter<Balances, Msa>;
 }
 
 // See https://paritytech.github.io/substrate/master/pallet_parachain_system/index.html for


### PR DESCRIPTION
# Goal
Require keys that are used to pay with Capacity
to have a minimum balance of the existential deposit.
    
Remove the tightly coupled dependency of the MSA pallet.

Closes #1311


