### PR TITLE
Fallback to the github token

### DIFF
--- a/.github/workflows/verify-pr-commit.yml
+++ b/.github/workflows/verify-pr-commit.yml
@@ -729,7 +729,7 @@ jobs:
       - name: Check Out Repo
         uses: actions/checkout@v3
         with:
-          token: ${{secrets.GHA_GIT_COMMIT}}
+          token: ${{ secrets.GHA_GIT_COMMIT || github.token }}
           ref: ${{github.event.pull_request.head.sha}}
       - name: Run Benchmarks?
         id: run-benchmarks


### PR DESCRIPTION
Some things don't need access to the `GHA_GIT_COMMIT`, so let them carry on with just the normal github token.
