### PR TITLE
switch calc code coverage job to prev runners

### DIFF
--- a/.github/workflows/verify-pr-commit.yml
+++ b/.github/workflows/verify-pr-commit.yml
@@ -293,7 +293,7 @@ jobs:
     needs: changes
     if: needs.changes.outputs.rust == 'true'
     name: Calculate Code Coverage
-    runs-on: [self-hosted, Linux, X64, testing, v2]
+    runs-on: [self-hosted, Linux, X64, build]
     container: ubuntu:20.04
     steps:
       - name: Install Required Packages


### PR DESCRIPTION
# Goal
The goal of this PR is to switch "Calculate Code Coverage"  job to previous errors due to new runner related error.

Closes #1378