### PR TITLE
Rpc fixes 1

### DIFF
--- a/pallets/handles/src/lib.rs
+++ b/pallets/handles/src/lib.rs
@@ -453,8 +453,7 @@ pub mod pallet {
 		///
 		/// * `PresumptiveSuffixesResponse` - The response containing the next available suffixes.
 		/// ```
-		pub fn get_next_suffixes(handle: Vec<u8>, count: u16) -> PresumptiveSuffixesResponse {
-			let base_handle: Handle = handle.try_into().unwrap_or_default();
+		pub fn get_next_suffixes(base_handle: Handle, count: u16) -> PresumptiveSuffixesResponse {
 			let base_handle_str = core::str::from_utf8(&base_handle).unwrap_or_default();
 
 			// Convert base handle into a canonical base

--- a/pallets/handles/src/rpc/src/lib.rs
+++ b/pallets/handles/src/rpc/src/lib.rs
@@ -96,7 +96,7 @@ where
 	) -> RpcResult<PresumptiveSuffixesResponse> {
 		let api = self.client.runtime_api();
 		let at = BlockId::hash(self.client.info().best_hash);
-		let handle_input: Handle = base_handle.into_bytes().try_into().unwrap();
+		let handle_input: Handle = Self::get_handle(&base_handle)?;
 		let max_count = MAX_SUFFIXES_COUNT;
 		let count = count.unwrap_or(DEFAULT_SUFFIX_COUNT).min(max_count);
 		let suffixes_result = api.get_next_suffixes(&at, handle_input, count);
@@ -106,8 +106,14 @@ where
 	fn get_msa_for_handle(&self, display_handle: String) -> RpcResult<Option<MessageSourceId>> {
 		let api = self.client.runtime_api();
 		let at = BlockId::hash(self.client.info().best_hash);
-		let handle_vec: Handle = display_handle.into_bytes().try_into().unwrap();
+		let handle_vec: Handle = Self::get_handle(&display_handle)?;
 		let result = api.get_msa_for_handle(&at, handle_vec);
 		map_rpc_result(result)
+	}
+
+	fn get_handle(input: &str) -> Result<Handle, HandlesRpcError> {
+		let handle_bytes =
+			input.as_bytes().try_into().map_err(|_| HandlesRpcError::InvalidHandle)?;
+		Ok(Handle::new(handle_bytes))
 	}
 }

--- a/pallets/handles/src/rpc/src/lib.rs
+++ b/pallets/handles/src/rpc/src/lib.rs
@@ -64,7 +64,10 @@ impl<C, M> HandlesHandler<C, M> {
 
 /// Errors that occur on the client RPC
 #[derive(Debug)]
-pub enum HandlesRpcError {}
+pub enum HandlesRpcError {
+	/// InvalidHandle
+	InvalidHandle,
+}
 
 impl From<HandlesRpcError> for RpcError {
 	fn from(e: HandlesRpcError) -> Self {
@@ -104,7 +107,7 @@ where
 		let api = self.client.runtime_api();
 		let at = BlockId::hash(self.client.info().best_hash);
 		let handle_vec: Handle = display_handle.into_bytes().try_into().unwrap();
-		let result = api.get_msa_for_handle(&at, handle_vec.into());
+		let result = api.get_msa_for_handle(&at, handle_vec);
 		map_rpc_result(result)
 	}
 }

--- a/runtime/frequency/src/lib.rs
+++ b/runtime/frequency/src/lib.rs
@@ -1361,7 +1361,7 @@ impl_runtime_apis! {
 		}
 
 		fn get_next_suffixes(base_handle: Handle, count: u16) -> PresumptiveSuffixesResponse {
-			Handles::get_next_suffixes(base_handle.into(), count)
+			Handles::get_next_suffixes(base_handle, count)
 		}
 
 		fn get_msa_for_handle(display_handle: Handle) -> Option<MessageSourceId> {


### PR DESCRIPTION
# Goal
The goal of this PR is  to address the issue of safety check in rpc

> We use into_bytes().try_into().unwrap() in two places in the RPC. Change these so that they error instead of panic.