### PR TITLE
Switched PRNG from rand to oorandom

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3312,8 +3312,8 @@ dependencies = [
 name = "handles-utils"
 version = "0.0.0"
 dependencies = [
+ "oorandom",
  "phf",
- "rand 0.8.5",
  "twox-hash",
  "unicode-normalization",
 ]
@@ -5160,6 +5160,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b7e5500299e16ebb147ae15a00a942af264cf3688f47923b8fc2cd5858f23ad3"
 
 [[package]]
+name = "oorandom"
+version = "11.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0ab1bc2a289d34bd04a330323ac98a1b4bc82c9d9fcb1e66b63caa84da26b575"
+
+[[package]]
 name = "opaque-debug"
 version = "0.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5640,7 +5646,6 @@ dependencies = [
  "numtoa",
  "parity-scale-codec",
  "pretty_assertions",
- "rand 0.8.5",
  "scale-info",
  "serde",
  "sp-core",

--- a/pallets/handles/Cargo.toml
+++ b/pallets/handles/Cargo.toml
@@ -17,7 +17,6 @@ codec = { package = "parity-scale-codec", version = "3.1.5", default-features = 
 log = { version = "0.4.17", default-features = false }
 scale-info = { version = "2.2.0", default-features = false, features = ["derive",] }
 numtoa = "0.2.4"
-rand = { version = "0.8.5", default-features = false, features = ["small_rng"] }
 # Substrate
 frame-benchmarking = { git = "https://github.com/paritytech/substrate", default-features = false, optional = true, branch = "polkadot-v0.9.36" }
 frame-support = { git = "https://github.com/paritytech/substrate", default-features = false, branch = "polkadot-v0.9.36" }

--- a/pallets/handles/src/handles-utils/Cargo.toml
+++ b/pallets/handles/src/handles-utils/Cargo.toml
@@ -11,7 +11,7 @@ repository = "https://github.com/libertyDSNP/frequency/"
 
 [dependencies]
 phf = { version = "0.11", default-features = false, features = ["macros"] }
-rand = { version = "0.8.5", default-features = false, features = ["small_rng"] }
+oorandom = "11.1.3"
 unicode-normalization = { version = "0.1.22", default-features = false }
 twox-hash = { version = "1.6.3", default-features = false, features = ["digest_0_10"] }
 

--- a/pallets/handles/src/handles-utils/src/suffix.rs
+++ b/pallets/handles/src/handles-utils/src/suffix.rs
@@ -3,7 +3,7 @@
 //! `suffix_generator` provides a `SuffixGenerator` struct to generate unique suffix sequences for a given range
 //! and seed, excluding already used suffixes.
 
-use rand::{rngs::SmallRng, Rng, SeedableRng};
+use oorandom::Rand32;
 use twox_hash::XxHash64;
 extern crate alloc;
 use alloc::vec::Vec;
@@ -33,15 +33,15 @@ pub fn generate_unique_suffixes(
 	canonical_base: &str,
 ) -> impl Iterator<Item = u16> + '_ {
 	let seed = generate_seed(canonical_base);
-	let mut rng = SmallRng::seed_from_u64(seed);
+	let mut rng = Rand32::new(seed);
 
 	let mut indices: Vec<u16> = (min..=max).collect();
-	let min = min as usize;
-	let max = max as usize;
+	// let min = min as usize;
+	// let max = max as usize;
 	(min..=max).rev().map(move |i| {
-		let j = rng.gen_range(min..=i);
-		indices.swap(i - min, j - min);
-		indices[i - min]
+		let j = rng.rand_range((min as u32)..(i+1) as u32) as u16;
+		indices.swap((i - min) as usize, (j - min) as usize);
+		indices[(i - min) as usize]
 	})
 }
 

--- a/pallets/handles/src/handles-utils/src/suffix.rs
+++ b/pallets/handles/src/handles-utils/src/suffix.rs
@@ -39,7 +39,7 @@ pub fn generate_unique_suffixes(
 	// let min = min as usize;
 	// let max = max as usize;
 	(min..=max).rev().map(move |i| {
-		let j = rng.rand_range((min as u32)..(i+1) as u32) as u16;
+		let j = rng.rand_range((min as u32)..(i + 1) as u32) as u16;
 		indices.swap((i - min) as usize, (j - min) as usize);
 		indices[(i - min) as usize]
 	})

--- a/pallets/handles/src/handles-utils/src/suffix.rs
+++ b/pallets/handles/src/handles-utils/src/suffix.rs
@@ -36,8 +36,6 @@ pub fn generate_unique_suffixes(
 	let mut rng = Rand32::new(seed);
 
 	let mut indices: Vec<u16> = (min..=max).collect();
-	// let min = min as usize;
-	// let max = max as usize;
 	(min..=max).rev().map(move |i| {
 		let j = rng.rand_range((min as u32)..(i + 1) as u32) as u16;
 		indices.swap((i - min) as usize, (j - min) as usize);

--- a/pallets/handles/src/handles-utils/src/tests/mod.rs
+++ b/pallets/handles/src/handles-utils/src/tests/mod.rs
@@ -1,3 +1,3 @@
 mod converter_tests;
-mod validator_tests;
 mod suffix_tests;
+mod validator_tests;

--- a/pallets/handles/src/handles-utils/src/tests/mod.rs
+++ b/pallets/handles/src/handles-utils/src/tests/mod.rs
@@ -1,2 +1,3 @@
 mod converter_tests;
 mod validator_tests;
+mod suffix_tests;

--- a/pallets/handles/src/handles-utils/src/tests/suffix_tests.rs
+++ b/pallets/handles/src/handles-utils/src/tests/suffix_tests.rs
@@ -1,0 +1,14 @@
+use crate::suffix::{generate_seed, generate_unique_suffixes};
+
+#[test]
+fn should_always_have_the_same_seed() {
+	assert_eq!(generate_seed("abcdefg"), 15079896798642598352u64);
+	assert_eq!(generate_seed("gfedcba"), 9497970330616778036u64);
+}
+
+
+#[test]
+fn should_generate_the_same_sequence() {
+	assert_eq!(generate_unique_suffixes(10, 99, "abcdefg").take(10).collect::<Vec<u16>>(), vec![49, 28, 22, 87, 57, 39, 69, 54, 79, 37]);
+	assert_eq!(generate_unique_suffixes(10, 99, "gfedcba").take(10).collect::<Vec<u16>>(), vec![78, 52, 69, 46, 89, 34, 88, 49, 97, 77]);
+}

--- a/pallets/handles/src/handles-utils/src/tests/suffix_tests.rs
+++ b/pallets/handles/src/handles-utils/src/tests/suffix_tests.rs
@@ -6,9 +6,14 @@ fn should_always_have_the_same_seed() {
 	assert_eq!(generate_seed("gfedcba"), 9497970330616778036u64);
 }
 
-
 #[test]
 fn should_generate_the_same_sequence() {
-	assert_eq!(generate_unique_suffixes(10, 99, "abcdefg").take(10).collect::<Vec<u16>>(), vec![49, 28, 22, 87, 57, 39, 69, 54, 79, 37]);
-	assert_eq!(generate_unique_suffixes(10, 99, "gfedcba").take(10).collect::<Vec<u16>>(), vec![78, 52, 69, 46, 89, 34, 88, 49, 97, 77]);
+	assert_eq!(
+		generate_unique_suffixes(10, 99, "abcdefg").take(10).collect::<Vec<u16>>(),
+		vec![49, 28, 22, 87, 57, 39, 69, 54, 79, 37]
+	);
+	assert_eq!(
+		generate_unique_suffixes(10, 99, "gfedcba").take(10).collect::<Vec<u16>>(),
+		vec![78, 52, 69, 46, 89, 34, 88, 49, 97, 77]
+	);
 }

--- a/pallets/handles/src/handles-utils/src/tests/suffix_tests.rs
+++ b/pallets/handles/src/handles-utils/src/tests/suffix_tests.rs
@@ -10,10 +10,10 @@ fn should_always_have_the_same_seed() {
 fn should_generate_the_same_sequence() {
 	assert_eq!(
 		generate_unique_suffixes(10, 99, "abcdefg").take(10).collect::<Vec<u16>>(),
-		vec![49, 28, 22, 87, 57, 39, 69, 54, 79, 37]
+		vec![23, 65, 16, 53, 25, 75, 29, 26, 10, 87]
 	);
 	assert_eq!(
 		generate_unique_suffixes(10, 99, "gfedcba").take(10).collect::<Vec<u16>>(),
-		vec![78, 52, 69, 46, 89, 34, 88, 49, 97, 77]
+		vec![64, 95, 99, 87, 44, 74, 20, 93, 43, 46]
 	);
 }


### PR DESCRIPTION
# Goal
The goal of this PR is to use a PRNG that generates consistent (portable) values between Rust and WASM.

Closes #1407 
