### PR TITLE
set token:capacity ratio to 50, set thaw period to 30 days.

### DIFF
--- a/integration-tests/package-lock.json
+++ b/integration-tests/package-lock.json
@@ -304,7 +304,7 @@
         "node_modules/@frequency-chain/api-augment": {
             "version": "0.0.0",
             "resolved": "file:../js/api-augment/dist/frequency-chain-api-augment-0.0.0.tgz",
-            "integrity": "sha512-v3hdXspRQjwKBcR5LDH8z5GDh+ye9O7WfKDGeATlUPH+pU4xt3ChZAnPP1o3+mEp7YJ3s+TZZVpyOyRVUpBgQw==",
+            "integrity": "sha512-qEpa46lUZo/csNMn01yBuLufU5EO5vvhLp/EFaBfdbiSYEFS4BnCV76bPyEcBc7OppaGN3pWruaeeh+bFnklAQ==",
             "license": "Apache-2.0",
             "dependencies": {
                 "@polkadot/api": "^10.3.2",

--- a/pallets/capacity/src/benchmarking.rs
+++ b/pallets/capacity/src/benchmarking.rs
@@ -83,8 +83,8 @@ benchmarks! {
 	}
 	unstake {
 		let caller: T::AccountId = create_funded_account::<T>("account", SEED, 5u32);
-		let staking_amount: BalanceOf<T> = T::MinimumStakingAmount::get().saturating_add(6u32.into());
-		let unstaking_amount = 5u32;
+		let staking_amount: BalanceOf<T> = T::MinimumStakingAmount::get().saturating_add(20u32.into());
+		let unstaking_amount = 9u32;
 		let capacity_amount: BalanceOf<T> = Capacity::<T>::calculate_capacity(staking_amount);
 		let target = 1;
 		let block_number = 4u32;
@@ -95,7 +95,7 @@ benchmarks! {
 
 		staking_account.deposit(staking_amount);
 		target_details.deposit(staking_amount, capacity_amount);
-		capacity_details.deposit(&capacity_amount);
+		capacity_details.deposit(&staking_amount, &capacity_amount);
 
 		Capacity::<T>::set_staking_account(&caller.clone(), &staking_account);
 		Capacity::<T>::set_target_details_for(&caller.clone(), target, target_details);

--- a/pallets/capacity/src/benchmarking.rs
+++ b/pallets/capacity/src/benchmarking.rs
@@ -39,7 +39,7 @@ benchmarks! {
 	stake {
 		let caller: T::AccountId = create_funded_account::<T>("account", SEED, 105u32);
 		let amount: BalanceOf<T> = T::MinimumStakingAmount::get();
-		let capacity: BalanceOf<T> = Capacity::<T>::calculate_capacity(amount);
+		let capacity: BalanceOf<T> = Capacity::<T>::capacity_generated(amount);
 		let target = 1;
 
 		register_provider::<T>(target, "Foo");
@@ -85,7 +85,7 @@ benchmarks! {
 		let caller: T::AccountId = create_funded_account::<T>("account", SEED, 5u32);
 		let staking_amount: BalanceOf<T> = T::MinimumStakingAmount::get().saturating_add(20u32.into());
 		let unstaking_amount = 9u32;
-		let capacity_amount: BalanceOf<T> = Capacity::<T>::calculate_capacity(staking_amount);
+		let capacity_amount: BalanceOf<T> = Capacity::<T>::capacity_generated(staking_amount);
 		let target = 1;
 		let block_number = 4u32;
 

--- a/pallets/capacity/src/lib.rs
+++ b/pallets/capacity/src/lib.rs
@@ -554,11 +554,6 @@ impl<T: Config> Pallet<T> {
 
 		let capacity_to_withdraw = Self::calculate_capacity(amount);
 
-		// let capacity_reduction = Self::calculate_capacity_reduction(
-		// 	amount,
-		// 	capacity_details.total_tokens_staked,
-		// 	capacity_details.total_capacity_issued,
-		// );
 		staking_target_details.withdraw(amount, capacity_to_withdraw);
 		capacity_details.withdraw(capacity_to_withdraw, amount);
 
@@ -626,8 +621,7 @@ impl<T: Config> Nontransferable for Pallet<T> {
 	fn deposit(msa_id: MessageSourceId, amount: Self::Balance) -> Result<(), DispatchError> {
 		let mut capacity_details =
 			Self::get_capacity_for(msa_id).ok_or(Error::<T>::TargetCapacityNotFound)?;
-		let capacity_to_deposit = Self::calculate_capacity(amount);
-		capacity_details.deposit(&amount, &capacity_to_deposit);
+		capacity_details.deposit(&amount, &Self::calculate_capacity(amount));
 		Self::set_capacity_for(msa_id, capacity_details);
 		Ok(())
 	}

--- a/pallets/capacity/src/tests/capacity_details_tests.rs
+++ b/pallets/capacity/src/tests/capacity_details_tests.rs
@@ -6,14 +6,14 @@ fn impl_staking_capacity_details_deposit() {
 	let mut capacity_details =
 		CapacityDetails::<BalanceOf<Test>, <Test as Config>::EpochNumber>::default();
 
-	assert_eq!(capacity_details.deposit(&10), Some(()));
+	assert_eq!(capacity_details.deposit(&10, &1), Some(()));
 
 	assert_eq!(
 		capacity_details,
 		CapacityDetails::<BalanceOf<Test>, <Test as Config>::EpochNumber> {
-			remaining_capacity: BalanceOf::<Test>::from(10u64),
 			total_tokens_staked: BalanceOf::<Test>::from(10u64),
-			total_capacity_issued: BalanceOf::<Test>::from(10u64),
+			remaining_capacity: BalanceOf::<Test>::from(1u64),
+			total_capacity_issued: BalanceOf::<Test>::from(1u64),
 			last_replenished_epoch: <Test as Config>::EpochNumber::from(0u32)
 		}
 	)

--- a/pallets/capacity/src/tests/mock.rs
+++ b/pallets/capacity/src/tests/mock.rs
@@ -9,7 +9,7 @@ use frame_support::{
 	traits::{ConstU16, ConstU32, ConstU64},
 };
 use frame_system::EnsureSigned;
-use sp_core::{crypto::Zeroize, ConstU8, H256};
+use sp_core::{ConstU8, H256};
 use sp_runtime::{
 	testing::Header,
 	traits::{BlakeTwo256, Convert, IdentityLookup},

--- a/pallets/capacity/src/tests/mock.rs
+++ b/pallets/capacity/src/tests/mock.rs
@@ -152,12 +152,17 @@ impl pallet_msa::Config for Test {
 	type MaxSignaturesStored = ConstU32<8000>;
 }
 
+parameter_types! {
+	pub static TokenPerCapacity: u32 = 10;
+	pub static MinimumStakingAmount: u64 = 10; // this has to be >= TokenPerCapacity
+}
+
 impl pallet_capacity::Config for Test {
 	type RuntimeEvent = RuntimeEvent;
 	type WeightInfo = ();
 	type Currency = pallet_balances::Pallet<Self>;
 	type TargetValidator = Msa;
-	type MinimumStakingAmount = ConstU64<5>;
+	type MinimumStakingAmount = MinimumStakingAmount;
 	type MinimumTokenBalance = ConstU64<10>;
 	type MaxUnlockingChunks = ConstU32<4>;
 
@@ -167,12 +172,22 @@ impl pallet_capacity::Config for Test {
 	type UnstakingThawPeriod = ConstU16<2>;
 	type MaxEpochLength = ConstU64<100>;
 	type EpochNumber = u32;
+	type TokenPerCapacity = TokenPerCapacity;
 }
 
 pub fn new_test_ext() -> sp_io::TestExternalities {
 	let mut t = frame_system::GenesisConfig::default().build_storage::<Test>().unwrap();
 	pallet_balances::GenesisConfig::<Test> {
-		balances: vec![(100, 10), (200, 20), (300, 30), (400, 40), (500, 50), (600, 60)],
+		balances: vec![
+			(50, 5),
+			(100, 100),
+			(200, 200),
+			(300, 300),
+			(400, 400),
+			(500, 500),
+			(600, 600),
+			(10_000, 10_000),
+		],
 	}
 	.assimilate_storage(&mut t)
 	.unwrap();

--- a/pallets/capacity/src/tests/mock.rs
+++ b/pallets/capacity/src/tests/mock.rs
@@ -152,17 +152,12 @@ impl pallet_msa::Config for Test {
 	type MaxSignaturesStored = ConstU32<8000>;
 }
 
-parameter_types! {
-	pub static TokenPerCapacity: u32 = 10;
-	pub static MinimumStakingAmount: u64 = 10; // this has to be >= TokenPerCapacity
-}
-
 impl pallet_capacity::Config for Test {
 	type RuntimeEvent = RuntimeEvent;
 	type WeightInfo = ();
 	type Currency = pallet_balances::Pallet<Self>;
 	type TargetValidator = Msa;
-	type MinimumStakingAmount = MinimumStakingAmount;
+	type MinimumStakingAmount = ConstU64<10>; // this has to be >= TokenPerCapacity
 	type MinimumTokenBalance = ConstU64<10>;
 	type MaxUnlockingChunks = ConstU32<4>;
 
@@ -172,7 +167,7 @@ impl pallet_capacity::Config for Test {
 	type UnstakingThawPeriod = ConstU16<2>;
 	type MaxEpochLength = ConstU64<100>;
 	type EpochNumber = u32;
-	type TokenPerCapacity = TokenPerCapacity;
+	type TokenPerCapacity = ConstU32<10>;
 }
 
 pub fn new_test_ext() -> sp_io::TestExternalities {

--- a/pallets/capacity/src/tests/mock.rs
+++ b/pallets/capacity/src/tests/mock.rs
@@ -9,11 +9,11 @@ use frame_support::{
 	traits::{ConstU16, ConstU32, ConstU64},
 };
 use frame_system::EnsureSigned;
-use sp_core::{ConstU8, H256};
+use sp_core::{crypto::Zeroize, ConstU8, H256};
 use sp_runtime::{
 	testing::Header,
 	traits::{BlakeTwo256, Convert, IdentityLookup},
-	AccountId32, DispatchError,
+	AccountId32, DispatchError, Perbill,
 };
 
 type UncheckedExtrinsic = frame_system::mocking::MockUncheckedExtrinsic<Test>;
@@ -152,12 +152,16 @@ impl pallet_msa::Config for Test {
 	type MaxSignaturesStored = ConstU32<8000>;
 }
 
+parameter_types! {
+	pub const TestCapacityPerToken: Perbill = Perbill::from_percent(10);
+}
 impl pallet_capacity::Config for Test {
 	type RuntimeEvent = RuntimeEvent;
 	type WeightInfo = ();
 	type Currency = pallet_balances::Pallet<Self>;
 	type TargetValidator = Msa;
-	type MinimumStakingAmount = ConstU64<10>; // this has to be >= TokenPerCapacity
+	// In test, this must be >= Token:Capacity ratio since unit is plancks
+	type MinimumStakingAmount = ConstU64<10>;
 	type MinimumTokenBalance = ConstU64<10>;
 	type MaxUnlockingChunks = ConstU32<4>;
 
@@ -167,7 +171,7 @@ impl pallet_capacity::Config for Test {
 	type UnstakingThawPeriod = ConstU16<2>;
 	type MaxEpochLength = ConstU64<100>;
 	type EpochNumber = u32;
-	type TokenPerCapacity = ConstU32<10>;
+	type CapacityPerToken = TestCapacityPerToken;
 }
 
 pub fn new_test_ext() -> sp_io::TestExternalities {

--- a/pallets/capacity/src/tests/other_tests.rs
+++ b/pallets/capacity/src/tests/other_tests.rs
@@ -130,19 +130,54 @@ fn it_configures_staking_minimum_greater_than_or_equal_to_existential_deposit() 
 	});
 }
 
+#[derive(Debug, Default)]
+struct UnstakingTestCase<T: Config> {
+	unstaking: u64,
+	total_staked: u64,
+	total_capacity: u64,
+	expected_reduction: BalanceOf<T>,
+}
+
 #[test]
 fn calculate_capacity_reduction_determines_the_correct_capacity_reduction_amount() {
-	let unstaking_amount = 10;
-	let total_amount_staked = 100;
-	let total_capacity = 200;
-
-	let capacity_reduction = Capacity::calculate_capacity_reduction(
-		unstaking_amount,
-		total_amount_staked,
-		total_capacity,
-	);
-
-	assert_eq!(capacity_reduction, 20);
+	let test_cases: Vec<UnstakingTestCase<Test>> = vec![
+		UnstakingTestCase {
+			unstaking: 10,
+			total_staked: 100,
+			total_capacity: 200,
+			expected_reduction: 20,
+		},
+		UnstakingTestCase {
+			unstaking: 5,
+			total_staked: 300,
+			total_capacity: 30,
+			expected_reduction: 1,
+		},
+		UnstakingTestCase {
+			unstaking: 15,
+			total_staked: 30,
+			total_capacity: 2,
+			expected_reduction: 1,
+		},
+		UnstakingTestCase {
+			unstaking: 99,
+			total_staked: 100,
+			total_capacity: 2001,
+			expected_reduction: 1981,
+		},
+	];
+	for tc in test_cases {
+		let capacity_reduction = Capacity::calculate_capacity_reduction(
+			tc.unstaking,
+			tc.total_staked,
+			tc.total_capacity,
+		);
+		assert_eq!(
+			tc.expected_reduction, capacity_reduction,
+			"In case {:?} expected {:?}, got {:?}",
+			tc, tc.expected_reduction, capacity_reduction
+		);
+	}
 }
 
 #[test]

--- a/pallets/capacity/src/tests/stake_and_deposit_tests.rs
+++ b/pallets/capacity/src/tests/stake_and_deposit_tests.rs
@@ -365,7 +365,7 @@ fn ensure_can_stake_is_successful() {
 #[test]
 fn increase_stake_and_issue_capacity_is_successful() {
 	new_test_ext().execute_with(|| {
-		let staker = 100;
+		let staker = 10_000; // has 10_000 token
 		let target: MessageSourceId = 1;
 		let amount = 550;
 		let mut staking_account = StakingAccountDetails::<Test>::default();

--- a/pallets/capacity/src/tests/stake_and_deposit_tests.rs
+++ b/pallets/capacity/src/tests/stake_and_deposit_tests.rs
@@ -1,5 +1,5 @@
 use super::{mock::*, testing_utils::*};
-use crate::{BalanceOf, Error, Event, StakingAccountDetails};
+use crate::{BalanceOf, CapacityDetails, Error, Event, StakingAccountDetails};
 use common_primitives::{capacity::Nontransferable, msa::MessageSourceId};
 use frame_support::{assert_noop, assert_ok, traits::WithdrawReasons};
 use sp_runtime::ArithmeticError;
@@ -9,24 +9,35 @@ fn stake_works() {
 	new_test_ext().execute_with(|| {
 		let account = 200;
 		let target: MessageSourceId = 1;
-		let amount = 5;
+		let amount = 50;
 		let capacity = 5;
 		register_provider(target, String::from("Foo"));
 		assert_ok!(Capacity::stake(RuntimeOrigin::signed(account), target, amount));
 
 		// Check that StakingAccountLedger is updated.
-		assert_eq!(Capacity::get_staking_account_for(account).unwrap().total, amount);
-		assert_eq!(Capacity::get_staking_account_for(account).unwrap().active, amount);
+		assert_eq!(Capacity::get_staking_account_for(account).unwrap().total, 50);
+		assert_eq!(Capacity::get_staking_account_for(account).unwrap().active, 50);
 		assert_eq!(Capacity::get_staking_account_for(account).unwrap().unlocking.len(), 0);
 
 		// Check that StakingTargetLedger is updated.
-		assert_eq!(Capacity::get_target_for(account, target).unwrap().amount, amount);
-		assert_eq!(Capacity::get_target_for(account, target).unwrap().capacity, amount);
+		assert_eq!(Capacity::get_target_for(account, target).unwrap().amount, 50);
+		assert_eq!(Capacity::get_target_for(account, target).unwrap().capacity, 5);
 
 		// Check that CapacityLedger is updated.
-		assert_eq!(Capacity::get_capacity_for(target).unwrap().remaining_capacity, amount);
-		assert_eq!(Capacity::get_capacity_for(target).unwrap().total_capacity_issued, amount);
-		assert_eq!(Capacity::get_capacity_for(target).unwrap().last_replenished_epoch, 0);
+		let capacity_details = Capacity::get_capacity_for(target).unwrap();
+
+		assert_eq!(
+			CapacityDetails {
+				remaining_capacity: 5,
+				total_tokens_staked: 50,
+				total_capacity_issued: 5,
+				last_replenished_epoch: 0,
+			},
+			capacity_details
+		);
+		// assert_eq!(Capacity::get_capacity_for(target).unwrap().total_capacity_issued, 5);
+		// assert_eq!(Ca)
+		// assert_eq!(Capacity::get_capacity_for(target).unwrap().last_replenished_epoch, 0);
 
 		let events = staking_events();
 		assert_eq!(events.first().unwrap(), &Event::Staked { account, target, amount, capacity });
@@ -81,7 +92,7 @@ fn stake_increase_stake_amount_works() {
 	new_test_ext().execute_with(|| {
 		let account = 300;
 		let target: MessageSourceId = 1;
-		let initial_amount = 5;
+		let initial_amount = 50;
 		let capacity = 5;
 		register_provider(target, String::from("Foo"));
 
@@ -93,7 +104,7 @@ fn stake_increase_stake_amount_works() {
 			&Event::Staked { account, target, amount: initial_amount, capacity }
 		);
 
-		assert_eq!(Balances::locks(&account)[0].amount, 5);
+		assert_eq!(Balances::locks(&account)[0].amount, 50);
 		assert_eq!(Balances::locks(&account)[0].reasons, WithdrawReasons::all().into());
 
 		assert_ok!(Capacity::set_epoch_length(RuntimeOrigin::root(), 10));
@@ -101,18 +112,18 @@ fn stake_increase_stake_amount_works() {
 		// run to epoch 2
 		run_to_block(21);
 
-		let additional_amount = 10;
+		let additional_amount = 100;
 		let capacity = 10;
 		// Additional Stake
 		assert_ok!(Capacity::stake(RuntimeOrigin::signed(account), target, additional_amount));
 
 		// Check that StakingAccountLedger is updated.
-		assert_eq!(Capacity::get_staking_account_for(account).unwrap().total, 15);
-		assert_eq!(Capacity::get_staking_account_for(account).unwrap().active, 15);
+		assert_eq!(Capacity::get_staking_account_for(account).unwrap().total, 150);
+		assert_eq!(Capacity::get_staking_account_for(account).unwrap().active, 150);
 		assert_eq!(Capacity::get_staking_account_for(account).unwrap().unlocking.len(), 0);
 
 		// Check that StakingTargetLedger is updated.
-		assert_eq!(Capacity::get_target_for(account, target).unwrap().amount, 15);
+		assert_eq!(Capacity::get_target_for(account, target).unwrap().amount, 150);
 		assert_eq!(Capacity::get_target_for(account, target).unwrap().capacity, 15);
 
 		// Check that CapacityLedger is updated.
@@ -126,7 +137,7 @@ fn stake_increase_stake_amount_works() {
 			&Event::Staked { account, target, amount: additional_amount, capacity }
 		);
 
-		assert_eq!(Balances::locks(&account)[0].amount, 15);
+		assert_eq!(Balances::locks(&account)[0].amount, 150);
 		assert_eq!(Balances::locks(&account)[0].reasons, WithdrawReasons::all().into());
 	});
 }
@@ -138,17 +149,17 @@ fn stake_multiple_accounts_can_stake_to_the_same_target() {
 			let target: MessageSourceId = 1;
 			register_provider(target, String::from("Foo"));
 			let account_1 = 200;
-			let stake_amount_1 = 5;
+			let stake_amount_1 = 50;
 
 			assert_ok!(Capacity::stake(RuntimeOrigin::signed(account_1), target, stake_amount_1));
 
 			// Check that StakingAccountLedger is updated.
-			assert_eq!(Capacity::get_staking_account_for(account_1).unwrap().total, 5);
-			assert_eq!(Capacity::get_staking_account_for(account_1).unwrap().active, 5);
+			assert_eq!(Capacity::get_staking_account_for(account_1).unwrap().total, 50);
+			assert_eq!(Capacity::get_staking_account_for(account_1).unwrap().active, 50);
 			assert_eq!(Capacity::get_staking_account_for(account_1).unwrap().unlocking.len(), 0);
 
 			// Check that StakingTargetLedger is updated.
-			assert_eq!(Capacity::get_target_for(account_1, target).unwrap().amount, 5);
+			assert_eq!(Capacity::get_target_for(account_1, target).unwrap().amount, 50);
 			assert_eq!(Capacity::get_target_for(account_1, target).unwrap().capacity, 5);
 
 			// Check that CapacityLedger is updated.
@@ -162,17 +173,17 @@ fn stake_multiple_accounts_can_stake_to_the_same_target() {
 			run_to_block(21);
 
 			let account_2 = 300;
-			let stake_amount_2 = 10;
+			let stake_amount_2 = 100;
 
 			assert_ok!(Capacity::stake(RuntimeOrigin::signed(account_2), target, stake_amount_2));
 
 			// Check that StakingAccountLedger is updated.
-			assert_eq!(Capacity::get_staking_account_for(account_2).unwrap().total, 10);
-			assert_eq!(Capacity::get_staking_account_for(account_2).unwrap().active, 10);
+			assert_eq!(Capacity::get_staking_account_for(account_2).unwrap().total, 100);
+			assert_eq!(Capacity::get_staking_account_for(account_2).unwrap().active, 100);
 			assert_eq!(Capacity::get_staking_account_for(account_2).unwrap().unlocking.len(), 0);
 
 			// Check that StakingTargetLedger is updated.
-			assert_eq!(Capacity::get_target_for(account_2, target).unwrap().amount, 10);
+			assert_eq!(Capacity::get_target_for(account_2, target).unwrap().amount, 100);
 			assert_eq!(Capacity::get_target_for(account_2, target).unwrap().capacity, 10);
 
 			// Check that CapacityLedger is updated.
@@ -191,12 +202,12 @@ fn stake_an_account_can_stake_to_multiple_targets() {
 		register_provider(target_1, String::from("Foo"));
 		register_provider(target_2, String::from("Boo"));
 
-		let account = 300;
-		let amount_1 = 10;
-		let amount_2 = 7;
+		let account = 400;
+		let amount_1 = 100;
+		let amount_2 = 200;
 
 		assert_ok!(Capacity::stake(RuntimeOrigin::signed(account), target_1, amount_1));
-		assert_eq!(Capacity::get_staking_account_for(account).unwrap().total, 10);
+		assert_eq!(Capacity::get_staking_account_for(account).unwrap().total, amount_1);
 
 		assert_ok!(Capacity::set_epoch_length(RuntimeOrigin::root(), 10));
 
@@ -205,17 +216,17 @@ fn stake_an_account_can_stake_to_multiple_targets() {
 		assert_ok!(Capacity::stake(RuntimeOrigin::signed(account), target_2, amount_2));
 
 		// Check that StakingAccountLedger is updated.
-		assert_eq!(Capacity::get_staking_account_for(account).unwrap().total, 17);
-		assert_eq!(Capacity::get_staking_account_for(account).unwrap().active, 17);
+		assert_eq!(Capacity::get_staking_account_for(account).unwrap().total, 300);
+		assert_eq!(Capacity::get_staking_account_for(account).unwrap().active, 300);
 		assert_eq!(Capacity::get_staking_account_for(account).unwrap().unlocking.len(), 0);
 
 		// Check that StakingTargetLedger is updated for target 1.
-		assert_eq!(Capacity::get_target_for(account, target_1).unwrap().amount, 10);
+		assert_eq!(Capacity::get_target_for(account, target_1).unwrap().amount, 100);
 		assert_eq!(Capacity::get_target_for(account, target_1).unwrap().capacity, 10);
 
 		// Check that StakingTargetLedger is updated for target 2.
-		assert_eq!(Capacity::get_target_for(account, target_2).unwrap().amount, 7);
-		assert_eq!(Capacity::get_target_for(account, target_2).unwrap().capacity, 7);
+		assert_eq!(Capacity::get_target_for(account, target_2).unwrap().amount, 200);
+		assert_eq!(Capacity::get_target_for(account, target_2).unwrap().capacity, 20);
 
 		// Check that CapacityLedger is updated for target 1.
 		assert_eq!(Capacity::get_capacity_for(target_1).unwrap().remaining_capacity, 10);
@@ -223,8 +234,8 @@ fn stake_an_account_can_stake_to_multiple_targets() {
 		assert_eq!(Capacity::get_capacity_for(target_1).unwrap().last_replenished_epoch, 0);
 
 		// Check that CapacityLedger is updated for target 2.
-		assert_eq!(Capacity::get_capacity_for(target_2).unwrap().remaining_capacity, 7);
-		assert_eq!(Capacity::get_capacity_for(target_2).unwrap().total_capacity_issued, 7);
+		assert_eq!(Capacity::get_capacity_for(target_2).unwrap().remaining_capacity, 20);
+		assert_eq!(Capacity::get_capacity_for(target_2).unwrap().total_capacity_issued, 20);
 		assert_eq!(Capacity::get_capacity_for(target_2).unwrap().last_replenished_epoch, 0);
 	});
 }
@@ -236,22 +247,22 @@ fn stake_when_staking_amount_is_greater_than_free_balance_it_stakes_maximum() {
 		register_provider(target, String::from("Foo"));
 		let account = 200;
 		// An amount greater than the free balance
-		let amount = 23;
+		let amount = 230;
 
 		assert_ok!(Capacity::stake(RuntimeOrigin::signed(account), target, amount));
 
 		// Check that StakingAccountLedger is updated.
-		assert_eq!(Capacity::get_staking_account_for(account).unwrap().total, 10);
-		assert_eq!(Capacity::get_staking_account_for(account).unwrap().active, 10);
+		assert_eq!(Capacity::get_staking_account_for(account).unwrap().total, 190);
+		assert_eq!(Capacity::get_staking_account_for(account).unwrap().active, 190);
 		assert_eq!(Capacity::get_staking_account_for(account).unwrap().unlocking.len(), 0);
 
 		// Check that StakingTargetLedger is updated.
-		assert_eq!(Capacity::get_target_for(account, target).unwrap().amount, 10);
-		assert_eq!(Capacity::get_target_for(account, target).unwrap().capacity, 10);
+		assert_eq!(Capacity::get_target_for(account, target).unwrap().amount, 190);
+		assert_eq!(Capacity::get_target_for(account, target).unwrap().capacity, 19);
 
 		// Check that CapacityLedger is updated.
-		assert_eq!(Capacity::get_capacity_for(target).unwrap().remaining_capacity, 10);
-		assert_eq!(Capacity::get_capacity_for(target).unwrap().total_capacity_issued, 10);
+		assert_eq!(Capacity::get_capacity_for(target).unwrap().remaining_capacity, 19);
+		assert_eq!(Capacity::get_capacity_for(target).unwrap().total_capacity_issued, 19);
 		assert_eq!(Capacity::get_capacity_for(target).unwrap().last_replenished_epoch, 0);
 	});
 }
@@ -261,9 +272,9 @@ fn stake_when_staking_amount_is_less_than_min_token_balance_it_errors() {
 	new_test_ext().execute_with(|| {
 		let target: MessageSourceId = 1;
 		register_provider(target, String::from("Foo"));
-		let account = 100;
+		let account = 50;
 		// An amount that leaves less than the minimum token balance
-		let amount = 6;
+		let amount = 4;
 
 		assert_noop!(
 			Capacity::stake(RuntimeOrigin::signed(account), target, amount),
@@ -359,7 +370,7 @@ fn increase_stake_and_issue_capacity_is_successful() {
 	new_test_ext().execute_with(|| {
 		let staker = 100;
 		let target: MessageSourceId = 1;
-		let amount = 55;
+		let amount = 550;
 		let mut staking_account = StakingAccountDetails::<Test>::default();
 
 		assert_ok!(Capacity::increase_stake_and_issue_capacity(
@@ -369,8 +380,8 @@ fn increase_stake_and_issue_capacity_is_successful() {
 			amount
 		));
 
-		assert_eq!(staking_account.total, 55);
-		assert_eq!(staking_account.active, 55);
+		assert_eq!(staking_account.total, amount);
+		assert_eq!(staking_account.active, amount);
 		assert_eq!(staking_account.unlocking.len(), 0);
 
 		let capacity_details = Capacity::get_capacity_for(&target).unwrap();
@@ -381,7 +392,7 @@ fn increase_stake_and_issue_capacity_is_successful() {
 
 		let target_details = Capacity::get_target_for(&staker, &target).unwrap();
 
-		assert_eq!(target_details.amount, 55);
+		assert_eq!(target_details.amount, amount);
 		assert_eq!(target_details.capacity, 55);
 	});
 }

--- a/pallets/capacity/src/tests/stake_and_deposit_tests.rs
+++ b/pallets/capacity/src/tests/stake_and_deposit_tests.rs
@@ -35,9 +35,6 @@ fn stake_works() {
 			},
 			capacity_details
 		);
-		// assert_eq!(Capacity::get_capacity_for(target).unwrap().total_capacity_issued, 5);
-		// assert_eq!(Ca)
-		// assert_eq!(Capacity::get_capacity_for(target).unwrap().last_replenished_epoch, 0);
 
 		let events = staking_events();
 		assert_eq!(events.first().unwrap(), &Event::Staked { account, target, amount, capacity });

--- a/pallets/capacity/src/tests/staking_account_details_tests.rs
+++ b/pallets/capacity/src/tests/staking_account_details_tests.rs
@@ -11,8 +11,8 @@ type UnlockBVec<T> = BoundedVec<
 #[test]
 fn staking_account_details_withdraw_reduces_active_staking_balance_and_creates_unlock_chunk() {
 	let mut staking_account_details = StakingAccountDetails::<Test> {
-		active: BalanceOf::<Test>::from(10u64),
-		total: BalanceOf::<Test>::from(10u64),
+		active: BalanceOf::<Test>::from(15u64),
+		total: BalanceOf::<Test>::from(15u64),
 		unlocking: BoundedVec::default(),
 	};
 	assert_eq!(Ok(3u64), staking_account_details.withdraw(3, 3));
@@ -22,8 +22,8 @@ fn staking_account_details_withdraw_reduces_active_staking_balance_and_creates_u
 	assert_eq!(
 		staking_account_details,
 		StakingAccountDetails::<Test> {
-			active: BalanceOf::<Test>::from(7u64),
-			total: BalanceOf::<Test>::from(10u64),
+			active: BalanceOf::<Test>::from(12u64),
+			total: BalanceOf::<Test>::from(15u64),
 			unlocking: expected_chunks,
 		}
 	)
@@ -126,6 +126,6 @@ fn impl_staking_account_details_get_stakable_amount_for() {
 		assert_eq!(staking_account.get_stakable_amount_for(&account, 5), 5);
 
 		// When staking an amount above account free balance. It stakes all of the free balance.
-		assert_eq!(staking_account.get_stakable_amount_for(&account, 25), 10);
+		assert_eq!(staking_account.get_stakable_amount_for(&account, 200), 190);
 	});
 }

--- a/pallets/capacity/src/tests/unstaking_tests.rs
+++ b/pallets/capacity/src/tests/unstaking_tests.rs
@@ -11,8 +11,8 @@ fn unstake_happy_path() {
 	new_test_ext().execute_with(|| {
 		let token_account = 200;
 		let target: MessageSourceId = 1;
-		let staking_amount = 100; // 10 capacity
-		let unstaking_amount = 40; // 4 capacity
+		let staking_amount = 100;
+		let unstaking_amount = 40;
 
 		register_provider(target, String::from("Test Target"));
 

--- a/pallets/capacity/src/tests/unstaking_tests.rs
+++ b/pallets/capacity/src/tests/unstaking_tests.rs
@@ -103,7 +103,7 @@ fn unstake_errors_max_unlocking_chunks_exceeded() {
 		let token_account = 200;
 		let target: MessageSourceId = 1;
 		let staking_amount = 60;
-		let unstaking_amount = 10; // TODO: we need to figure out how to deal with fractional capacity.
+		let unstaking_amount = 10;
 
 		register_provider(target, String::from("Test Target"));
 

--- a/pallets/capacity/src/tests/unstaking_tests.rs
+++ b/pallets/capacity/src/tests/unstaking_tests.rs
@@ -11,8 +11,8 @@ fn unstake_happy_path() {
 	new_test_ext().execute_with(|| {
 		let token_account = 200;
 		let target: MessageSourceId = 1;
-		let staking_amount = 10;
-		let unstaking_amount = 4;
+		let staking_amount = 100; // 10 capacity
+		let unstaking_amount = 40; // 4 capacity
 
 		register_provider(target, String::from("Test Target"));
 
@@ -35,7 +35,7 @@ fn unstake_happy_path() {
 
 		assert_eq!(
 			StakingAccountDetails::<Test> {
-				active: BalanceOf::<Test>::from(6u64),
+				active: BalanceOf::<Test>::from(60u64),
 				total: BalanceOf::<Test>::from(staking_amount),
 				unlocking: expected_unlocking_chunks,
 			},
@@ -48,7 +48,7 @@ fn unstake_happy_path() {
 		assert_eq!(
 			staking_target_details,
 			StakingTargetDetails::<BalanceOf<Test>> {
-				amount: BalanceOf::<Test>::from(6u64),
+				amount: BalanceOf::<Test>::from(60u64),
 				capacity: BalanceOf::<Test>::from(6u64),
 			}
 		);
@@ -60,7 +60,7 @@ fn unstake_happy_path() {
 			capacity_details,
 			CapacityDetails::<BalanceOf<Test>, <Test as Config>::EpochNumber> {
 				remaining_capacity: BalanceOf::<Test>::from(6u64),
-				total_tokens_staked: BalanceOf::<Test>::from(6u64),
+				total_tokens_staked: BalanceOf::<Test>::from(60u64),
 				total_capacity_issued: BalanceOf::<Test>::from(6u64),
 				last_replenished_epoch: <Test as Config>::EpochNumber::from(0u32),
 			}
@@ -102,8 +102,8 @@ fn unstake_errors_max_unlocking_chunks_exceeded() {
 	new_test_ext().execute_with(|| {
 		let token_account = 200;
 		let target: MessageSourceId = 1;
-		let staking_amount = 10;
-		let unstaking_amount = 1;
+		let staking_amount = 60;
+		let unstaking_amount = 10; // TODO: we need to figure out how to deal with fractional capacity.
 
 		register_provider(target, String::from("Test Target"));
 

--- a/pallets/capacity/src/types.rs
+++ b/pallets/capacity/src/types.rs
@@ -173,10 +173,10 @@ where
 {
 	/// Increase a targets total Tokens staked and Capacity total issuance by an amount.
 	/// To be called on a stake
-	pub fn deposit(&mut self, amount: &Balance) -> Option<()> {
-		self.remaining_capacity = amount.checked_add(&self.remaining_capacity)?;
+	pub fn deposit(&mut self, amount: &Balance, capacity: &Balance) -> Option<()> {
 		self.total_tokens_staked = amount.checked_add(&self.total_tokens_staked)?;
-		self.total_capacity_issued = amount.checked_add(&self.total_capacity_issued)?;
+		self.remaining_capacity = capacity.checked_add(&self.remaining_capacity)?;
+		self.total_capacity_issued = capacity.checked_add(&self.total_capacity_issued)?;
 
 		// We do not touch last_replenished epoch here, because it would create a DoS vulnerability.
 		// Since capacity is lazily replenished, an attacker could stake

--- a/pallets/frequency-tx-payment/src/mock.rs
+++ b/pallets/frequency-tx-payment/src/mock.rs
@@ -14,6 +14,7 @@ use sp_runtime::{
 	traits::{BlakeTwo256, Convert, IdentityLookup, SaturatedConversion},
 	AccountId32,
 };
+use sp_std::ops::Div;
 
 use frame_support::{
 	parameter_types,
@@ -210,12 +211,14 @@ impl pallet_transaction_payment::Config for Test {
 	type OperationalFeeMultiplier = ConstU8<5>;
 }
 
+pub const TEST_TOKEN_PER_CAPACITY: u32 = 10;
+
 impl pallet_capacity::Config for Test {
 	type RuntimeEvent = RuntimeEvent;
 	type WeightInfo = ();
 	type Currency = pallet_balances::Pallet<Self>;
 	type TargetValidator = ();
-	type MinimumStakingAmount = ConstU64<5>;
+	type MinimumStakingAmount = ConstU64<10>; // this has to be >= TokenPerCapacity
 	type MinimumTokenBalance = ConstU64<10>;
 	type MaxUnlockingChunks = ConstU32<4>;
 
@@ -225,6 +228,7 @@ impl pallet_capacity::Config for Test {
 	type UnstakingThawPeriod = ConstU16<2>;
 	type MaxEpochLength = ConstU64<100>;
 	type EpochNumber = u32;
+	type TokenPerCapacity = ConstU32<TEST_TOKEN_PER_CAPACITY>;
 }
 
 use pallet_balances::Call as BalancesCall;
@@ -330,12 +334,12 @@ impl ExtBuilder {
 				<Test as frame_system::Config>::AccountId,
 				<Test as pallet_balances::Config>::Balance,
 			)> = vec![
-				(1, 10 * self.balance_factor),
-				(2, 20 * self.balance_factor),
-				(3, 30 * self.balance_factor),
-				(4, 40 * self.balance_factor),
-				(5, 50 * self.balance_factor),
-				(6, 60 * self.balance_factor),
+				(1, 100 * self.balance_factor),
+				(2, 200 * self.balance_factor),
+				(3, 300 * self.balance_factor),
+				(4, 400 * self.balance_factor),
+				(5, 500 * self.balance_factor),
+				(6, 600 * self.balance_factor),
 			];
 			msa_accounts.iter().for_each(|(account, balance)| {
 				let msa_id = create_msa_account(account.clone());
@@ -358,6 +362,7 @@ pub fn create_msa_account(
 
 fn create_capacity_for(target: MessageSourceId, amount: u64) {
 	let mut capacity_details = Capacity::get_capacity_for(target).unwrap_or_default();
-	capacity_details.deposit(&amount).unwrap();
+	let capacity: u64 = amount / (TEST_TOKEN_PER_CAPACITY as u64);
+	capacity_details.deposit(&amount, &capacity).unwrap();
 	Capacity::set_capacity_for(target, capacity_details);
 }

--- a/pallets/frequency-tx-payment/src/mock.rs
+++ b/pallets/frequency-tx-payment/src/mock.rs
@@ -12,7 +12,7 @@ use sp_core::{ConstU8, H256};
 use sp_runtime::{
 	testing::Header,
 	traits::{BlakeTwo256, Convert, IdentityLookup, SaturatedConversion},
-	AccountId32,
+	AccountId32, Perbill,
 };
 use sp_std::ops::Div;
 
@@ -213,12 +213,17 @@ impl pallet_transaction_payment::Config for Test {
 
 pub const TEST_TOKEN_PER_CAPACITY: u32 = 10;
 
+parameter_types! {
+	pub const TestCapacityPerToken: Perbill = Perbill::from_percent(10);
+}
+
 impl pallet_capacity::Config for Test {
 	type RuntimeEvent = RuntimeEvent;
 	type WeightInfo = ();
 	type Currency = pallet_balances::Pallet<Self>;
 	type TargetValidator = ();
-	type MinimumStakingAmount = ConstU64<10>; // this has to be >= TokenPerCapacity
+	// In test, this must be >= Token:Capacity ratio since unit is plancks
+	type MinimumStakingAmount = ConstU64<10>;
 	type MinimumTokenBalance = ConstU64<10>;
 	type MaxUnlockingChunks = ConstU32<4>;
 
@@ -228,7 +233,7 @@ impl pallet_capacity::Config for Test {
 	type UnstakingThawPeriod = ConstU16<2>;
 	type MaxEpochLength = ConstU64<100>;
 	type EpochNumber = u32;
-	type TokenPerCapacity = ConstU32<TEST_TOKEN_PER_CAPACITY>;
+	type CapacityPerToken = TestCapacityPerToken;
 }
 
 use pallet_balances::Call as BalancesCall;

--- a/pallets/frequency-tx-payment/src/mock.rs
+++ b/pallets/frequency-tx-payment/src/mock.rs
@@ -211,10 +211,11 @@ impl pallet_transaction_payment::Config for Test {
 	type OperationalFeeMultiplier = ConstU8<5>;
 }
 
+// so the value can be used by create_capacity_for below, without having to pass it a Config.
 pub const TEST_TOKEN_PER_CAPACITY: u32 = 10;
 
 parameter_types! {
-	pub const TestCapacityPerToken: Perbill = Perbill::from_percent(10);
+	pub const TestCapacityPerToken: Perbill = Perbill::from_percent(TEST_TOKEN_PER_CAPACITY);
 }
 
 impl pallet_capacity::Config for Test {

--- a/pallets/frequency-tx-payment/src/tests.rs
+++ b/pallets/frequency-tx-payment/src/tests.rs
@@ -264,7 +264,7 @@ fn pay_with_capacity_returns_weight_of_child_call() {
 }
 
 #[test]
-fn charge_frq_transaction_payment_withdraw_fee_for_capacity_batch_tx_returns_tupple_with_fee_and_enum(
+fn charge_frq_transaction_payment_withdraw_fee_for_capacity_batch_tx_returns_tuple_with_fee_and_enum(
 ) {
 	let balance_factor = 10;
 
@@ -289,7 +289,9 @@ fn charge_frq_transaction_payment_withdraw_fee_for_capacity_batch_tx_returns_tup
 			// fee = base_weight(5)
 			//   + extrinsic_weight(11) * WeightToFee(1)
 			//   + TransactionByteFee(1)* len(10) = 26
-			assert_eq!(charge_tx_payment.withdraw_fee(&who, call, &info, len).unwrap().0, 26u64);
+			let res = charge_tx_payment.withdraw_fee(&who, call, &info, len);
+			assert_ok!(&res);
+			assert_eq!(res.unwrap().0, 26u64);
 			assert_eq!(
 				charge_tx_payment.withdraw_fee(&who, call, &info, len).unwrap().1.is_capacity(),
 				true

--- a/runtime/common/src/constants.rs
+++ b/runtime/common/src/constants.rs
@@ -374,6 +374,7 @@ impl sp_std::fmt::Debug for MaxItemizedBlobSizeBytes {
 pub type CapacityMinimumStakingAmount = ConstU128<{ currency::EXISTENTIAL_DEPOSIT }>;
 pub type CapacityMinimumTokenBalance = ConstU128<{ currency::DOLLARS }>;
 pub type CapacityMaxUnlockingChunks = ConstU32<4>;
-pub type CapacityMaxEpochLength = ConstU32<7_200>;
-pub type CapacityUnstakingThawPeriod = ConstU16<2>;
+pub type CapacityMaxEpochLength = ConstU32<7_200>; // one day, assuming 12 second blocks.
+pub type CapacityUnstakingThawPeriod = ConstU16<30>; // 30 Epochs, or 30 days given the above
+pub type TokenPerCapacity = ConstU32<100>;
 // -end- Capacity Pallet ---

--- a/runtime/common/src/constants.rs
+++ b/runtime/common/src/constants.rs
@@ -375,6 +375,17 @@ pub type CapacityMinimumStakingAmount = ConstU128<{ currency::EXISTENTIAL_DEPOSI
 pub type CapacityMinimumTokenBalance = ConstU128<{ currency::DOLLARS }>;
 pub type CapacityMaxUnlockingChunks = ConstU32<4>;
 pub type CapacityMaxEpochLength = ConstU32<7_200>; // one day, assuming 12 second blocks.
+
+#[cfg(not(feature = "frequency-rococo-local"))]
 pub type CapacityUnstakingThawPeriod = ConstU16<30>; // 30 Epochs, or 30 days given the above
-pub type TokenPerCapacity = ConstU32<100>;
+
+#[cfg(feature = "frequency-rococo-local")]
+pub type CapacityUnstakingThawPeriod = ConstU16<2>; // 2 Epochs
+
+parameter_types! {
+	// 1:50 Capacity:Token, must be declared this way instead of using `from_rational` because of
+	//  ```error[E0015]: cannot call non-const fn `Perbill::from_rational::<u32>` in constant functions```
+	pub const CapacityPerToken: Perbill = Perbill::from_percent(2);
+}
+
 // -end- Capacity Pallet ---

--- a/runtime/frequency/src/lib.rs
+++ b/runtime/frequency/src/lib.rs
@@ -555,10 +555,6 @@ impl pallet_msa::Config for Runtime {
 	>;
 }
 
-parameter_types! {
-	pub const CapacityPerToken: Perbill = Perbill::from_percent(1);
-}
-
 impl pallet_capacity::Config for Runtime {
 	type RuntimeEvent = RuntimeEvent;
 	type WeightInfo = pallet_capacity::weights::SubstrateWeight<Runtime>;

--- a/runtime/frequency/src/lib.rs
+++ b/runtime/frequency/src/lib.rs
@@ -429,7 +429,7 @@ pub const VERSION: RuntimeVersion = RuntimeVersion {
 	spec_name: spec_name!("frequency"),
 	impl_name: create_runtime_str!("frequency"),
 	authoring_version: 1,
-	spec_version: 27,
+	spec_version: 28,
 	impl_version: 0,
 	apis: RUNTIME_API_VERSIONS,
 	transaction_version: 1,

--- a/runtime/frequency/src/lib.rs
+++ b/runtime/frequency/src/lib.rs
@@ -568,6 +568,7 @@ impl pallet_capacity::Config for Runtime {
 	type UnstakingThawPeriod = CapacityUnstakingThawPeriod;
 	type MaxEpochLength = CapacityMaxEpochLength;
 	type EpochNumber = u32;
+	type TokenPerCapacity = TokenPerCapacity;
 }
 
 impl pallet_schemas::Config for Runtime {

--- a/runtime/frequency/src/lib.rs
+++ b/runtime/frequency/src/lib.rs
@@ -555,6 +555,10 @@ impl pallet_msa::Config for Runtime {
 	>;
 }
 
+parameter_types! {
+	pub const CapacityPerToken: Perbill = Perbill::from_percent(1);
+}
+
 impl pallet_capacity::Config for Runtime {
 	type RuntimeEvent = RuntimeEvent;
 	type WeightInfo = pallet_capacity::weights::SubstrateWeight<Runtime>;
@@ -568,7 +572,7 @@ impl pallet_capacity::Config for Runtime {
 	type UnstakingThawPeriod = CapacityUnstakingThawPeriod;
 	type MaxEpochLength = CapacityMaxEpochLength;
 	type EpochNumber = u32;
-	type TokenPerCapacity = TokenPerCapacity;
+	type CapacityPerToken = CapacityPerToken;
 }
 
 impl pallet_schemas::Config for Runtime {


### PR DESCRIPTION
# Goal
The goal of this PR is to set the token:capacity ratio to what we want, and increase the thaw period to 30 days (30*7200 twelve-second blocks)

Additionally fixes a couple of bugs that were uncovered in capacity accounting.

Closes: #1300

# Checklist
- [x] Tests updated
- [x] Bugs fixed
- [x] Address PR comments
- [x] Final FRQCY:Capacity ratio for Frequency/Rococo.
- [x] Bump spec_version
