### PR TITLE
fix(benchmark-ci): fix benchmark trigger in CI commit message

### DIFF
--- a/.github/workflows/verify-pr-commit.yml
+++ b/.github/workflows/verify-pr-commit.yml
@@ -793,7 +793,7 @@ jobs:
       - name: Update Weights
         run: |
           set -x
-          pallets_str="${{steps.run-benchmarks.outputs.pallets}}"
+          pallets_str="${{steps.should-run-benchmarks.outputs.pallets}}"
           echo "Pallets: $pallets_str"
           if [ -z "${pallets_str}" -o $pallets_str = 'all' ]; then
             echo "Running benchmarks for all pallets..."

--- a/Makefile
+++ b/Makefile
@@ -89,6 +89,7 @@ upgrade-local:
 #       script directly, as it is able to run the build stage just once for all benchmarks
 #
 BENCH_TARGETS=\
+benchmarks-capacity \
 benchmarks-messages \
 benchmarks-msa \
 benchmarks-frequency-tx-payment \
@@ -109,13 +110,14 @@ benchmarks-pallet_treasury \
 benchmarks-pallet_utility
 
 BENCH_LOCAL_TARGETS=\
+benchmarks-capacity-local \
+benchmarks-handles-local \
 benchmarks-messages-local \
 benchmarks-msa-local \
 benchmarks-overhead-local \
 benchmarks-schemas-local \
 benchmarks-frequency-tx-payment-local \
 benchmarks-stateful-storage-local \
-benchmarks-handles-local \
 benchmarks-time-release-local \
 benchmarks-pallet_balances-local \
 benchmarks-pallet_collator_selection-local \
@@ -161,9 +163,6 @@ benchmarks-multi:
 .PHONY: benchmarks-multi-local
 benchmarks-multi-local:
 	./scripts/run_benchmarks.sh -t bench-dev $(PALLETS)
-
-benchmarks-capacity:
-	./scripts/run_benchmark.sh -p capacity
 
 .PHONY: docs
 docs:


### PR DESCRIPTION
# Goal
The goal of this PR is to fix the benchmark CI process to properly recognize the "[run-benchmark pallet]" syntax

Closes #1425 

# Checklist
- [ ] Chain spec updated
- [ ] Custom RPC OR Runtime API added/changed? Updated js/api-augment.
- [ ] Design doc(s) updated
- [ ] Tests added
- [ ] Benchmarks added
- [ ] Weights updated
