### PR TITLE
 Add unit test for multihash panic in multiformats/multihash

### DIFF
--- a/pallets/messages/src/tests/other_tests.rs
+++ b/pallets/messages/src/tests/other_tests.rs
@@ -643,3 +643,17 @@ fn validate_cid_not_utf8_aligned_errors() {
 		assert_noop!(MessagesPallet::validate_cid(&bad_cid), Error::<Test>::InvalidCid);
 	})
 }
+
+#[test]
+fn validate_cid_not_correct_format_errors() {
+	new_test_ext().execute_with(|| {
+		// This should not panic, but should return an error.
+		let bad_cid = vec![0, 1, 0, 1, 203, 155, 0, 0, 0, 5, 67];
+
+		assert_noop!(MessagesPallet::validate_cid(&bad_cid), Error::<Test>::InvalidCid);
+		// This should not panic, but should return an error.
+		let another_bad_cid = vec![241, 0, 0, 0, 0, 0, 128, 132, 132, 132, 58];
+
+		assert_noop!(MessagesPallet::validate_cid(&another_bad_cid), Error::<Test>::InvalidCid);
+	})
+}


### PR DESCRIPTION
# Goal
The goal of this PR is to add a unit test in the messages pallet to detect a panic on some types of bad cids.
`multihash` v0.18.1 fixes an issue with calling `unwrap()` on certain types of errors in a `no-std` environment.
`multihash` is included by the `cid` crate used for IPFS messages.
[`Cargo.lock` was updated by another PR before this was merged, so v0.18.1 is already there]

Closes #1233 

Further updates in progress #1417 
https://github.com/multiformats/rust-cid/pull/135
