### PR TITLE
[Handles] Testing Cleanup

### DIFF
--- a/pallets/handles/src/handles-utils/src/tests/converter_tests.rs
+++ b/pallets/handles/src/handles-utils/src/tests/converter_tests.rs
@@ -94,19 +94,21 @@ fn test_convert_to_canonical_combining_marks_reduce_to_the_same_canonical_form()
 	let mut handle_with_combining_mark = String::new();
 	handle_with_combining_mark.push('\u{0041}');
 	handle_with_combining_mark.push('\u{0301}');
-	handle_with_combining_mark.push_str("varo");
+	handle_with_combining_mark.push_str("lvaro");
 
 	// Construct the handle "Álvaro" where the first character consists
 	// of the Latin-1 Supplement character 0x00C1, which contains both
 	// the base character `A` and the accute diacritical in one character
 	let mut handle_without_combining_mark = String::new();
 	handle_without_combining_mark.push('\u{00C1}');
-	handle_without_combining_mark.push_str("varo");
+	handle_without_combining_mark.push_str("lvaro");
 
 	let canonical_with_combining_mark = convert_to_canonical(&handle_with_combining_mark);
 	let canonical_without_combining_mark = convert_to_canonical(&handle_without_combining_mark);
+
+	let expected_canonical_form = "a1var0";
 	assert_eq!(canonical_with_combining_mark, canonical_without_combining_mark);
-	assert_eq!(canonical_with_combining_mark, "avar0");
+	assert_eq!(canonical_with_combining_mark, expected_canonical_form);
 }
 
 #[test]

--- a/pallets/handles/src/handles-utils/src/tests/converter_tests.rs
+++ b/pallets/handles/src/handles-utils/src/tests/converter_tests.rs
@@ -106,7 +106,7 @@ fn test_convert_to_canonical_combining_marks_reduce_to_the_same_canonical_form()
 	let canonical_with_combining_mark = convert_to_canonical(&handle_with_combining_mark);
 	let canonical_without_combining_mark = convert_to_canonical(&handle_without_combining_mark);
 
-	let expected_canonical_form = "a1var0";
+	let expected_canonical_form = String::from("a1var0");
 	assert_eq!(canonical_with_combining_mark, canonical_without_combining_mark);
 	assert_eq!(canonical_with_combining_mark, expected_canonical_form);
 }

--- a/pallets/handles/src/tests/handle_creation_tests.rs
+++ b/pallets/handles/src/tests/handle_creation_tests.rs
@@ -300,7 +300,7 @@ fn claim_handle_supports_stripping_diacriticals_from_utf8_with_combining_marks()
 		let mut handle_with_combining_mark = String::new();
 		handle_with_combining_mark.push('\u{0041}');
 		handle_with_combining_mark.push('\u{0301}');
-		handle_with_combining_mark.push_str("varo");
+		handle_with_combining_mark.push_str("lvaro");
 
 		let (payload, proof) = get_signed_claims_payload(
 			&alice,


### PR DESCRIPTION
# Goal
The goal of this PR is to fix a typo in tests for diacritical mark reduction

# Discussion
- Added missing `l` in the name `Álvaro` used for testing string normalization and diacritical mark removal
- Pulled expected canonical value into a variable `expected_canonical_form` for clarity when reading tests


