### PR TITLE
[Handles] Unit tests cleanup

### DIFF
--- a/pallets/handles/src/handles-utils/src/tests/suffix_tests.rs
+++ b/pallets/handles/src/handles-utils/src/tests/suffix_tests.rs
@@ -1,7 +1,6 @@
 use crate::suffix::{generate_seed, generate_unique_suffixes};
 use std::collections::HashSet;
 
-
 #[test]
 fn should_always_have_the_same_seed() {
 	assert_eq!(generate_seed("abcdefg"), 15079896798642598352u64);
@@ -27,10 +26,6 @@ fn should_generate_unique_sequence() {
 
 	for suffix in suffixes {
 		let unique = suffix_set.insert(suffix);
-		assert!(
-			unique,
-			"Duplicate suffix generated: {}",
-			suffix
-		);
+		assert!(unique, "Duplicate suffix generated: {}", suffix);
 	}
 }

--- a/pallets/handles/src/handles-utils/src/tests/suffix_tests.rs
+++ b/pallets/handles/src/handles-utils/src/tests/suffix_tests.rs
@@ -1,4 +1,6 @@
 use crate::suffix::{generate_seed, generate_unique_suffixes};
+use std::collections::HashSet;
+
 
 #[test]
 fn should_always_have_the_same_seed() {
@@ -16,4 +18,19 @@ fn should_generate_the_same_sequence() {
 		generate_unique_suffixes(10, 99, "gfedcba").take(10).collect::<Vec<u16>>(),
 		vec![64, 95, 99, 87, 44, 74, 20, 93, 43, 46]
 	);
+}
+
+#[test]
+fn should_generate_unique_sequence() {
+	let mut suffix_set = HashSet::new();
+	let suffixes = generate_unique_suffixes(0, 99, "abcdefg");
+
+	for suffix in suffixes {
+		let unique = suffix_set.insert(suffix);
+		assert!(
+			unique,
+			"Duplicate suffix generated: {}",
+			suffix
+		);
+	}
 }

--- a/pallets/handles/src/lib.rs
+++ b/pallets/handles/src/lib.rs
@@ -314,7 +314,7 @@ pub mod pallet {
 		///
 		/// The generated suffix as a `u16`.
 		///
-		fn generate_suffix_for_canonical_handle(
+		pub fn generate_suffix_for_canonical_handle(
 			canonical_base: &str,
 			cursor: usize,
 		) -> Result<u16, DispatchError> {
@@ -519,37 +519,6 @@ pub mod pallet {
 			Self::get_msa_id_for_canonical_and_suffix(canonical_base, suffix)
 		}
 
-		/// Creates a full display handle by combining a base handle string with a suffix generated
-		/// from an index into the suffix sequence.
-		///
-		/// # Arguments
-		///
-		/// * `base_handle_str` - The base handle string.
-		/// * `suffix_sequence_index` - The index into the suffix sequence.
-		///
-		/// # Returns
-		///
-		/// * `DisplayHandle` - The full display handle.
-		///
-		#[cfg(test)]
-		pub fn create_full_handle_for_index(
-			base_handle_str: &str,
-			suffix_sequence_index: SequenceIndex,
-		) -> Vec<u8> {
-			// Convert base handle into a canonical base
-			let canonical_handle_str = convert_to_canonical(&base_handle_str);
-
-			// Generate suffix from index into the suffix sequence
-			let suffix = Self::generate_suffix_for_canonical_handle(
-				&canonical_handle_str,
-				suffix_sequence_index as usize,
-			)
-			.unwrap_or_default();
-
-			let display_handle = Self::build_full_display_handle(base_handle_str, suffix).unwrap();
-			display_handle.into_inner()
-		}
-
 		/// Claims a handle for a given MSA (MessageSourceId) by validating and storing the base handle,
 		/// generating a canonical base, generating a suffix, and composing the full display handle.
 		///
@@ -657,7 +626,7 @@ pub mod pallet {
 		///
 		/// * `DisplayHandle` - The full display handle.
 		///
-		fn build_full_display_handle(
+		pub fn build_full_display_handle(
 			base_handle: &str,
 			suffix: HandleSuffix,
 		) -> Result<DisplayHandle, DispatchError> {

--- a/pallets/handles/src/tests/handle_creation_tests.rs
+++ b/pallets/handles/src/tests/handle_creation_tests.rs
@@ -79,20 +79,17 @@ fn claim_handle_already_claimed() {
 		let alice = sr25519::Pair::from_seed(&[0; 32]);
 		let expiration = 100;
 
-		let test_cases: [TestCase<DispatchResult>; 2] =[
-			TestCase {
-				handle: "test1",
-				expected: Ok(()),
-			},
+		let test_cases: [TestCase<DispatchResult>; 2] = [
+			TestCase { handle: "test1", expected: Ok(()) },
 			TestCase {
 				handle: "test1",
 				expected: Err(Error::<Test>::MSAHandleAlreadyExists.into()),
-			}
+			},
 		];
 
 		for test_case in test_cases {
 			let (payload, proof) =
-			get_signed_claims_payload(&alice, test_case.handle.as_bytes().to_vec(), expiration);
+				get_signed_claims_payload(&alice, test_case.handle.as_bytes().to_vec(), expiration);
 
 			assert_eq!(
 				Handles::claim_handle(
@@ -113,20 +110,17 @@ fn claim_handle_already_claimed_with_different_case() {
 		let alice = sr25519::Pair::from_seed(&[0; 32]);
 		let expiration = 100;
 
-		let test_cases: [TestCase<DispatchResult>; 2] =[
-			TestCase {
-				handle: "test1",
-				expected: Ok(()),
-			},
+		let test_cases: [TestCase<DispatchResult>; 2] = [
+			TestCase { handle: "test1", expected: Ok(()) },
 			TestCase {
 				handle: "TEST1",
 				expected: Err(Error::<Test>::MSAHandleAlreadyExists.into()),
-			}
+			},
 		];
 
 		for test_case in test_cases {
 			let (payload, proof) =
-			get_signed_claims_payload(&alice, test_case.handle.as_bytes().to_vec(), expiration);
+				get_signed_claims_payload(&alice, test_case.handle.as_bytes().to_vec(), expiration);
 
 			assert_eq!(
 				Handles::claim_handle(
@@ -147,20 +141,17 @@ fn claim_handle_already_claimed_with_homoglyph() {
 		let alice = sr25519::Pair::from_seed(&[0; 32]);
 		let expiration = 100;
 
-		let test_cases: [TestCase<DispatchResult>; 2] =[
-			TestCase {
-				handle: "test1",
-				expected: Ok(()),
-			},
+		let test_cases: [TestCase<DispatchResult>; 2] = [
+			TestCase { handle: "test1", expected: Ok(()) },
 			TestCase {
 				handle: "tést1",
 				expected: Err(Error::<Test>::MSAHandleAlreadyExists.into()),
-			}
+			},
 		];
 
 		for test_case in test_cases {
 			let (payload, proof) =
-			get_signed_claims_payload(&alice, test_case.handle.as_bytes().to_vec(), expiration);
+				get_signed_claims_payload(&alice, test_case.handle.as_bytes().to_vec(), expiration);
 
 			assert_eq!(
 				Handles::claim_handle(

--- a/pallets/handles/src/tests/handle_creation_tests.rs
+++ b/pallets/handles/src/tests/handle_creation_tests.rs
@@ -12,7 +12,6 @@ fn test_full_handle_creation() {
 		for sequence_index in 0..89 {
 			let display_handle = Handles::create_full_handle_for_index("test", sequence_index);
 			assert_ok!(core::str::from_utf8(&display_handle));
-
 		}
 	})
 }

--- a/pallets/handles/src/tests/handle_creation_tests.rs
+++ b/pallets/handles/src/tests/handle_creation_tests.rs
@@ -11,8 +11,8 @@ fn test_full_handle_creation() {
 		// Min is 10, Max is 99 inclusive
 		for sequence_index in 0..89 {
 			let display_handle = Handles::create_full_handle_for_index("test", sequence_index);
-			let display_handle_str = core::str::from_utf8(&display_handle).ok().unwrap();
-			println!("display_handle_str={}", display_handle_str);
+			assert_ok!(core::str::from_utf8(&display_handle));
+
 		}
 	})
 }


### PR DESCRIPTION
# Goal
The goal of this PR is to clean up unit testing for User Handles

Closes #1412

# Discussion
- [x] Add assertion to `test_full_handle_creation` in `pallets/handles/src/tests/handle_creation_tests.rs`
- [x] Add `should_generate_unique_sequence` in `pallets/handles/src/handle-utils/src/tests/suffix_tests.rs`
- [x]  Move the create_full_handle_for_index and create_full_handle test helper functions into the pallets/handles/src/tests/handle_creation_tests.rs file
- [x] Update the pallets/handles/src/tests/handle_creation_tests.rs to follow table testing patterns

# Checklist
- [ ] Chain spec updated
- [ ] Custom RPC OR Runtime API added/changed? Updated js/api-augment.
- [ ] Design doc(s) updated
- [x] Tests added
- [ ] Benchmarks added
- [ ] Weights updated
