### PR TITLE
[User Handles] Strip combining marks when claiming a handle

### DIFF
--- a/pallets/handles/src/handles-utils/src/converter.rs
+++ b/pallets/handles/src/handles-utils/src/converter.rs
@@ -19,8 +19,8 @@ include!(concat!(env!("OUT_DIR"), "/confusables.rs"));
 pub const HANDLE_DELIMITER: char = '.';
 
 /// Creates a new `HandleConverter` instance with a built confusables map.
-/// Converts a given string to its canonical form by stripping Unicode whitespace,
-/// replacing confusable characters, and stripping diacritical marks.
+/// Converts a given string to its canonical form by stripping Unicode
+/// whitespace and replacing confusable characters.
 /// The resulting string is converted to lowercase ASCII characters.
 ///
 /// # Arguments
@@ -34,8 +34,7 @@ pub const HANDLE_DELIMITER: char = '.';
 pub fn convert_to_canonical(input_str: &str) -> alloc::string::String {
 	let white_space_stripped = strip_unicode_whitespace(input_str);
 	let confusables_removed = replace_confusables(&white_space_stripped);
-	let diacriticals_stripped = strip_diacriticals(&confusables_removed);
-	diacriticals_stripped.to_ascii_lowercase()
+	confusables_removed.to_ascii_lowercase()
 }
 
 /// Replaces any characters in the input string that are confusable with a different character.

--- a/pallets/handles/src/handles-utils/src/converter.rs
+++ b/pallets/handles/src/handles-utils/src/converter.rs
@@ -19,8 +19,8 @@ include!(concat!(env!("OUT_DIR"), "/confusables.rs"));
 pub const HANDLE_DELIMITER: char = '.';
 
 /// Creates a new `HandleConverter` instance with a built confusables map.
-/// Converts a given string to its canonical form by stripping Unicode
-/// whitespace and replacing confusable characters.
+/// Converts a given string to its canonical form by stripping Unicode whitespace,
+/// replacing confusable characters, and stripping diacritical marks.
 /// The resulting string is converted to lowercase ASCII characters.
 ///
 /// # Arguments
@@ -33,7 +33,8 @@ pub const HANDLE_DELIMITER: char = '.';
 ///
 pub fn convert_to_canonical(input_str: &str) -> alloc::string::String {
 	let white_space_stripped = strip_unicode_whitespace(input_str);
-	let confusables_removed = replace_confusables(&white_space_stripped);
+	let diacriticals_stripped = strip_diacriticals(&white_space_stripped);
+	let confusables_removed = replace_confusables(&diacriticals_stripped);
 	confusables_removed.to_ascii_lowercase()
 }
 

--- a/pallets/handles/src/handles-utils/src/tests/converter_tests.rs
+++ b/pallets/handles/src/handles-utils/src/tests/converter_tests.rs
@@ -106,6 +106,7 @@ fn test_convert_to_canonical_combining_marks_reduce_to_the_same_canonical_form()
 	let canonical_with_combining_mark = convert_to_canonical(&handle_with_combining_mark);
 	let canonical_without_combining_mark = convert_to_canonical(&handle_without_combining_mark);
 	assert_eq!(canonical_with_combining_mark, canonical_without_combining_mark);
+	assert_eq!(canonical_with_combining_mark, "avar0");
 }
 
 #[test]

--- a/pallets/handles/src/handles-utils/src/tests/converter_tests.rs
+++ b/pallets/handles/src/handles-utils/src/tests/converter_tests.rs
@@ -1,6 +1,6 @@
-use crate::converter::{
+use crate::{converter::{
 	replace_confusables, split_display_name, strip_diacriticals, strip_unicode_whitespace,
-};
+}, convert_to_canonical};
 
 use crate::validator::consists_of_supported_unicode_character_sets;
 
@@ -82,6 +82,27 @@ fn test_strip_unicode_whitespace() {
 	let whitespace_stripped_string = strip_unicode_whitespace(&string_with_whitespace);
 	println!("Whitespace stripped string: {}", whitespace_stripped_string);
 	assert_eq!(whitespace_stripped_string, "helloworld!");
+}
+
+#[test]
+fn test_convert_to_canonical_combining_marks_reduce_to_the_same_canonical_form() {
+	// Construct a handle "Álvaro" where the first character consists of
+	// a base character and a combining mark for an accute accent
+	let mut handle_with_combining_mark = String::new();
+	handle_with_combining_mark.push('\u{0041}');
+	handle_with_combining_mark.push('\u{0301}');
+	handle_with_combining_mark.push_str("varo");
+
+	// Construct the handle "Álvaro" where the first character consists
+	// of the Latin-1 Supplement character 0x00C1, which contains both
+	// the base character `A` and the accute diacritical in one character
+	let mut handle_without_combining_mark = String::new();
+	handle_without_combining_mark.push('\u{00C1}');
+	handle_without_combining_mark.push_str("varo");
+
+	let canonical_with_combining_mark = convert_to_canonical(&handle_with_combining_mark);
+	let canonical_without_combining_mark = convert_to_canonical(&handle_without_combining_mark);
+	assert_eq!(canonical_with_combining_mark, canonical_without_combining_mark);
 }
 
 #[test]

--- a/pallets/handles/src/handles-utils/src/tests/converter_tests.rs
+++ b/pallets/handles/src/handles-utils/src/tests/converter_tests.rs
@@ -1,6 +1,9 @@
-use crate::{converter::{
-	replace_confusables, split_display_name, strip_diacriticals, strip_unicode_whitespace,
-}, convert_to_canonical};
+use crate::{
+	convert_to_canonical,
+	converter::{
+		replace_confusables, split_display_name, strip_diacriticals, strip_unicode_whitespace,
+	},
+};
 
 use crate::validator::consists_of_supported_unicode_character_sets;
 

--- a/pallets/handles/src/handles-utils/src/tests/validator_tests.rs
+++ b/pallets/handles/src/handles-utils/src/tests/validator_tests.rs
@@ -1,9 +1,5 @@
-use crate::{
-	confusables::CONFUSABLES,
-	validator::{
-		consists_of_supported_unicode_character_sets, contains_blocked_characters,
-		is_reserved_handle,
-	},
+use crate::validator::{
+	consists_of_supported_unicode_character_sets, contains_blocked_characters, is_reserved_handle,
 };
 
 #[test]
@@ -74,6 +70,10 @@ fn test_consists_of_supported_unicode_character_sets_rejects_emojis() {
 
 	assert!(!consists_of_supported_unicode_character_sets(&string_containing_emojis));
 }
+
+// Will load `CONFUSABLES` with all the confusables at build time.
+// See build.rs
+include!(concat!(env!("OUT_DIR"), "/confusables.rs"));
 
 #[test]
 fn test_confusables_map_does_not_contain_keys_in_unsupported_character_sets() {

--- a/pallets/handles/src/handles-utils/src/tests/validator_tests.rs
+++ b/pallets/handles/src/handles-utils/src/tests/validator_tests.rs
@@ -74,7 +74,7 @@ fn test_consists_of_supported_unicode_character_sets_rejects_emojis() {
 #[test]
 fn test_confusables_map_does_not_contain_keys_in_unsupported_character_sets() {
 	for key in CONFUSABLES.keys() {
-		//TODO: Remove this println! when the test is passings
+		//TODO: Remove this println! when the test is passing
 		println!("codepoint: {:x}", *key as u32);
 		assert!(consists_of_supported_unicode_character_sets(&key.to_string()));
 	}

--- a/pallets/handles/src/handles-utils/src/tests/validator_tests.rs
+++ b/pallets/handles/src/handles-utils/src/tests/validator_tests.rs
@@ -1,6 +1,10 @@
-use crate::{confusables::CONFUSABLES, validator::{
-	consists_of_supported_unicode_character_sets, contains_blocked_characters, is_reserved_handle,
-}};
+use crate::{
+	confusables::CONFUSABLES,
+	validator::{
+		consists_of_supported_unicode_character_sets, contains_blocked_characters,
+		is_reserved_handle,
+	},
+};
 
 #[test]
 fn test_is_reserved_handle_happy_path() {

--- a/pallets/handles/src/handles-utils/src/tests/validator_tests.rs
+++ b/pallets/handles/src/handles-utils/src/tests/validator_tests.rs
@@ -78,8 +78,6 @@ include!(concat!(env!("OUT_DIR"), "/confusables.rs"));
 #[test]
 fn test_confusables_map_does_not_contain_keys_in_unsupported_character_sets() {
 	for key in CONFUSABLES.keys() {
-		//TODO: Remove this println! when the test is passing
-		println!("codepoint: {:x}", *key as u32);
 		assert!(consists_of_supported_unicode_character_sets(&key.to_string()));
 	}
 }

--- a/pallets/handles/src/handles-utils/src/tests/validator_tests.rs
+++ b/pallets/handles/src/handles-utils/src/tests/validator_tests.rs
@@ -1,6 +1,6 @@
-use crate::validator::{
+use crate::{confusables::CONFUSABLES, validator::{
 	consists_of_supported_unicode_character_sets, contains_blocked_characters, is_reserved_handle,
-};
+}};
 
 #[test]
 fn test_is_reserved_handle_happy_path() {
@@ -69,4 +69,13 @@ fn test_consists_of_supported_unicode_character_sets_rejects_emojis() {
 	let string_containing_emojis = format_args!("John{}", '\u{1F600}').to_string();
 
 	assert!(!consists_of_supported_unicode_character_sets(&string_containing_emojis));
+}
+
+#[test]
+fn test_confusables_map_does_not_contain_keys_in_unsupported_character_sets() {
+	for key in CONFUSABLES.keys() {
+		//TODO: Remove this println! when the test is passings
+		println!("codepoint: {:x}", *key as u32);
+		assert!(consists_of_supported_unicode_character_sets(&key.to_string()));
+	}
 }

--- a/pallets/handles/src/lib.rs
+++ b/pallets/handles/src/lib.rs
@@ -42,7 +42,7 @@ use alloc::{string::String, vec};
 mod benchmarking;
 
 use handles_utils::{
-	converter::{convert_to_canonical, split_display_name, strip_diacriticals, HANDLE_DELIMITER},
+	converter::{convert_to_canonical, split_display_name, HANDLE_DELIMITER},
 	suffix::generate_unique_suffixes,
 	validator::{
 		consists_of_supported_unicode_character_sets, contains_blocked_characters,
@@ -565,17 +565,13 @@ pub mod pallet {
 			);
 
 			let base_handle_str = Self::validate_base_handle(payload.base_handle)?;
-
-			// Strip diacritical marks from the validated handle
-			let diacritical_stripped_base_handle_str = strip_diacriticals(&base_handle_str);
-
-			Self::validate_base_handle_contains_characters_in_supported_ranges(
-				&diacritical_stripped_base_handle_str,
-			)?;
-
 			// Convert base handle into a canonical base
 			let (canonical_handle_str, canonical_base) =
 				Self::get_canonical_string_vec_from_base_handle(&base_handle_str);
+
+			Self::validate_canonical_handle_contains_characters_in_supported_ranges(
+				&canonical_handle_str,
+			)?;
 
 			// Generate suffix from the next available index into the suffix sequence
 			let suffix_sequence_index =
@@ -630,7 +626,7 @@ pub mod pallet {
 			Ok(base_handle_str)
 		}
 
-		fn validate_base_handle_contains_characters_in_supported_ranges(
+		fn validate_canonical_handle_contains_characters_in_supported_ranges(
 			base_handle_str: &str,
 		) -> DispatchResult {
 			// Validation: The handle must consist of characters not containing reserved words or blocked characters

--- a/pallets/handles/src/lib.rs
+++ b/pallets/handles/src/lib.rs
@@ -565,6 +565,7 @@ pub mod pallet {
 			);
 
 			let base_handle_str = Self::validate_base_handle(payload.base_handle)?;
+
 			// Convert base handle into a canonical base
 			let (canonical_handle_str, canonical_base) =
 				Self::get_canonical_string_vec_from_base_handle(&base_handle_str);

--- a/pallets/handles/src/tests/handle_creation_tests.rs
+++ b/pallets/handles/src/tests/handle_creation_tests.rs
@@ -243,3 +243,58 @@ fn test_get_next_suffixes() {
 		assert_eq!(presumptive_suffixes.len(), 5);
 	});
 }
+
+#[test]
+fn claim_handle_supports_stripping_diacriticals_from_utf8_with_combining_marks() {
+	new_test_ext().execute_with(|| {
+		let alice = sr25519::Pair::from_seed(&[0; 32]);
+		let expiration = 100;
+
+		// Construct a handle "Álvaro" where the first character consists of
+		// a base character and a combining mark for an accute accent
+		let mut handle_with_combining_mark = String::new();
+		handle_with_combining_mark.push('\u{0041}');
+		handle_with_combining_mark.push('\u{0301}');
+		handle_with_combining_mark.push_str("varo");
+
+		let (payload, proof) = get_signed_claims_payload(
+			&alice,
+			handle_with_combining_mark.as_bytes().to_vec(),
+			expiration,
+		);
+		assert_ok!(Handles::claim_handle(
+			RuntimeOrigin::signed(alice.public().into()),
+			alice.public().into(),
+			proof,
+			payload.clone()
+		));
+
+		// Construct the handle "Álvaro" where the first character consists
+		// of the Latin-1 Supplement character 0x00C1, which contains both
+		// the base character `A` and the accute diacritical in one character
+		let mut handle_without_combining_mark = String::new();
+		handle_without_combining_mark.push('\u{00C1}');
+		handle_without_combining_mark.push_str("varo");
+
+		let (payload, proof) = get_signed_claims_payload(
+			&alice,
+			handle_with_combining_mark.as_bytes().to_vec(),
+			expiration,
+		);
+
+		// Assert that both forms of "Álvaro" pass validation and reduce
+		// to the same cannonical form as witnessed by the single unicode
+		// character form of the handle triggering `MSAHandleAlreadyExists`
+		// when the combined mark containing version has already successfully
+		// been used for handle creation
+		assert_noop!(
+			Handles::claim_handle(
+				RuntimeOrigin::signed(alice.public().into()),
+				alice.public().into(),
+				proof,
+				payload.clone()
+			),
+			Error::<Test>::MSAHandleAlreadyExists
+		);
+	});
+}

--- a/pallets/handles/src/tests/handle_creation_tests.rs
+++ b/pallets/handles/src/tests/handle_creation_tests.rs
@@ -268,25 +268,20 @@ fn claim_handle_supports_stripping_diacriticals_from_utf8_with_combining_marks()
 			proof,
 			payload.clone()
 		));
+	});
+}
 
-		// Construct the handle "Álvaro" where the first character consists
-		// of the Latin-1 Supplement character 0x00C1, which contains both
-		// the base character `A` and the accute diacritical in one character
-		let mut handle_without_combining_mark = String::new();
-		handle_without_combining_mark.push('\u{00C1}');
-		handle_without_combining_mark.push_str("varo");
-
+#[test]
+fn claim_handle_fails_when_handle_contains_unsupported_unicode_characters() {
+	new_test_ext().execute_with(|| {
+		let alice = sr25519::Pair::from_seed(&[0; 32]);
+		let expiration = 100;
+		let handle_with_unsupported_unicode_characters = "𓅓𓅱𓅱𓆑𓆷";
 		let (payload, proof) = get_signed_claims_payload(
 			&alice,
-			handle_with_combining_mark.as_bytes().to_vec(),
+			handle_with_unsupported_unicode_characters.as_bytes().to_vec(),
 			expiration,
 		);
-
-		// Assert that both forms of "Álvaro" pass validation and reduce
-		// to the same cannonical form as witnessed by the single unicode
-		// character form of the handle triggering `MSAHandleAlreadyExists`
-		// when the combined mark containing version has already successfully
-		// been used for handle creation
 		assert_noop!(
 			Handles::claim_handle(
 				RuntimeOrigin::signed(alice.public().into()),
@@ -294,7 +289,7 @@ fn claim_handle_supports_stripping_diacriticals_from_utf8_with_combining_marks()
 				proof,
 				payload.clone()
 			),
-			Error::<Test>::MSAHandleAlreadyExists
+			Error::<Test>::HandleDoesNotConsistOfSupportedCharacterSets
 		);
 	});
 }


### PR DESCRIPTION
# Goal
The goal of this PR is to support the stripping of diacritical marks when claiming a user handle where UTF8 encoding contains combining marks.

Closes #1334
Affects #1416

# Checklist
- [ ] Chain spec updated
- [ ] Custom RPC OR Runtime API added/changed? Updated js/api-augment.
- [ ] Design doc(s) updated
- [x] Tests added
- [ ] Benchmarks added
- [ ] Weights updated
