### PR TITLE
User handles capacity stable weights

### DIFF
--- a/pallets/frequency-tx-payment/src/capacity_stable_weights.rs
+++ b/pallets/frequency-tx-payment/src/capacity_stable_weights.rs
@@ -69,7 +69,7 @@ pub trait WeightInfo {
 	fn upsert_page_with_signature(s: u32, ) -> Weight;
 	fn delete_page_with_signature() -> Weight;
 	// Handles
-	fn claim_handle() -> Weight;
+	fn claim_handle(b: u32, ) -> Weight;
 }
 
 /// Weights for pallet_msa using the Substrate node and recommended hardware.
@@ -200,14 +200,15 @@ impl<T: frame_system::Config> WeightInfo for SubstrateWeight<T> {
 			.saturating_add(T::DbWeight::get().reads(3 as u64))
 			.saturating_add(T::DbWeight::get().writes(1 as u64))
 	}
-	// TODO: Needs to be updated once benchmarks are run.
-	// Storage: Msa PublicKeyToMsaId (r:2 w:0)
+	// Storage: Msa PublicKeyToMsaId (r:1 w:0)
 	// Storage: Handles MSAIdToDisplayName (r:1 w:1)
 	// Storage: Handles CanonicalBaseHandleToSuffixIndex (r:1 w:1)
 	// Storage: Handles CanonicalBaseHandleAndSuffixToMSAId (r:0 w:1)
-	fn claim_handle() -> Weight {
-		Weight::from_ref_time(323_287_217 as u64)
-			.saturating_add(T::DbWeight::get().reads(4 as u64))
+	fn claim_handle(b: u32, ) -> Weight {
+		Weight::from_ref_time(90_537_753 as u64)
+			// Standard Error: 27_078
+			.saturating_add(Weight::from_ref_time(104_522 as u64).saturating_mul(b as u64))
+			.saturating_add(T::DbWeight::get().reads(3 as u64))
 			.saturating_add(T::DbWeight::get().writes(3 as u64))
 	}
 }

--- a/runtime/frequency/src/lib.rs
+++ b/runtime/frequency/src/lib.rs
@@ -902,7 +902,7 @@ impl GetStableWeight<RuntimeCall, Weight> for CapacityEligibleCalls {
 			RuntimeCall::StatefulStorage(StatefulStorageCall::apply_item_actions_with_signature { payload, ..}) => Some(capacity_stable_weights::SubstrateWeight::<Runtime>::apply_item_actions_with_signature(StatefulStorage::sum_add_actions_bytes(&payload.actions))),
 			RuntimeCall::StatefulStorage(StatefulStorageCall::upsert_page_with_signature { payload, ..}) => Some(capacity_stable_weights::SubstrateWeight::<Runtime>::upsert_page_with_signature(payload.payload.len() as u32 )),
 			RuntimeCall::StatefulStorage(StatefulStorageCall::delete_page_with_signature { .. }) => Some(capacity_stable_weights::SubstrateWeight::<Runtime>::delete_page_with_signature()),
-			RuntimeCall::Handles(HandlesCall::claim_handle { .. }) => Some(capacity_stable_weights::SubstrateWeight::<Runtime>::claim_handle()),
+			RuntimeCall::Handles(HandlesCall::claim_handle { payload, .. }) => Some(capacity_stable_weights::SubstrateWeight::<Runtime>::claim_handle(payload.base_handle.len() as u32)),
 			_ => None,
 		}
 	}


### PR DESCRIPTION
# Goal
The goal of this PR is to update User Handles stable weights for capacity with values generated on reference hardware.


# Checklist
- [ ] Chain spec updated
- [ ] Custom RPC OR Runtime API added/changed? Updated js/api-augment.
- [ ] Design doc(s) updated
- [ ] Tests added
- [ ] Benchmarks added
- [x] Weights updated
