### PR TITLE
fix GitHub requires a tag error for release candidates

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -726,6 +726,7 @@ jobs:
           name: "[Release Candidate] ${{env.NEW_RELEASE_TAG}}"
           prerelease: true
           body_path: tools/ci/release-notes/release-notes.md
+          tag_name: ${{env.NEW_RELEASE_TAG}}
           files: |
             /tmp/frequency*.*
             /tmp/metadata-compare-*


### PR DESCRIPTION
# Goal
The goal of this PR is fix "GitHub requires a tag" error when a release candidate is cut from UI.

Test release candidate: https://github.com/LibertyDSNP/frequency/actions/runs/4658267567

Closes #1358