### PR TITLE
Refactor Capacity Integration Tests

### DIFF
--- a/integration-tests/capacity/replenishment.test.ts
+++ b/integration-tests/capacity/replenishment.test.ts
@@ -12,31 +12,15 @@ import {
   getNextEpochBlock,
   TEST_EPOCH_LENGTH,
   setEpochLength,
-  createAndFundKeypair
+  createGraphChangeSchema,
+  CENTS,
+  DOLLARS,
+  STARTING_BALANCE
 } from "../scaffolding/helpers";
 import { firstValueFrom } from "rxjs";
-import { AVRO_GRAPH_CHANGE } from "../schemas/fixtures/avroGraphChangeSchemaType";
 
 describe("Capacity Replenishment Testing: ", function () {
-  const CENTS = 1000000n
-  const DOLLARS = 100n * CENTS;
-  const STARTING_BALANCE = 6n * CENTS + DOLLARS;
-
   let schemaId: u16;
-
-  async function createGraphChangeSchema() {
-    const keys = createKeys('SchemaCreatorKeys');
-    await fundKeypair(devAccounts[0].keys, keys, STARTING_BALANCE);
-    const [createSchemaEvent, eventMap] = await ExtrinsicHelper
-      .createSchema(keys, AVRO_GRAPH_CHANGE, "AvroBinary", "OnChain")
-      .fundAndSend();
-    assert.notEqual(eventMap["system.ExtrinsicSuccess"], undefined);
-    if (createSchemaEvent && ExtrinsicHelper.api.events.schemas.SchemaCreated.is(createSchemaEvent)) {
-      schemaId = createSchemaEvent.data.schemaId;
-    } else {
-      assert.fail("failed to create a schema")
-    }
-  }
 
   async function getRemainingCapacity(providerId: u64): Promise<u128> {
     const capacityStaked = (await firstValueFrom(ExtrinsicHelper.api.query.capacity.capacityLedger(providerId))).unwrap();
@@ -57,7 +41,7 @@ describe("Capacity Replenishment Testing: ", function () {
 
   before(async function () {
     await setEpochLength(devAccounts[0].keys, TEST_EPOCH_LENGTH);
-    await createGraphChangeSchema();
+    schemaId = await createGraphChangeSchema();
   });
 
   describe("Capacity is replenished", function () {

--- a/integration-tests/capacity/transactions.test.ts
+++ b/integration-tests/capacity/transactions.test.ts
@@ -8,9 +8,11 @@ import {
     generateDelegationPayload, signPayloadSr25519, stakeToProvider, fundKeypair,
     TEST_EPOCH_LENGTH,
     setEpochLength,
-    generateAddKeyPayload
+    generateAddKeyPayload,
+    CENTS,
+    DOLLARS,
+    createGraphChangeSchema
 } from "../scaffolding/helpers";
-import { AVRO_GRAPH_CHANGE } from "../schemas/fixtures/avroGraphChangeSchemaType";
 import { firstValueFrom } from "rxjs";
 
 function assertEvent(events: EventMap, eventName: string) {
@@ -18,9 +20,7 @@ function assertEvent(events: EventMap, eventName: string) {
 }
 
 describe("Capacity Transactions", function () {
-    let CENTS = 1000000n;
-    let DOLLARS = 100n * CENTS;
-    let stakeAmount: bigint = 200n * DOLLARS;
+    const FUNDS_AMOUNT: bigint = 200n * DOLLARS;
 
     before(async function () {
         await setEpochLength(devAccounts[0].keys, TEST_EPOCH_LENGTH);
@@ -28,43 +28,36 @@ describe("Capacity Transactions", function () {
 
     describe("pay_with_capacity", function () {
         describe("when caller has a Capacity account", async function () {
-            let stakeKeys: KeyringPair;
-            let stakeProviderId: u64;
+            let capacityKeys: KeyringPair;
+            let capacityProvider: u64;
             let schemaId: u16;
             const amountStaked = 9n * CENTS;
 
             beforeEach(async function () {
-                stakeKeys = createKeys("StakeKeys");
-                stakeProviderId = await createMsaAndProvider(stakeKeys, "StakeProvider", stakeAmount);
+                capacityKeys = createKeys("CapacityKeys");
+                capacityProvider = await createMsaAndProvider(capacityKeys, "CapacityProvider", FUNDS_AMOUNT);
 
                 // Create schemas for testing with Grant Delegation to test pay_with_capacity
-                const createSchemaOp = ExtrinsicHelper.createSchema(stakeKeys, AVRO_GRAPH_CHANGE, "AvroBinary", "OnChain");
-                const [createSchemaEvent] = await createSchemaOp.fundAndSend();
-
-                assert.notEqual(createSchemaEvent, undefined, "setup should return SchemaCreated event");
-
-                if (createSchemaEvent && ExtrinsicHelper.api.events.schemas.SchemaCreated.is(createSchemaEvent)) {
-                    schemaId = createSchemaEvent.data[1];
-                }
-
+                schemaId = await createGraphChangeSchema();
                 assert.notEqual(schemaId, undefined, "setup should populate schemaId");
+
             });
 
             it("successfully pays with Capacity for eligible transaction - grantDelegation", async function () {
-                await assert.doesNotReject(stakeToProvider(stakeKeys, stakeProviderId, amountStaked));
+                await assert.doesNotReject(stakeToProvider(capacityKeys, capacityProvider, amountStaked));
 
-                let delegatorKeys = createKeys("userKeys");
+                let delegatorKeys = createKeys("delegatorKeys");
                 await fundKeypair(devAccounts[0].keys, delegatorKeys, 100n * DOLLARS);
 
                 let [MsaCreatedEvent] = await ExtrinsicHelper.createMsa(delegatorKeys).signAndSend();
                 assert.notEqual(MsaCreatedEvent, undefined, "should have returned MsaCreated event");
 
                 const payload = await generateDelegationPayload({
-                    authorizedMsaId: stakeProviderId,
+                    authorizedMsaId: capacityProvider,
                     schemaIds: [schemaId],
                 });
                 const addProviderData = ExtrinsicHelper.api.registry.createType("PalletMsaAddProvider", payload);
-                const grantDelegationOp = ExtrinsicHelper.grantDelegation(delegatorKeys, stakeKeys,
+                const grantDelegationOp = ExtrinsicHelper.grantDelegation(delegatorKeys, capacityKeys,
                     signPayloadSr25519(delegatorKeys, addProviderData), payload);
 
                 const [grantDelegationEvent, chainEvents] = await grantDelegationOp.payWithCapacity();
@@ -86,7 +79,7 @@ describe("Capacity Transactions", function () {
                 const remainingCapacity = amountStaked - fee.toBigInt();
 
                 // Check for remaining capacity to be reduced by correct amount
-                const capacityStaked = (await firstValueFrom(ExtrinsicHelper.api.query.capacity.capacityLedger(stakeProviderId))).unwrap();
+                const capacityStaked = (await firstValueFrom(ExtrinsicHelper.api.query.capacity.capacityLedger(capacityProvider))).unwrap();
                 assert.equal(capacityStaked.remainingCapacity, remainingCapacity, 
                     `should return a capacityLedger with ${remainingCapacity} remainingCapacity`);
                 assert.equal(capacityStaked.totalTokensStaked, amountStaked, 
@@ -98,11 +91,8 @@ describe("Capacity Transactions", function () {
             // When a user attempts to pay for a non-capacity transaction with Capacity,
             // it should error and drop the transaction from the transaction-pool.
             it("fails to pay with Capacity for a non-capacity transaction", async function () {
-                let providerId: u64 = new u64(ExtrinsicHelper.api.registry, 0);
-
-                const increaseStakeObj = ExtrinsicHelper.stake(stakeKeys, providerId, 1n * CENTS);
-
-                await assert.rejects(increaseStakeObj.payWithCapacity(), {
+                const nonCapacityTxn = ExtrinsicHelper.stake(capacityKeys, capacityProvider, 1n * CENTS);
+                await assert.rejects(nonCapacityTxn.payWithCapacity(), {
                     name: "RpcError", message:
                         "1010: Invalid Transaction: Custom error: 0"
                 });
@@ -112,20 +102,18 @@ describe("Capacity Transactions", function () {
             // and is NOT eligible to replenish Capacity, it should error and be dropped
             // from the transaction pool.
             it("fails to pay for a transaction with empty capacity", async function () {
-                let providerKeys = createKeys("providerKeys");
-                let _providerId = await createMsaAndProvider(providerKeys, "UnstakeProvider");
+                let noCapacityKeys = createKeys("noCapacityKeys");
+                let _providerId = await createMsaAndProvider(noCapacityKeys, "NoCapProvider");
 
-                let delegatorKeys = createKeys("userKeys");
-                let _userMsaId = await ExtrinsicHelper.createMsa(delegatorKeys);
+                let delegatorKeys = createKeys("delegatorKeys");
 
-                let providerId: u64 = new u64(ExtrinsicHelper.api.registry, 0);
                 const payload = await generateDelegationPayload({
-                    authorizedMsaId: providerId,
+                    authorizedMsaId: capacityProvider,
                     schemaIds: [schemaId],
                 });
                 const addProviderData = ExtrinsicHelper.api.registry.createType("PalletMsaAddProvider", payload);
-                const grantDelegationOp = ExtrinsicHelper.grantDelegation(delegatorKeys, providerKeys,
-                    signPayloadSr25519(providerKeys, addProviderData), payload);
+                const grantDelegationOp = ExtrinsicHelper.grantDelegation(delegatorKeys, noCapacityKeys,
+                    signPayloadSr25519(noCapacityKeys, addProviderData), payload);
 
                 await assert.rejects(grantDelegationOp.payWithCapacity(), {
                     name: "RpcError", message:
@@ -135,33 +123,35 @@ describe("Capacity Transactions", function () {
 
             // *All keys should have at least an EXISTENTIAL_DEPOSIT = 1M.
             it("fails to pay for transaction when key does has not met the min deposit", async function () {
-                let newProviderKeys = createKeys("newKeys");
+                let noTokensKeys = createKeys("noTokensKeys");
+                let delegatorKeys = createKeys("delegatorKeys");
 
-                await assert.doesNotReject(stakeToProvider(stakeKeys, stakeProviderId, 1n * DOLLARS));
+                await assert.doesNotReject(stakeToProvider(capacityKeys, capacityProvider, 1n * DOLLARS));
 
                 // Add new key
-                let newKeyPayload: AddKeyData = await generateAddKeyPayload({ msaId: new u64(ExtrinsicHelper.api.registry, stakeProviderId), newPublicKey: newProviderKeys.publicKey });
+                let newKeyPayload: AddKeyData = await generateAddKeyPayload({
+                     msaId: new u64(ExtrinsicHelper.api.registry, capacityProvider), newPublicKey: noTokensKeys.publicKey
+                });
                 let addKeyData = ExtrinsicHelper.api.registry.createType("PalletMsaAddKeyData", newKeyPayload);
 
-                let ownerSig = signPayloadSr25519(stakeKeys, addKeyData);
-                let newSig = signPayloadSr25519(newProviderKeys, addKeyData);
-                const addPublicKeyOp = ExtrinsicHelper.addPublicKeyToMsa(stakeKeys, ownerSig, newSig, newKeyPayload);
+                let ownerSig = signPayloadSr25519(capacityKeys, addKeyData);
+                let newSig = signPayloadSr25519(noTokensKeys, addKeyData);
+                const addPublicKeyOp = ExtrinsicHelper.addPublicKeyToMsa(capacityKeys, ownerSig, newSig, newKeyPayload);
 
                 const [publicKeyEvents] = await addPublicKeyOp.fundAndSend();
                 assert.notEqual(publicKeyEvents, undefined, 'should have added public key');
 
-                let delegatorKeys = createKeys("delegatorKeys");
                 await fundKeypair(devAccounts[0].keys, delegatorKeys, 100n * DOLLARS);
                 const createMsaOp = ExtrinsicHelper.createMsa(delegatorKeys);
                 const [MsaCreatedEvent] = await createMsaOp.fundAndSend();
                 assert.notEqual(MsaCreatedEvent, undefined, "should have returned MsaCreated event");
 
                 const payload = await generateDelegationPayload({
-                    authorizedMsaId: stakeProviderId,
+                    authorizedMsaId: capacityProvider,
                     schemaIds: [schemaId],
                 });
                 const addProviderData = ExtrinsicHelper.api.registry.createType("PalletMsaAddProvider", payload);
-                const grantDelegationOp = ExtrinsicHelper.grantDelegation(delegatorKeys, newProviderKeys,
+                const grantDelegationOp = ExtrinsicHelper.grantDelegation(delegatorKeys, noTokensKeys,
                     signPayloadSr25519(delegatorKeys, addProviderData), payload);
 
                 await assert.rejects(grantDelegationOp.payWithCapacity(), {
@@ -180,7 +170,7 @@ describe("Capacity Transactions", function () {
                 // Create and fund a keypair with EXISTENTIAL_DEPOSIT
                 // Use this keypair for delegator operations
                 delegatorKeys = createKeys("OtherProviderKeys");
-                delegatorProviderId = await createMsaAndProvider(delegatorKeys, "Delegator", stakeAmount);
+                delegatorProviderId = await createMsaAndProvider(delegatorKeys, "Delegator", FUNDS_AMOUNT);
                 schemaId = new u16(ExtrinsicHelper.api.registry, 0);
             });
 
@@ -188,7 +178,7 @@ describe("Capacity Transactions", function () {
                 it("fails to pay for a transaction", async function () {
                     // Create a keypair with msaId, but no provider
                     let noProviderKeys = createKeys("NoProviderKeys");
-                    await fundKeypair(devAccounts[0].keys, noProviderKeys, stakeAmount);
+                    await fundKeypair(devAccounts[0].keys, noProviderKeys, FUNDS_AMOUNT);
                     const createMsaOp = ExtrinsicHelper.createMsa(noProviderKeys);
 
                     const [MsaCreatedEvent] = await createMsaOp.fundAndSend();


### PR DESCRIPTION
# Goal
The goal of this PR is refactor some of the capacity end to end tests to make them easier to read.

- Pulled out some constants and a function into the common helpers.ts
- Changed some variable names to better reflect their test purpose
- Removed some setup that was unnecessary for specific tests