### PR TITLE
Fix type def for canonical_handle -> canonical_base

### DIFF
--- a/integration-tests/handles/handles.test.ts
+++ b/integration-tests/handles/handles.test.ts
@@ -48,7 +48,8 @@ describe("🤝 Handles", () => {
             let suffix_from_state = full_handle_state.suffix;
             let suffix = suffix_from_state.toNumber();
             assert.notEqual(suffix, 0, "suffix should not be 0");
-
+            assert.notEqual(full_handle_state.canonical_base, undefined, "canonical_base should not be undefined");
+            assert.notEqual(full_handle_state.base_handle, undefined, "base_handle should not be undefined");
             let currentBlock = await getBlockNumber();
             await ExtrinsicHelper.run_to_block(currentBlock + 20);
 

--- a/js/api-augment/definitions/handles.ts
+++ b/js/api-augment/definitions/handles.ts
@@ -39,7 +39,7 @@ export default {
     HandleSuffix: "u16",
     HandleResponse: {
       base_handle: "String",
-      canonical_handle: "String",
+      canonical_base: "String",
       suffix: "u16",
     },
     PresumptiveSuffixesResponse: {


### PR DESCRIPTION
# Goal
The goal of this PR is  to fix handles typedef to match the node semantics 

# Checklist
- [ ] Chain spec updated
- [x] Custom RPC OR Runtime API added/changed? Updated js/api-augment.
- [ ] Design doc(s) updated
- [ ] Tests added
- [ ] Benchmarks added
- [ ] Weights updated
