### PR TITLE
Convert HandleConverter struct to use associated functions

### DIFF
--- a/pallets/handles/src/lib.rs
+++ b/pallets/handles/src/lib.rs
@@ -419,10 +419,9 @@ pub mod pallet {
 				.map_err(|_| Error::<T>::InvalidHandleEncoding)
 				.ok()?;
 
-			let handle_converter = HandleConverter::new();
-			let (base_handle_str, suffix) = handle_converter.split_display_name(full_handle_str);
+			let (base_handle_str, suffix) = HandleConverter::split_display_name(full_handle_str);
 			let base_handle = base_handle_str.as_bytes().to_vec();
-			let canonical_handle_str = handle_converter.convert_to_canonical(&base_handle_str);
+			let canonical_handle_str = HandleConverter::convert_to_canonical(&base_handle_str);
 			let canonical_handle = canonical_handle_str.as_bytes().to_vec();
 			Some(HandleResponse { base_handle, suffix, canonical_handle })
 		}
@@ -447,8 +446,7 @@ pub mod pallet {
 			let base_handle: Handle = handle.try_into().unwrap_or_default();
 			let base_handle_str = core::str::from_utf8(&base_handle).unwrap_or("");
 
-			let handle_converter = HandleConverter::new();
-			let canonical_handle_str = handle_converter.convert_to_canonical(&base_handle_str);
+			let canonical_handle_str = HandleConverter::convert_to_canonical(&base_handle_str);
 			let canonical_handle_vec = canonical_handle_str.as_bytes().to_vec();
 			let canonical_handle: Handle = canonical_handle_vec.try_into().unwrap();
 			let suffix_index =
@@ -493,8 +491,7 @@ pub mod pallet {
 			suffix_sequence_index: SequenceIndex,
 		) -> Handle {
 			// Convert base display handle into a canonical display handle
-			let handle_converter = HandleConverter::new();
-			let canonical_handle_str = handle_converter.convert_to_canonical(&base_handle_str);
+			let canonical_handle_str = HandleConverter::convert_to_canonical(&base_handle_str);
 
 			// Generate suffix from index into the suffix sequence
 			let suffix = Self::generate_suffix_for_canonical_handle(
@@ -581,8 +578,7 @@ pub mod pallet {
 			);
 
 			// Convert base display handle into a canonical display handle
-			let handle_converter = HandleConverter::new();
-			let canonical_handle_str = handle_converter.convert_to_canonical(&base_handle_str);
+			let canonical_handle_str = HandleConverter::convert_to_canonical(&base_handle_str);
 			let canonical_handle_vec = canonical_handle_str.as_bytes().to_vec();
 			let canonical_handle: Handle = canonical_handle_vec.try_into().unwrap();
 
@@ -638,11 +634,10 @@ pub mod pallet {
 			let display_name_str = core::str::from_utf8(&display_name_handle)
 				.map_err(|_| Error::<T>::InvalidHandleEncoding)?;
 
-			let handle_converter = HandleConverter::new();
 			let (base_handle_str, suffix_num) =
-				handle_converter.split_display_name(display_name_str);
+				HandleConverter::split_display_name(display_name_str);
 
-			let canonical_handle_str = handle_converter.convert_to_canonical(&base_handle_str);
+			let canonical_handle_str = HandleConverter::convert_to_canonical(&base_handle_str);
 			let canonical_handle_vec = canonical_handle_str.as_bytes().to_vec();
 			let canonical_handle: Handle = canonical_handle_vec.try_into().unwrap();
 

--- a/pallets/handles/src/tests/converter_tests.rs
+++ b/pallets/handles/src/tests/converter_tests.rs
@@ -11,7 +11,6 @@ fn test_replace_confusables() {
 	assert!(file.is_ok());
 
 	let reader = BufReader::new(file.ok().unwrap());
-	let handle_converter = HandleConverter::new();
 	for line_result in reader.lines() {
 		let original_line = line_result.ok().unwrap();
 
@@ -19,7 +18,7 @@ fn test_replace_confusables() {
 		// that each subsequent character may be confused with
 		let first_character = original_line.chars().next().unwrap();
 
-		let normalized_line = handle_converter.replace_confusables(&original_line);
+		let normalized_line = HandleConverter::replace_confusables(&original_line);
 		for normalized_character in normalized_line.chars() {
 			let normalized_character_codepoint =
 				format!("\'\\u{{{:x}}}\'", normalized_character as u32);
@@ -33,9 +32,8 @@ fn test_replace_confusables() {
 
 #[test]
 fn test_strip_diacriticals() {
-	let handle_converter = HandleConverter::new();
 	let diacritical_string = "ÄÅÖäåöĂăĔĚĕĞğģĬĭŎŏŬǓŭàáâñ";
-	let stripped_string = handle_converter.strip_diacriticals(diacritical_string);
+	let stripped_string = HandleConverter::strip_diacriticals(diacritical_string);
 	assert_eq!(stripped_string, "AAOaaoAaEEeGggIiOoUUuaaan");
 }
 
@@ -72,9 +70,8 @@ fn test_strip_unicode_whitespace() {
 	let string_with_whitespace =
 		format!("{}hello{}world!{}", whitespace_string, whitespace_string, whitespace_string);
 	println!("String with whitespace: {}", string_with_whitespace);
-	let handle_converter = HandleConverter::new();
 	let whitespace_stripped_string =
-		handle_converter.strip_unicode_whitespace(&string_with_whitespace);
+		HandleConverter::strip_unicode_whitespace(&string_with_whitespace);
 	println!("Whitespace stripped string: {}", whitespace_stripped_string);
 	assert_eq!(whitespace_stripped_string, "helloworld!");
 }

--- a/pallets/handles/src/utils/converter.rs
+++ b/pallets/handles/src/utils/converter.rs
@@ -15,14 +15,6 @@ pub struct HandleConverter {}
 /// Creates a new `HandleConverter` instance with the specified input string.
 impl HandleConverter {
 	/// Creates a new `HandleConverter` instance with a built confusables map.
-	///
-	/// # Returns
-	///
-	/// A new `HandleConverter` instance.
-	///
-	pub fn new() -> Self {
-		Self {}
-	}
 	/// Converts a given string to its canonical form by stripping Unicode whitespace,
 	/// replacing confusable characters, and stripping diacritical marks.
 	/// The resulting string is converted to lowercase ASCII characters.
@@ -35,10 +27,10 @@ impl HandleConverter {
 	///
 	/// A new string in canonical form.
 	///
-	pub fn convert_to_canonical(&self, input_str: &str) -> codec::alloc::string::String {
-		let white_space_stripped = self.strip_unicode_whitespace(input_str);
-		let confusables_removed = self.replace_confusables(&white_space_stripped);
-		let diacriticals_stripped = self.strip_diacriticals(&confusables_removed);
+	pub fn convert_to_canonical(input_str: &str) -> codec::alloc::string::String {
+		let white_space_stripped = Self::strip_unicode_whitespace(input_str);
+		let confusables_removed = Self::replace_confusables(&white_space_stripped);
+		let diacriticals_stripped = Self::strip_diacriticals(&confusables_removed);
 		diacriticals_stripped.to_ascii_lowercase()
 	}
 
@@ -51,7 +43,7 @@ impl HandleConverter {
 	/// # Returns
 	///
 	/// A new string where any confusable characters have been replaced with their corresponding non-confusable characters.
-	pub fn replace_confusables(&self, input_str: &str) -> codec::alloc::string::String {
+	pub fn replace_confusables(input_str: &str) -> codec::alloc::string::String {
 		input_str
 			.chars()
 			.map(|character| CONFUSABLES.get(&character).map_or(character, |&value| value))
@@ -67,7 +59,7 @@ impl HandleConverter {
 	/// This function uses the NFKD normalization form and filtering of combining marks to strip the diacritical marks from the input string.
 	/// Combining marks are Unicode characters that are intended to modify the appearance of another character.
 	///
-	pub fn strip_diacriticals(&self, input_str: &str) -> codec::alloc::string::String {
+	pub fn strip_diacriticals(input_str: &str) -> codec::alloc::string::String {
 		input_str
 			.nfkd()
 			.filter(|character| !is_combining_mark(*character))
@@ -84,7 +76,7 @@ impl HandleConverter {
 	///
 	/// A tuple containing the base handle string and the handle suffix as a `HandleSuffix` enum.
 	///
-	pub fn split_display_name(&self, display_name_str: &str) -> (String, HandleSuffix) {
+	pub fn split_display_name(display_name_str: &str) -> (String, HandleSuffix) {
 		let parts: Vec<&str> = display_name_str.split(".").collect();
 		let base_handle_str = parts[0].to_string();
 		let suffix = parts[1];
@@ -116,7 +108,7 @@ impl HandleConverter {
 	/// # Returns
 	///
 	/// A new string without any Unicode whitespace characters.
-	pub fn strip_unicode_whitespace(&self, input_str: &str) -> String {
+	pub fn strip_unicode_whitespace(input_str: &str) -> String {
 		input_str
 			.chars()
 			.filter(|character| !character.is_whitespace())


### PR DESCRIPTION
# Goal
The goal of this PR is change HandleConverter from methods to associated functions.
