### PR TITLE
Added clean target to Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,9 @@
 UNAME := $(shell uname)
 
+.PHONY: clean
+clean:
+	cargo clean
+
 .PHONY: start
 start:
 	./scripts/init.sh start-frequency-instant


### PR DESCRIPTION
# Goal
The goal of this PR is to add a "clean" target to the `Makefile`.  This currently just does a `cargo clean `but in the future could remove the /tmp/frequency folder as well as anything else deemed necessary.
