### PR TITLE
fix github ui triggered release errors

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -20,6 +20,7 @@ env:
   NEW_RELEASE_TAG: ${{github.event.inputs.release-version || github.ref_name}}
   RELEASE_BRANCH_NAME: release-${{github.event.inputs.release-version || github.ref_name}}
   LATEST_FULL_RELEASE_TAG: _LATEST-FULL-RELEASE
+  XXX: ${{github.event.inputs.release-version || github.ref_name}}
   TEST_RUN: ${{startsWith(github.event.inputs.release-version || github.ref_name, 'v0.0.1')}}
   RUST_TOOLCHAIN: "nightly-2022-10-09" # TODO: Set this dynamically
 


### PR DESCRIPTION
# Goal
The goal of this PR is to resolve errors discovered during the `v1.4.0` run triggered from UI.

Part of #1325