### PR TITLE
Use `String` for ease of use of api library

### DIFF
--- a/integration-tests/handles/handles.test.ts
+++ b/integration-tests/handles/handles.test.ts
@@ -81,6 +81,7 @@ describe("🤝 Handles", () => {
             let suffix_input_type = ExtrinsicHelper.api.registry.createType("PresumptiveSuffixesRequest", request_suffixes);
             let suffixes_response = await ExtrinsicHelper.getNextSuffixesForHandle(suffix_input_type);
             let resp_base_handle = suffixes_response.base_handle.toString();
+            assert.equal(resp_base_handle, handle, "resp_base_handle should be equal to handle");
             let suffix_assumed = suffixes_response.suffixes[0];
             assert.notEqual(suffix_assumed, 0, "suffix_assumed should not be 0");         
 
@@ -101,6 +102,11 @@ describe("🤝 Handles", () => {
             if (!handle_response.isSome) {
                 throw new Error("handle_response should be Some");
             }
+            let full_handle_state = handle_response.unwrap();
+            let suffix_from_state = full_handle_state.suffix;
+            let suffix = suffix_from_state.toNumber();
+            assert.notEqual(suffix, 0, "suffix should not be 0");
+            assert.equal(suffix, suffix_assumed, "suffix should be equal to suffix_assumed");
          });
     }); 
 });

--- a/integration-tests/package-lock.json
+++ b/integration-tests/package-lock.json
@@ -697,7 +697,7 @@
         "node_modules/@frequency-chain/api-augment": {
             "version": "0.0.0",
             "resolved": "file:../js/api-augment/dist/frequency-chain-api-augment-0.0.0.tgz",
-            "integrity": "sha512-E86M6OPVfzrEDg/sFpguw0jidI9mNjEL4XblG9KJpK6XAmas4RF9PUdfkk0zxRWyfFzQUiB6hYFzp7pUdj9j7Q==",
+            "integrity": "sha512-8Ea7ObKkRQxhJXW+oF+LiQPPgdbkqbbB9SVJVonkGR+3h7X4SIISQ1PCqSa90inmKA7v8HyEUlSh2sjIrx/x9A==",
             "license": "Apache-2.0",
             "dependencies": {
                 "@polkadot/api": "^9.14.2",

--- a/js/api-augment/definitions/handles.ts
+++ b/js/api-augment/definitions/handles.ts
@@ -24,17 +24,17 @@ export default {
   types: {
     HandleSuffix: "u16",
     HandleResponse: {
-      base_handle: "Vec<u8>",
-      canonical_handle: "Vec<u8>",
+      base_handle: "String",
+      canonical_handle: "String",
       suffix: "u16",
     },
     PresumptiveSuffixesRequest: {
-      base_handle: "Vec<u8>",
+      base_handle: "String",
       count: "u16",
     },
     PresumptiveSuffixesResponse: {
       suffixes: "Vec<HandleSuffix>",
-      base_handle: "Vec<u8>",
+      base_handle: "String",
     },
   },
   runtime: {


### PR DESCRIPTION
# Goal
The goal of this PR i i to address
@wilwade's feedback

> Could we convert these Vec<u8>s into strings to make it easier for RPC consumers?


# Discussion
<!-- List discussion items -->

# Checklist
- [ ] Chain spec updated
- [ ] Custom RPC OR Runtime API added/changed? Updated js/api-augment.
- [ ] Design doc(s) updated
- [ ] Tests added
- [ ] Benchmarks added
- [ ] Weights updated
