### PR TITLE
Fixed default Makefile target

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,8 @@
 UNAME := $(shell uname)
 
+.PHONY: all
+all: start
+
 .PHONY: clean
 clean:
 	cargo clean


### PR DESCRIPTION
# Goal
The goal of this PR is to fix the default Makefile target.

Restores the default from before the clean target was added.
