### PR TITLE
feat(FrqTxPayment): add extension weights 

### DIFF
--- a/pallets/capacity/src/lib.rs
+++ b/pallets/capacity/src/lib.rs
@@ -582,7 +582,7 @@ impl<T: Config> Pallet<T> {
 				.saturating_add(RocksDbWeight::get().writes(1))
 		} else {
 			// 1 for get_current_epoch_info, 1 for get_epoch_length
-			RocksDbWeight::get().reads(2u64)
+			RocksDbWeight::get().reads(2u64).saturating_add(RocksDbWeight::get().writes(1))
 		}
 	}
 }


### PR DESCRIPTION
# Goal
Add write and reads weight to "pay_with_capacity"
extrinsic.

The additional weight added to the extrinsic is
from the amount of work done when executing
the logic for paying with Capacity in the
SignedExtension.

These weights can be added to the overhead benchmarks
but more setup is needed to make this happen.

By moving these weights here, we can make sure
we are accounting for the work that is being
done when paying with Capacity.

Additionally, update the weights returned by
on_initialize in the Capacity pallet. The update
adds write for updating the epoch number.

with @enddynayn 
