### PR TITLE
fix(Capacity) Ensure Epoch incrementing when not starting chain from block 0

### DIFF
--- a/pallets/capacity/src/lib.rs
+++ b/pallets/capacity/src/lib.rs
@@ -130,7 +130,6 @@ pub mod pallet {
 		type UnstakingThawPeriod: Get<u16>;
 
 		/// Maximum number of blocks an epoch can be
-		/// currently used as the actual value of epoch length.
 		#[pallet::constant]
 		type MaxEpochLength: Get<Self::BlockNumber>;
 
@@ -576,10 +575,9 @@ impl<T: Config> Pallet<T> {
 	}
 
 	fn start_new_epoch_if_needed(current_block: T::BlockNumber) -> Weight {
-		if Self::get_current_epoch_info()
-			.epoch_start
-			.saturating_add(Self::get_epoch_length())
-			.eq(&current_block)
+		// Should we start a new epoch?
+		if current_block.saturating_sub(Self::get_current_epoch_info().epoch_start) >=
+			Self::get_epoch_length()
 		{
 			let current_epoch = Self::get_current_epoch();
 			CurrentEpoch::<T>::set(current_epoch.saturating_add(1u32.into()));

--- a/pallets/capacity/src/tests/epochs_tests.rs
+++ b/pallets/capacity/src/tests/epochs_tests.rs
@@ -1,5 +1,8 @@
 use super::mock::*;
-use crate::{Config, EpochLength, Error, Event};
+use crate::{
+	tests::testing_utils::{run_to_block, system_run_to_block},
+	Config, EpochLength, Error, Event,
+};
 use frame_support::{assert_noop, assert_ok, traits::Get};
 use sp_runtime::DispatchError::BadOrigin;
 #[test]
@@ -56,4 +59,55 @@ fn get_epoch_length_should_return_storage_epoch_length() {
 
 		assert_eq!(epoch_length, 101u64);
 	});
+}
+
+#[test]
+fn start_new_epoch_if_needed_when_not_starting_from_zero() {
+	new_test_ext().execute_with(|| {
+		EpochLength::<Test>::set(100u64);
+		let epoch_info = Capacity::get_current_epoch_info();
+		let cur_epoch = Capacity::get_current_epoch();
+		// Run the system to block 999 before initializing Capacity to emulate
+		// deploying to an existing network where blockheight is greater than 0.
+		system_run_to_block(999);
+		run_to_block(1000);
+		let after_epoch = Capacity::get_current_epoch();
+		let after_epoch_info = Capacity::get_current_epoch_info();
+		assert_eq!(epoch_info.epoch_start, 0);
+		assert_eq!(after_epoch_info.epoch_start, 1000);
+		assert_eq!(after_epoch, cur_epoch + 1);
+	})
+}
+
+#[test]
+fn start_new_epoch_if_needed_when_epoch_length_changes() {
+	new_test_ext().execute_with(|| {
+		EpochLength::<Test>::set(100u64);
+		// Starting block = 100
+		system_run_to_block(100);
+		let epoch_info = Capacity::get_current_epoch_info();
+		let cur_epoch = Capacity::get_current_epoch();
+		assert_eq!(epoch_info.epoch_start, 0);
+		assert_eq!(cur_epoch, 0);
+		run_to_block(150);
+		let middle_epoch = Capacity::get_current_epoch();
+		let middle_epoch_info = Capacity::get_current_epoch_info();
+		assert_eq!(middle_epoch, 1);
+		assert_eq!(middle_epoch_info.epoch_start, 101);
+		// Change epoch length = 20
+		EpochLength::<Test>::set(20u64);
+		run_to_block(151);
+		let after_epoch = Capacity::get_current_epoch();
+		let after_epoch_info = Capacity::get_current_epoch_info();
+		// epoch 1 starts at 101
+		// epoch 2 starts at 151 (First block after epoch length change)
+		assert_eq!(after_epoch_info.epoch_start, 151);
+		assert_eq!(after_epoch, 2);
+		run_to_block(171);
+		let last_epoch = Capacity::get_current_epoch();
+		let last_epoch_info = Capacity::get_current_epoch_info();
+		assert_eq!(last_epoch, 3);
+		// epoch 3 starts at 171 (151 + 20)
+		assert_eq!(last_epoch_info.epoch_start, 171);
+	})
 }

--- a/pallets/capacity/src/tests/testing_utils.rs
+++ b/pallets/capacity/src/tests/testing_utils.rs
@@ -28,6 +28,16 @@ pub fn run_to_block(n: u64) {
 		Capacity::on_initialize(System::block_number());
 	}
 }
+// Remove capacity on_initialize, needed to emulate pre-existing blockheight
+pub fn system_run_to_block(n: u64) {
+	while System::block_number() < n {
+		if System::block_number() > 1 {
+			System::on_finalize(System::block_number());
+		}
+		System::set_block_number(System::block_number() + 1);
+		System::on_initialize(System::block_number());
+	}
+}
 
 pub fn register_provider(target_id: MessageSourceId, name: String) {
 	let name = Vec::from(name).try_into().expect("error");

--- a/runtime/frequency/src/lib.rs
+++ b/runtime/frequency/src/lib.rs
@@ -429,7 +429,7 @@ pub const VERSION: RuntimeVersion = RuntimeVersion {
 	spec_name: spec_name!("frequency"),
 	impl_name: create_runtime_str!("frequency"),
 	authoring_version: 1,
-	spec_version: 29,
+	spec_version: 30,
 	impl_version: 0,
 	apis: RUNTIME_API_VERSIONS,
 	transaction_version: 1,


### PR DESCRIPTION
# Goal
The goal of this PR is to fix Capacity Epoch not incrementing when there is pre-existing block height before deployment.

The code only worked when the Epoch Info was started with a chain starting from block 0.
When Capacity was deployed to existing networks with block heights higher than 0, the current epoch would never increment.

New logic changes so that when blocks are greater than or equal to current will start the epoch incrementing.

# Checklist
- [ ] Chain spec updated
- [ ] Custom RPC OR Runtime API added/changed? Updated js/api-augment.
- [ ] Design doc(s) updated
- [x] Tests added
- [ ] Benchmarks added
- [ ] Weights updated
