### PR TITLE
Decrease use of parameter types

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6334,6 +6334,7 @@ name = "pallet-time-release"
 version = "0.0.0"
 dependencies = [
  "chrono",
+ "common-primitives",
  "frame-benchmarking",
  "frame-support",
  "frame-system",

--- a/common/primitives/src/msa.rs
+++ b/common/primitives/src/msa.rs
@@ -53,7 +53,7 @@ impl From<DelegatorId> for MessageSourceId {
 }
 
 /// Struct for the information of the relationship between an MSA and a Provider
-#[derive(TypeInfo, RuntimeDebug, Clone, Decode, Encode, PartialEq, MaxEncodedLen, Eq)]
+#[derive(TypeInfo, RuntimeDebug, Clone, Decode, Encode, MaxEncodedLen, Eq)]
 #[scale_info(skip_type_params(MaxSchemaGrantsPerDelegation))]
 pub struct Delegation<SchemaId, BlockNumber, MaxSchemaGrantsPerDelegation>
 where
@@ -63,6 +63,19 @@ where
 	pub revoked_at: BlockNumber,
 	/// Schemas that the provider is allowed to use for a delegated message.
 	pub schema_permissions: BoundedBTreeMap<SchemaId, BlockNumber, MaxSchemaGrantsPerDelegation>,
+}
+
+// Cannot derive the PartialEq without a mess of impl PartialEq for MaxSchemaGrantsPerDelegation
+impl<SchemaId, BlockNumber, MaxSchemaGrantsPerDelegation> PartialEq
+	for Delegation<SchemaId, BlockNumber, MaxSchemaGrantsPerDelegation>
+where
+	SchemaId: PartialEq,
+	BlockNumber: PartialEq,
+	MaxSchemaGrantsPerDelegation: Get<u32>,
+{
+	fn eq(&self, other: &Self) -> bool {
+		self.revoked_at == other.revoked_at && self.schema_permissions == other.schema_permissions
+	}
 }
 
 impl<
@@ -173,7 +186,7 @@ pub trait ProviderLookup {
 	/// Type for block number.
 	type BlockNumber;
 	/// Type for maximum number of schemas that can be granted to a provider.
-	type MaxSchemaGrantsPerDelegation: Get<u32> + Clone + Eq;
+	type MaxSchemaGrantsPerDelegation: Get<u32>;
 	/// Schema Id is the unique identifier for a Schema
 	type SchemaId;
 
@@ -189,7 +202,7 @@ pub trait DelegationValidator {
 	/// Type for block number.
 	type BlockNumber;
 	/// Type for maximum number of schemas that can be granted to a provider.
-	type MaxSchemaGrantsPerDelegation: Get<u32> + Clone + Eq;
+	type MaxSchemaGrantsPerDelegation: Get<u32>;
 	/// Schema Id is the unique identifier for a Schema
 	type SchemaId;
 

--- a/pallets/capacity/src/tests/epochs_tests.rs
+++ b/pallets/capacity/src/tests/epochs_tests.rs
@@ -5,6 +5,7 @@ use crate::{
 };
 use frame_support::{assert_noop, assert_ok, traits::Get};
 use sp_runtime::DispatchError::BadOrigin;
+
 #[test]
 fn set_epoch_length_happy_path() {
 	new_test_ext().execute_with(|| {
@@ -45,7 +46,7 @@ fn get_epoch_length_should_return_max_epoch_length_when_unset() {
 	new_test_ext().execute_with(|| {
 		let epoch_length: <Test as frame_system::Config>::BlockNumber =
 			Capacity::get_epoch_length();
-		let max_epoch_length: u64 = <Test as Config>::MaxEpochLength::get();
+		let max_epoch_length: u32 = <Test as Config>::MaxEpochLength::get();
 
 		assert_eq!(epoch_length, max_epoch_length);
 	});
@@ -53,18 +54,18 @@ fn get_epoch_length_should_return_max_epoch_length_when_unset() {
 #[test]
 fn get_epoch_length_should_return_storage_epoch_length() {
 	new_test_ext().execute_with(|| {
-		EpochLength::<Test>::set(101u64);
+		EpochLength::<Test>::set(101u32);
 		let epoch_length: <Test as frame_system::Config>::BlockNumber =
 			Capacity::get_epoch_length();
 
-		assert_eq!(epoch_length, 101u64);
+		assert_eq!(epoch_length, 101u32);
 	});
 }
 
 #[test]
 fn start_new_epoch_if_needed_when_not_starting_from_zero() {
 	new_test_ext().execute_with(|| {
-		EpochLength::<Test>::set(100u64);
+		EpochLength::<Test>::set(100u32);
 		let epoch_info = Capacity::get_current_epoch_info();
 		let cur_epoch = Capacity::get_current_epoch();
 		// Run the system to block 999 before initializing Capacity to emulate
@@ -82,7 +83,7 @@ fn start_new_epoch_if_needed_when_not_starting_from_zero() {
 #[test]
 fn start_new_epoch_if_needed_when_epoch_length_changes() {
 	new_test_ext().execute_with(|| {
-		EpochLength::<Test>::set(100u64);
+		EpochLength::<Test>::set(100u32);
 		// Starting block = 100
 		system_run_to_block(100);
 		let epoch_info = Capacity::get_current_epoch_info();
@@ -95,7 +96,7 @@ fn start_new_epoch_if_needed_when_epoch_length_changes() {
 		assert_eq!(middle_epoch, 1);
 		assert_eq!(middle_epoch_info.epoch_start, 101);
 		// Change epoch length = 20
-		EpochLength::<Test>::set(20u64);
+		EpochLength::<Test>::set(20u32);
 		run_to_block(151);
 		let after_epoch = Capacity::get_current_epoch();
 		let after_epoch_info = Capacity::get_current_epoch_info();

--- a/pallets/capacity/src/tests/mock.rs
+++ b/pallets/capacity/src/tests/mock.rs
@@ -1,7 +1,7 @@
 use crate as pallet_capacity;
 
 use common_primitives::{
-	node::{AccountId, ProposalProvider},
+	node::{AccountId, Header, ProposalProvider},
 	schema::{SchemaId, SchemaValidator},
 };
 use frame_support::{
@@ -11,7 +11,6 @@ use frame_support::{
 use frame_system::EnsureSigned;
 use sp_core::{ConstU8, H256};
 use sp_runtime::{
-	testing::Header,
 	traits::{BlakeTwo256, Convert, IdentityLookup},
 	AccountId32, DispatchError, Perbill,
 };
@@ -41,14 +40,14 @@ impl frame_system::Config for Test {
 	type RuntimeOrigin = RuntimeOrigin;
 	type RuntimeCall = RuntimeCall;
 	type Index = u64;
-	type BlockNumber = u64;
+	type BlockNumber = u32;
 	type Hash = H256;
 	type Hashing = BlakeTwo256;
 	type AccountId = u64;
 	type Lookup = IdentityLookup<Self::AccountId>;
 	type Header = Header;
 	type RuntimeEvent = RuntimeEvent;
-	type BlockHashCount = ConstU64<250>;
+	type BlockHashCount = ConstU32<250>;
 	type Version = ();
 	type PalletInfo = PalletInfo;
 	type AccountData = pallet_balances::AccountData<u64>;
@@ -72,30 +71,8 @@ impl pallet_balances::Config for Test {
 	type WeightInfo = ();
 }
 
-parameter_types! {
-	pub const MaxSchemaGrantsPerDelegation: u32 = 30;
-}
-impl Clone for MaxSchemaGrantsPerDelegation {
-	fn clone(&self) -> Self {
-		MaxSchemaGrantsPerDelegation {}
-	}
-}
+pub type MaxSchemaGrantsPerDelegation = ConstU32<30>;
 
-impl Eq for MaxSchemaGrantsPerDelegation {
-	fn assert_receiver_is_total_eq(&self) -> () {}
-}
-
-impl PartialEq for MaxSchemaGrantsPerDelegation {
-	fn eq(&self, _other: &Self) -> bool {
-		true
-	}
-}
-
-impl sp_std::fmt::Debug for MaxSchemaGrantsPerDelegation {
-	fn fmt(&self, _: &mut sp_std::fmt::Formatter) -> sp_std::fmt::Result {
-		Ok(())
-	}
-}
 pub struct TestAccountId;
 
 impl Convert<u64, AccountId> for TestAccountId {
@@ -152,6 +129,7 @@ impl pallet_msa::Config for Test {
 	type MaxSignaturesStored = ConstU32<8000>;
 }
 
+// Needs parameter_types! for the Perbill
 parameter_types! {
 	pub const TestCapacityPerToken: Perbill = Perbill::from_percent(10);
 }
@@ -169,7 +147,7 @@ impl pallet_capacity::Config for Test {
 	type BenchmarkHelper = Msa;
 
 	type UnstakingThawPeriod = ConstU16<2>;
-	type MaxEpochLength = ConstU64<100>;
+	type MaxEpochLength = ConstU32<100>;
 	type EpochNumber = u32;
 	type CapacityPerToken = TestCapacityPerToken;
 }

--- a/pallets/capacity/src/tests/testing_utils.rs
+++ b/pallets/capacity/src/tests/testing_utils.rs
@@ -18,7 +18,7 @@ pub fn staking_events() -> Vec<Event<Test>> {
 	result
 }
 
-pub fn run_to_block(n: u64) {
+pub fn run_to_block(n: u32) {
 	while System::block_number() < n {
 		if System::block_number() > 1 {
 			System::on_finalize(System::block_number());
@@ -28,8 +28,8 @@ pub fn run_to_block(n: u64) {
 		Capacity::on_initialize(System::block_number());
 	}
 }
-// Remove capacity on_initialize, needed to emulate pre-existing blockheight
-pub fn system_run_to_block(n: u64) {
+// Remove capacity on_initialize, needed to emulate pre-existing block height
+pub fn system_run_to_block(n: u32) {
 	while System::block_number() < n {
 		if System::block_number() > 1 {
 			System::on_finalize(System::block_number());

--- a/pallets/frequency-tx-payment/src/tests/mock.rs
+++ b/pallets/frequency-tx-payment/src/tests/mock.rs
@@ -3,14 +3,13 @@ use crate::*;
 
 use common_primitives::{
 	msa::MessageSourceId,
-	node::{AccountId, ProposalProvider},
+	node::{AccountId, Header, ProposalProvider},
 	schema::{SchemaId, SchemaValidator},
 };
 use frame_system::EnsureSigned;
 use pallet_transaction_payment::CurrencyAdapter;
 use sp_core::{ConstU8, H256};
 use sp_runtime::{
-	testing::Header,
 	traits::{BlakeTwo256, Convert, IdentityLookup, SaturatedConversion},
 	AccountId32, Perbill,
 };
@@ -66,14 +65,14 @@ impl frame_system::Config for Test {
 	type RuntimeOrigin = RuntimeOrigin;
 	type RuntimeCall = RuntimeCall;
 	type Index = u64;
-	type BlockNumber = u64;
+	type BlockNumber = u32;
 	type Hash = H256;
 	type Hashing = BlakeTwo256;
 	type AccountId = u64;
 	type Lookup = IdentityLookup<Self::AccountId>;
 	type Header = Header;
 	type RuntimeEvent = RuntimeEvent;
-	type BlockHashCount = ConstU64<250>;
+	type BlockHashCount = ConstU32<250>;
 	type Version = ();
 	type PalletInfo = PalletInfo;
 	type AccountData = pallet_balances::AccountData<u64>;
@@ -97,28 +96,8 @@ impl pallet_balances::Config for Test {
 	type MaxReserves = ();
 }
 
-parameter_types! {
-	pub const MaxSchemaGrantsPerDelegation: u32 = 30;
-	pub const MaximumCapacityBatchLength: u8 = 2;
-}
-impl Clone for MaxSchemaGrantsPerDelegation {
-	fn clone(&self) -> Self {
-		MaxSchemaGrantsPerDelegation {}
-	}
-}
-impl Eq for MaxSchemaGrantsPerDelegation {
-	fn assert_receiver_is_total_eq(&self) -> () {}
-}
-impl PartialEq for MaxSchemaGrantsPerDelegation {
-	fn eq(&self, _other: &Self) -> bool {
-		true
-	}
-}
-impl sp_std::fmt::Debug for MaxSchemaGrantsPerDelegation {
-	fn fmt(&self, _: &mut sp_std::fmt::Formatter) -> sp_std::fmt::Result {
-		Ok(())
-	}
-}
+pub type MaxSchemaGrantsPerDelegation = ConstU32<30>;
+pub type MaximumCapacityBatchLength = ConstU8<2>;
 
 pub struct TestAccountId;
 impl Convert<u64, AccountId> for TestAccountId {
@@ -177,6 +156,7 @@ impl pallet_msa::Config for Test {
 	type MaxSignaturesStored = ConstU32<8000>;
 }
 
+// Needs parameter_types! for the impls below
 parameter_types! {
 	pub static WeightToFee: u64 = 1;
 	pub static TransactionByteFee: u64 = 1;
@@ -213,6 +193,7 @@ impl pallet_transaction_payment::Config for Test {
 // so the value can be used by create_capacity_for below, without having to pass it a Config.
 pub const TEST_TOKEN_PER_CAPACITY: u32 = 10;
 
+// Needs parameter_types! for the Perbill
 parameter_types! {
 	pub const TestCapacityPerToken: Perbill = Perbill::from_percent(TEST_TOKEN_PER_CAPACITY);
 }
@@ -231,7 +212,7 @@ impl pallet_capacity::Config for Test {
 	type BenchmarkHelper = ();
 
 	type UnstakingThawPeriod = ConstU16<2>;
-	type MaxEpochLength = ConstU64<100>;
+	type MaxEpochLength = ConstU32<100>;
 	type EpochNumber = u32;
 	type CapacityPerToken = TestCapacityPerToken;
 }

--- a/pallets/handles/src/tests/mock.rs
+++ b/pallets/handles/src/tests/mock.rs
@@ -5,16 +5,15 @@ pub use pallet_handles::Call as HandlesCall;
 use common_primitives::{
 	handles::*,
 	msa::{MessageSourceId, MsaLookup, MsaValidator},
-	node::AccountId,
+	node::{AccountId, Header},
 	utils::wrap_binary_data,
 };
 use frame_support::{
 	dispatch::DispatchError,
-	traits::{ConstU16, ConstU32, ConstU64, OnFinalize, OnInitialize},
+	traits::{ConstU16, ConstU32, OnFinalize, OnInitialize},
 };
 use sp_core::{crypto::AccountId32, sr25519, ByteArray, Encode, Pair, H256};
 use sp_runtime::{
-	testing::Header,
 	traits::{BlakeTwo256, ConvertInto, IdentityLookup},
 	MultiSignature,
 };
@@ -70,14 +69,14 @@ impl frame_system::Config for Test {
 	type RuntimeOrigin = RuntimeOrigin;
 	type RuntimeCall = RuntimeCall;
 	type Index = u64;
-	type BlockNumber = u64;
+	type BlockNumber = u32;
 	type Hash = H256;
 	type Hashing = BlakeTwo256;
 	type AccountId = AccountId;
 	type Lookup = IdentityLookup<Self::AccountId>;
 	type Header = Header;
 	type RuntimeEvent = RuntimeEvent;
-	type BlockHashCount = ConstU64<250>;
+	type BlockHashCount = ConstU32<250>;
 	type Version = ();
 	type PalletInfo = PalletInfo;
 	type AccountData = ();
@@ -141,7 +140,7 @@ pub fn test_public(n: u8) -> AccountId32 {
 }
 
 // Run to the given block number
-pub fn run_to_block(n: u64) {
+pub fn run_to_block(n: u32) {
 	while System::block_number() < n {
 		if System::block_number() > 1 {
 			System::on_finalize(System::block_number());
@@ -156,8 +155,8 @@ pub fn run_to_block(n: u64) {
 pub fn get_signed_claims_payload(
 	account: &sr25519::Pair,
 	handle: Vec<u8>,
-	signature_expiration: u64,
-) -> (ClaimHandlePayload<u64>, MultiSignature) {
+	signature_expiration: u32,
+) -> (ClaimHandlePayload<u32>, MultiSignature) {
 	let base_handle = handle;
 	let payload = ClaimHandlePayload::new(base_handle.clone(), signature_expiration);
 	let encoded_payload = wrap_binary_data(payload.encode());

--- a/pallets/messages/src/tests/other_tests.rs
+++ b/pallets/messages/src/tests/other_tests.rs
@@ -10,8 +10,7 @@ use multibase::Base;
 use pretty_assertions::{assert_eq, assert_ne, assert_str_eq};
 use rand::Rng;
 use serde::Serialize;
-use sp_core::ConstU32;
-use sp_core::Get;
+use sp_core::{ConstU32, Get};
 use sp_std::vec::Vec;
 
 #[derive(Serialize)]

--- a/pallets/messages/src/tests/other_tests.rs
+++ b/pallets/messages/src/tests/other_tests.rs
@@ -11,6 +11,7 @@ use pretty_assertions::{assert_eq, assert_ne, assert_str_eq};
 use rand::Rng;
 use serde::Serialize;
 use sp_core::ConstU32;
+use sp_core::Get;
 use sp_std::vec::Vec;
 
 #[derive(Serialize)]
@@ -65,7 +66,7 @@ fn populate_messages(
 			.unwrap();
 			counter += 1;
 		}
-		Messages::<Test>::insert(idx as u64, schema_id, list);
+		Messages::<Test>::insert(idx as u32, schema_id, list);
 	}
 }
 
@@ -346,7 +347,7 @@ fn get_messages_by_schema_with_ipfs_payload_location_should_return_offchain_payl
 fn retrieved_ipfs_message_should_always_be_in_base32() {
 	new_test_ext().execute_with(|| {
 		let schema_id = IPFS_SCHEMA_ID;
-		let current_block: u64 = 1;
+		let current_block: u32 = 1;
 
 		// Populate message storage using Base64-encoded CID
 		populate_messages(schema_id, vec![1], PayloadLocation::IPFS, Some(DUMMY_CID_BASE64));

--- a/pallets/msa/src/lib.rs
+++ b/pallets/msa/src/lib.rs
@@ -124,7 +124,7 @@ pub mod pallet {
 
 		/// Maximum count of schemas granted for publishing data per Provider
 		#[pallet::constant]
-		type MaxSchemaGrantsPerDelegation: Get<u32> + Clone + sp_std::fmt::Debug + Eq;
+		type MaxSchemaGrantsPerDelegation: Get<u32>;
 
 		/// Maximum provider name size allowed per MSA association
 		#[pallet::constant]

--- a/pallets/msa/src/tests/delegation_tests.rs
+++ b/pallets/msa/src/tests/delegation_tests.rs
@@ -105,16 +105,16 @@ pub fn grant_delegation_changes_schema_permissions() {
 			add_provider_payload
 		));
 
-		let mut sp = BoundedBTreeMap::<SchemaId, u64, MaxSchemaGrantsPerDelegation>::new();
-		assert_ok!(sp.try_insert(1u16, 0u64));
-		assert_ok!(sp.try_insert(2u16, 0u64));
-		assert_ok!(sp.try_insert(3u16, 0u64));
+		let mut sp = BoundedBTreeMap::<SchemaId, u32, MaxSchemaGrantsPerDelegation>::new();
+		assert_ok!(sp.try_insert(1u16, 0u32));
+		assert_ok!(sp.try_insert(2u16, 0u32));
+		assert_ok!(sp.try_insert(3u16, 0u32));
 
-		let expected = Delegation { revoked_at: 0, schema_permissions: sp };
+		let expected = Delegation { revoked_at: 0u32, schema_permissions: sp };
 
 		assert_eq!(Msa::get_delegation(delegator, provider), Some(expected));
 
-		let revoked_block_number: u64 = 100;
+		let revoked_block_number: u32 = 100;
 		System::set_block_number(revoked_block_number);
 		// Revoke all schema ids.
 		let (delegator_signature, add_provider_payload) =
@@ -132,7 +132,7 @@ pub fn grant_delegation_changes_schema_permissions() {
 			add_provider_payload
 		));
 
-		let mut sp = BoundedBTreeMap::<SchemaId, u64, MaxSchemaGrantsPerDelegation>::new();
+		let mut sp = BoundedBTreeMap::<SchemaId, u32, MaxSchemaGrantsPerDelegation>::new();
 		assert_ok!(sp.try_insert(1u16, revoked_block_number)); // schema id 1 revoked at revoked_block_number
 		assert_ok!(sp.try_insert(2u16, revoked_block_number)); // schema id 2 revoked at revoked_block_number
 		assert_ok!(sp.try_insert(3u16, revoked_block_number)); // schema id 3 revoked at revoked_block_number
@@ -158,11 +158,11 @@ pub fn grant_delegation_changes_schema_permissions() {
 			add_provider_payload
 		));
 
-		let mut sp = BoundedBTreeMap::<SchemaId, u64, MaxSchemaGrantsPerDelegation>::new();
-		assert_ok!(sp.try_insert(1u16, 100u64)); // schema id 1 revoked at block 100
-		assert_ok!(sp.try_insert(2u16, 0u64)); // schema id 2 granted (block 0)
-		assert_ok!(sp.try_insert(3u16, 0u64)); // schema id 3 granted (block 0)
-		assert_ok!(sp.try_insert(4u16, 0u64)); // schema id 4 granted (block 0)
+		let mut sp = BoundedBTreeMap::<SchemaId, u32, MaxSchemaGrantsPerDelegation>::new();
+		assert_ok!(sp.try_insert(1u16, 100u32)); // schema id 1 revoked at block 100
+		assert_ok!(sp.try_insert(2u16, 0u32)); // schema id 2 granted (block 0)
+		assert_ok!(sp.try_insert(3u16, 0u32)); // schema id 3 granted (block 0)
+		assert_ok!(sp.try_insert(4u16, 0u32)); // schema id 4 granted (block 0)
 
 		let expected = Delegation { revoked_at: 0, schema_permissions: sp };
 		assert_eq!(Msa::get_delegation(delegator, provider), Some(expected));

--- a/pallets/msa/src/tests/mock.rs
+++ b/pallets/msa/src/tests/mock.rs
@@ -1,18 +1,20 @@
 use crate::{self as pallet_msa, types::EMPTY_FUNCTION, AddProvider};
 use common_primitives::{
-	msa::MessageSourceId, node::BlockNumber, schema::SchemaId, utils::wrap_binary_data,
+	msa::MessageSourceId,
+	node::{BlockNumber, Header},
+	schema::SchemaId,
+	utils::wrap_binary_data,
 };
 use frame_support::{
 	assert_ok,
 	dispatch::DispatchError,
 	parameter_types,
-	traits::{ConstU16, ConstU32, ConstU64, EitherOfDiverse, OnFinalize, OnInitialize},
+	traits::{ConstU16, ConstU32, EitherOfDiverse, OnFinalize, OnInitialize},
 };
 use frame_system::EnsureRoot;
 use pallet_collective;
 use sp_core::{sr25519, sr25519::Public, Encode, Pair, H256};
 use sp_runtime::{
-	testing::Header,
 	traits::{BlakeTwo256, ConvertInto, IdentityLookup},
 	AccountId32, MultiSignature,
 };
@@ -63,14 +65,14 @@ impl frame_system::Config for Test {
 	type RuntimeOrigin = RuntimeOrigin;
 	type RuntimeCall = RuntimeCall;
 	type Index = u64;
-	type BlockNumber = u64;
+	type BlockNumber = u32;
 	type Hash = H256;
 	type Hashing = BlakeTwo256;
 	type AccountId = AccountId;
 	type Lookup = IdentityLookup<Self::AccountId>;
 	type Header = Header;
 	type RuntimeEvent = RuntimeEvent;
-	type BlockHashCount = ConstU64<250>;
+	type BlockHashCount = ConstU32<250>;
 	type Version = ();
 	type PalletInfo = PalletInfo;
 	type AccountData = ();
@@ -127,35 +129,15 @@ impl pallet_handles::Config for Test {
 	type MsaBenchmarkHelper = ();
 }
 
+// Needs parameter_types! for the Option and statics
 parameter_types! {
 	pub static MaxPublicKeysPerMsa: u8 = 255;
-	pub const MaxProviderNameSize: u32 = 16;
-	pub const MaxSchemas: u32 = 5;
-	pub const MaxSchemaGrantsPerDelegation: u32 = 30;
 	pub static MaxSignaturesStored: Option<u32> = Some(8000);
 }
+pub type MaxProviderNameSize = ConstU32<16>;
+pub type MaxSchemas = ConstU32<5>;
+pub type MaxSchemaGrantsPerDelegation = ConstU32<30>;
 
-impl Clone for MaxSchemaGrantsPerDelegation {
-	fn clone(&self) -> Self {
-		MaxSchemaGrantsPerDelegation {}
-	}
-}
-
-impl Eq for MaxSchemaGrantsPerDelegation {
-	fn assert_receiver_is_total_eq(&self) -> () {}
-}
-
-impl PartialEq for MaxSchemaGrantsPerDelegation {
-	fn eq(&self, _other: &Self) -> bool {
-		true
-	}
-}
-
-impl sp_std::fmt::Debug for MaxSchemaGrantsPerDelegation {
-	fn fmt(&self, _: &mut sp_std::fmt::Formatter) -> sp_std::fmt::Result {
-		Ok(())
-	}
-}
 /// Interface to collective pallet to propose a proposal.
 pub struct CouncilProposalProvider;
 
@@ -224,7 +206,7 @@ pub fn new_test_ext() -> sp_io::TestExternalities {
 	ext
 }
 
-pub fn run_to_block(n: u64) {
+pub fn run_to_block(n: u32) {
 	while System::block_number() < n {
 		if System::block_number() > 1 {
 			System::on_finalize(System::block_number());

--- a/pallets/msa/src/tests/mock.rs
+++ b/pallets/msa/src/tests/mock.rs
@@ -135,7 +135,6 @@ parameter_types! {
 	pub static MaxSignaturesStored: Option<u32> = Some(8000);
 }
 pub type MaxProviderNameSize = ConstU32<16>;
-pub type MaxSchemas = ConstU32<5>;
 pub type MaxSchemaGrantsPerDelegation = ConstU32<30>;
 
 /// Interface to collective pallet to propose a proposal.

--- a/pallets/msa/src/tests/other_tests.rs
+++ b/pallets/msa/src/tests/other_tests.rs
@@ -400,7 +400,7 @@ pub fn valid_schema_grant() {
 
 		System::set_block_number(System::block_number() + 1);
 
-		assert_ok!(Msa::ensure_valid_schema_grant(provider, delegator, 2u16, 1u64));
+		assert_ok!(Msa::ensure_valid_schema_grant(provider, delegator, 2u16, 1u32));
 	})
 }
 

--- a/pallets/msa/src/tests/replay_tests.rs
+++ b/pallets/msa/src/tests/replay_tests.rs
@@ -180,9 +180,9 @@ fn replaying_grant_delegation_fails() {
 #[test]
 pub fn add_signature_replay_boundary_checks() {
 	struct TestCase {
-		current: u64,
-		mortality: u64,
-		run_to: u64,
+		current: u32,
+		mortality: u32,
+		run_to: u32,
 	}
 	new_test_ext().execute_with(|| {
 		// This tests signature replay attacks for mortality window size = 100 and 2 buckets,
@@ -192,21 +192,21 @@ pub fn add_signature_replay_boundary_checks() {
 		// checking explicitly for the error `SignatureAlreadySubmitted`.
 		let test_cases: Vec<TestCase> = vec![
 			// 1-block expiration for bucket 0, mortality crosses no boundary
-			TestCase { current: 1u64, mortality: 3u64, run_to: 2u64 },
+			TestCase { current: 1u32, mortality: 3u32, run_to: 2u32 },
 			// expiration for bucket 1, mortality is fast, crosses a 100-block boundary, we check at the boundary.
 			// at block 100, on_initialize's bucket-clearing has happened by the time register_extrinsic is called,
 			// so this should make sure that the signature is still there and the wrong bucket was not cleared.
-			TestCase { current: 99u64, mortality: 101u64, run_to: 100u64 },
+			TestCase { current: 99u32, mortality: 101u32, run_to: 100u32 },
 			// This does the same as above, only it's a different bucket.
-			TestCase { current: 11_149u64, mortality: 11_201u64, run_to: 11_200u64 },
+			TestCase { current: 11_149u32, mortality: 11_201u32, run_to: 11_200u32 },
 			// This sets mortality at a boundary
-			TestCase { current: 11_149u64, mortality: 11_200u64, run_to: 11_199u64 },
+			TestCase { current: 11_149u32, mortality: 11_200u32, run_to: 11_199u32 },
 			// This does the same as above, but for a different bucket.
-			TestCase { current: 11_249u64, mortality: 11_300u64, run_to: 11_299u64 },
+			TestCase { current: 11_249u32, mortality: 11_300u32, run_to: 11_299u32 },
 			// This case sets current block at a boundary, and sets the mortality to the very last block before the boundary
-			TestCase { current: 1_100u64, mortality: 1_199u64, run_to: 1_198u64 },
+			TestCase { current: 1_100u32, mortality: 1_199u32, run_to: 1_198u32 },
 			// This case has current block right before a boundary, and sets expiration to the very last possible block
-			TestCase { current: 1_699u64, mortality: 1_798u64, run_to: 1_797u64 },
+			TestCase { current: 1_699u32, mortality: 1_798u32, run_to: 1_797u32 },
 		];
 		for tc in test_cases {
 			System::set_block_number(tc.current);

--- a/pallets/msa/src/tests/schema_permission_tests.rs
+++ b/pallets/msa/src/tests/schema_permission_tests.rs
@@ -244,12 +244,12 @@ fn schema_permissions_trait_impl_try_get_mut_schema_success() {
 			&mut delegation,
 			schema_id
 		));
-		let default_block_number = 0u64;
+		let default_block_number = 0u32;
 
 		assert_eq!(delegation.schema_permissions.len(), 1);
 		assert_eq!(delegation.schema_permissions.get(&schema_id).unwrap(), &default_block_number);
 
-		let revoked_block_number = 2u64;
+		let revoked_block_number = 2u32;
 
 		assert_ok!(PermittedDelegationSchemas::<Test>::try_get_mut_schema(
 			&mut delegation,
@@ -273,7 +273,7 @@ pub fn ensure_valid_schema_grant_success() {
 
 		System::set_block_number(System::block_number() + 1);
 
-		assert_ok!(Msa::ensure_valid_schema_grant(provider, delegator, 1_u16, 1u64));
+		assert_ok!(Msa::ensure_valid_schema_grant(provider, delegator, 1_u16, 1u32));
 	})
 }
 
@@ -294,7 +294,7 @@ pub fn ensure_valid_schema_grant_errors_when_delegation_relationship_is_valid_an
 		System::set_block_number(System::block_number() + 1);
 
 		assert_err!(
-			Msa::ensure_valid_schema_grant(provider, delegator, 3_u16, 1u64),
+			Msa::ensure_valid_schema_grant(provider, delegator, 3_u16, 1u32),
 			Error::<Test>::SchemaNotGranted
 		);
 	})

--- a/pallets/msa/src/tests/signature_registry_tests.rs
+++ b/pallets/msa/src/tests/signature_registry_tests.rs
@@ -43,7 +43,7 @@ pub fn cannot_register_too_many_signatures() {
 #[test]
 pub fn stores_signature_and_increments_count() {
 	new_test_ext().execute_with(|| {
-		System::set_block_number(1 as u64);
+		System::set_block_number(1);
 		let mortality_block: BlockNumber = 51;
 		let signature = generate_test_signature();
 		assert_ok!(Msa::register_signature(&signature, mortality_block.into()));
@@ -162,9 +162,9 @@ pub fn cannot_register_signature_with_mortality_out_of_bounds() {
 }
 
 struct TestCase {
-	current: u64,
-	mortality: u64,
-	run_to: u64,
+	current: u32,
+	mortality: u32,
+	run_to: u32,
 	expected_ok: bool,
 }
 
@@ -174,35 +174,35 @@ pub fn add_msa_key_replay_fails() {
 		// these should all fail replay
 		let test_cases: Vec<TestCase> = vec![
 			TestCase {
-				current: 10_949u64,
-				mortality: 11_001u64,
-				run_to: 10_848u64,
+				current: 10_949u32,
+				mortality: 11_001u32,
+				run_to: 10_848u32,
 				expected_ok: true,
 			},
-			TestCase { current: 1u64, mortality: 3u64, run_to: 5u64, expected_ok: false },
-			TestCase { current: 99u64, mortality: 101u64, run_to: 100u64, expected_ok: true },
+			TestCase { current: 1u32, mortality: 3u32, run_to: 5u32, expected_ok: false },
+			TestCase { current: 99u32, mortality: 101u32, run_to: 100u32, expected_ok: true },
 			TestCase {
-				current: 1_100u64,
-				mortality: 1_199u64,
-				run_to: 1_198u64,
-				expected_ok: true,
-			},
-			TestCase {
-				current: 1_102u64,
-				mortality: 1_201u64,
-				run_to: 1_200u64,
+				current: 1_100u32,
+				mortality: 1_199u32,
+				run_to: 1_198u32,
 				expected_ok: true,
 			},
 			TestCase {
-				current: 1_099u64,
-				mortality: 1_148u64,
-				run_to: 1_101u64,
+				current: 1_102u32,
+				mortality: 1_201u32,
+				run_to: 1_200u32,
 				expected_ok: true,
 			},
 			TestCase {
-				current: 1_000_000u64,
-				mortality: 1_000_000u64,
-				run_to: 1_000_000u64,
+				current: 1_099u32,
+				mortality: 1_148u32,
+				run_to: 1_101u32,
+				expected_ok: true,
+			},
+			TestCase {
+				current: 1_000_000u32,
+				mortality: 1_000_000u32,
+				run_to: 1_000_000u32,
 				expected_ok: false,
 			},
 		];

--- a/pallets/schemas/src/tests/mock.rs
+++ b/pallets/schemas/src/tests/mock.rs
@@ -1,18 +1,16 @@
 use frame_support::{
 	dispatch::DispatchError,
-	parameter_types,
-	traits::{ConstU16, ConstU32, ConstU64, EitherOfDiverse},
+	traits::{ConstU16, ConstU32, EitherOfDiverse},
 	weights::{WeightToFeeCoefficient, WeightToFeeCoefficients, WeightToFeePolynomial},
 };
 use frame_system::EnsureRoot;
 
-use common_primitives::{node::AccountId, schema::SchemaId};
+use common_primitives::node::{AccountId, Header};
 pub use common_runtime::constants::*;
 use pallet_collective;
 use smallvec::smallvec;
 use sp_core::{Encode, H256};
 use sp_runtime::{
-	testing::Header,
 	traits::{BlakeTwo256, IdentityLookup},
 	AccountId32, Perbill,
 };
@@ -48,9 +46,7 @@ impl pallet_collective::Config<CouncilCollective> for Test {
 	type WeightInfo = ();
 }
 
-parameter_types! {
-	pub const MaxSchemaRegistrations: SchemaId = 64_000;
-}
+pub type MaxSchemaRegistrations = ConstU16<64_000>;
 
 pub struct WeightToFee;
 
@@ -125,14 +121,14 @@ impl frame_system::Config for Test {
 	type DbWeight = ();
 	type RuntimeOrigin = RuntimeOrigin;
 	type Index = u64;
-	type BlockNumber = u64;
+	type BlockNumber = u32;
 	type Hash = H256;
 	type Hashing = BlakeTwo256;
 	type AccountId = AccountId;
 	type Lookup = IdentityLookup<AccountId>;
 	type Header = Header;
 	type RuntimeEvent = RuntimeEvent;
-	type BlockHashCount = ConstU64<250>;
+	type BlockHashCount = ConstU32<250>;
 	type Version = ();
 	type PalletInfo = PalletInfo;
 	type OnNewAccount = ();

--- a/pallets/stateful-storage/src/lib.rs
+++ b/pallets/stateful-storage/src/lib.rs
@@ -120,7 +120,7 @@ pub mod pallet {
 
 		/// The maximum number of pages in a Paginated storage model
 		#[pallet::constant]
-		type MaxPaginatedPageId: Get<u32>;
+		type MaxPaginatedPageId: Get<u16>;
 
 		/// The maximum number of actions in itemized actions
 		#[pallet::constant]
@@ -291,10 +291,7 @@ pub mod pallet {
 			payload: BoundedVec<u8, <T>::MaxPaginatedPageSizeBytes>,
 		) -> DispatchResult {
 			let provider_key = ensure_signed(origin)?;
-			ensure!(
-				page_id as u32 <= T::MaxPaginatedPageId::get(),
-				Error::<T>::PageIdExceedsMaxAllowed
-			);
+			ensure!(page_id <= T::MaxPaginatedPageId::get(), Error::<T>::PageIdExceedsMaxAllowed);
 			Self::check_schema_for_write(schema_id, PayloadLocation::Paginated, false, false)?;
 			Self::check_msa_and_grants(provider_key, state_owner_msa_id, schema_id)?;
 			Self::update_paginated(
@@ -322,10 +319,7 @@ pub mod pallet {
 			#[pallet::compact] target_hash: PageHash,
 		) -> DispatchResult {
 			let provider_key = ensure_signed(origin)?;
-			ensure!(
-				page_id as u32 <= T::MaxPaginatedPageId::get(),
-				Error::<T>::PageIdExceedsMaxAllowed
-			);
+			ensure!(page_id <= T::MaxPaginatedPageId::get(), Error::<T>::PageIdExceedsMaxAllowed);
 			Self::check_schema_for_write(schema_id, PayloadLocation::Paginated, false, true)?;
 			Self::check_msa_and_grants(provider_key, state_owner_msa_id, schema_id)?;
 			Self::delete_paginated(state_owner_msa_id, schema_id, page_id, target_hash)?;
@@ -390,7 +384,7 @@ pub mod pallet {
 		) -> DispatchResult {
 			ensure_signed(origin)?;
 			ensure!(
-				payload.page_id as u32 <= T::MaxPaginatedPageId::get(),
+				payload.page_id <= T::MaxPaginatedPageId::get(),
 				Error::<T>::PageIdExceedsMaxAllowed
 			);
 			Self::check_payload_expiration(
@@ -431,7 +425,7 @@ pub mod pallet {
 		) -> DispatchResult {
 			ensure_signed(origin)?;
 			ensure!(
-				payload.page_id as u32 <= T::MaxPaginatedPageId::get(),
+				payload.page_id <= T::MaxPaginatedPageId::get(),
 				Error::<T>::PageIdExceedsMaxAllowed
 			);
 			Self::check_payload_expiration(

--- a/pallets/stateful-storage/src/tests/apply_item_actions_tests.rs
+++ b/pallets/stateful-storage/src/tests/apply_item_actions_tests.rs
@@ -13,7 +13,7 @@ use common_primitives::{
 use frame_support::{assert_err, assert_ok, BoundedVec};
 #[allow(unused_imports)]
 use pretty_assertions::{assert_eq, assert_ne, assert_str_eq};
-use sp_core::{sr25519, Pair};
+use sp_core::{sr25519, Get, Pair};
 use sp_runtime::MultiSignature;
 
 #[test]
@@ -383,11 +383,12 @@ fn apply_item_actions_with_signature_having_too_far_expiration_should_fail() {
 		let schema_id = ITEMIZED_SCHEMA;
 		let payload = vec![1; 5];
 		let actions = vec![ItemAction::Add { data: payload.try_into().unwrap() }];
+		let mortality_window: u32 = <Test as Config>::MortalityWindowSize::get();
 		let payload = ItemizedSignaturePayload {
 			actions: BoundedVec::try_from(actions).unwrap(),
 			target_hash: PageHash::default(),
 			msa_id,
-			expiration: (<Test as Config>::MortalityWindowSize::get() + 1).into(),
+			expiration: (mortality_window + 1).into(),
 			schema_id,
 		};
 		let encode_data_new_key_data = wrap_binary_data(payload.encode());

--- a/pallets/stateful-storage/src/tests/delete_page_tests.rs
+++ b/pallets/stateful-storage/src/tests/delete_page_tests.rs
@@ -10,7 +10,7 @@ use common_primitives::{stateful_storage::PageHash, utils::wrap_binary_data};
 use frame_support::{assert_err, assert_ok, assert_storage_noop};
 #[allow(unused_imports)]
 use pretty_assertions::{assert_eq, assert_ne, assert_str_eq};
-use sp_core::{sr25519, Pair};
+use sp_core::{sr25519, Get, Pair};
 use sp_runtime::MultiSignature;
 
 #[test]
@@ -27,7 +27,7 @@ fn delete_page_id_out_of_bounds_errors() {
 				RuntimeOrigin::signed(caller_1),
 				msa_id,
 				schema_id,
-				page_id,
+				page_id.into(),
 				NONEXISTENT_PAGE_HASH,
 			),
 			Error::<Test>::PageIdExceedsMaxAllowed
@@ -288,10 +288,11 @@ fn delete_page_with_signature_having_out_of_window_payload_should_fail() {
 		let delegator_key = pair.public();
 		let schema_id = UNDELEGATED_PAGINATED_SCHEMA;
 		let page_id = 1;
+		let mortality_window: u32 = <Test as Config>::MortalityWindowSize::get();
 		let payload = PaginatedDeleteSignaturePayload {
 			target_hash: PageHash::default(),
 			msa_id,
-			expiration: (<Test as Config>::MortalityWindowSize::get() + 1).into(),
+			expiration: (mortality_window + 1).into(),
 			schema_id,
 			page_id,
 		};

--- a/pallets/stateful-storage/src/tests/mock.rs
+++ b/pallets/stateful-storage/src/tests/mock.rs
@@ -10,20 +10,18 @@ use common_primitives::{
 		Delegation, DelegationValidator, DelegatorId, MessageSourceId, MsaLookup, MsaValidator,
 		ProviderId, ProviderLookup, SchemaGrantValidator,
 	},
-	node::AccountId,
+	node::{AccountId, Header},
 	schema::{ModelType, PayloadLocation, SchemaId, SchemaProvider, SchemaResponse, SchemaSetting},
-	stateful_storage::PageId,
 };
 use frame_support::{
 	dispatch::DispatchResult,
 	parameter_types,
-	traits::{ConstU16, ConstU64},
+	traits::{ConstU16, ConstU32},
 	Twox128,
 };
 use frame_system as system;
 use sp_core::{crypto::AccountId32, sr25519, ByteArray, Pair, H256};
 use sp_runtime::{
-	testing::Header,
 	traits::{BlakeTwo256, ConvertInto, IdentityLookup},
 	DispatchError,
 };
@@ -55,14 +53,14 @@ impl system::Config for Test {
 	type RuntimeOrigin = RuntimeOrigin;
 	type RuntimeCall = RuntimeCall;
 	type Index = u64;
-	type BlockNumber = u64;
+	type BlockNumber = u32;
 	type Hash = H256;
 	type Hashing = BlakeTwo256;
 	type AccountId = AccountId;
 	type Lookup = IdentityLookup<Self::AccountId>;
 	type Header = Header;
 	type RuntimeEvent = RuntimeEvent;
-	type BlockHashCount = ConstU64<250>;
+	type BlockHashCount = ConstU32<250>;
 	type Version = ();
 	type PalletInfo = PalletInfo;
 	type AccountData = ();
@@ -74,15 +72,16 @@ impl system::Config for Test {
 	type MaxConsumers = frame_support::traits::ConstU32<16>;
 }
 
+pub type MaxItemizedActionsCount = ConstU32<6>;
+pub type MaxSchemaGrantsPerDelegation = ConstU32<30>;
+pub type StatefulMortalityWindowSize = ConstU32<10>;
+
+// Needs parameter_types! for the impls below
 parameter_types! {
 	pub const MaxItemizedPageSizeBytes: u32 = 1024;
-	pub const MaxPaginatedPageSizeBytes: u32 = 1024;
 	pub const MaxItemizedBlobSizeBytes: u32 = 64;
-	pub const MaxPaginatedPageId: PageId = 32;
-	pub const MaxItemizedActionsCount: u32 = 6;
-
-	pub const MaxSchemaGrantsPerDelegation: u32 = 30;
-	pub const StatefulMortalityWindowSize: u32 = 10;
+	pub const MaxPaginatedPageSizeBytes: u32 = 1024;
+	pub const MaxPaginatedPageId: u16 = 32;
 }
 
 impl Default for MaxItemizedPageSizeBytes {
@@ -141,7 +140,7 @@ impl MsaValidator for MsaInfoHandler {
 }
 
 impl ProviderLookup for DelegationInfoHandler {
-	type BlockNumber = u64;
+	type BlockNumber = u32;
 	type MaxSchemaGrantsPerDelegation = MaxSchemaGrantsPerDelegation;
 	type SchemaId = SchemaId;
 
@@ -156,7 +155,7 @@ impl ProviderLookup for DelegationInfoHandler {
 	}
 }
 impl DelegationValidator for DelegationInfoHandler {
-	type BlockNumber = u64;
+	type BlockNumber = u32;
 	type MaxSchemaGrantsPerDelegation = MaxSchemaGrantsPerDelegation;
 	type SchemaId = SchemaId;
 
@@ -342,28 +341,6 @@ impl PartialEq for MaxItemizedBlobSizeBytes {
 }
 
 impl sp_std::fmt::Debug for MaxItemizedBlobSizeBytes {
-	fn fmt(&self, _: &mut sp_std::fmt::Formatter) -> sp_std::fmt::Result {
-		Ok(())
-	}
-}
-
-impl Clone for MaxSchemaGrantsPerDelegation {
-	fn clone(&self) -> Self {
-		MaxSchemaGrantsPerDelegation {}
-	}
-}
-
-impl Eq for MaxSchemaGrantsPerDelegation {
-	fn assert_receiver_is_total_eq(&self) -> () {}
-}
-
-impl PartialEq for MaxSchemaGrantsPerDelegation {
-	fn eq(&self, _other: &Self) -> bool {
-		true
-	}
-}
-
-impl sp_std::fmt::Debug for MaxSchemaGrantsPerDelegation {
 	fn fmt(&self, _: &mut sp_std::fmt::Formatter) -> sp_std::fmt::Result {
 		Ok(())
 	}

--- a/pallets/stateful-storage/src/tests/upsert_page_tests.rs
+++ b/pallets/stateful-storage/src/tests/upsert_page_tests.rs
@@ -14,7 +14,7 @@ use common_primitives::{
 use frame_support::{assert_err, assert_ok};
 #[allow(unused_imports)]
 use pretty_assertions::{assert_eq, assert_ne, assert_str_eq};
-use sp_core::{sr25519, Pair};
+use sp_core::{sr25519, Get, Pair};
 use sp_runtime::MultiSignature;
 use sp_std::hash::Hasher;
 use twox_hash::XxHash64;
@@ -42,7 +42,7 @@ fn upsert_page_id_out_of_bounds_errors() {
 				RuntimeOrigin::signed(caller_1),
 				msa_id.into(),
 				schema_id,
-				page_id,
+				page_id.into(),
 				hash_payload(&payload),
 				payload
 			),
@@ -373,11 +373,12 @@ fn upsert_page_with_signature_having_out_of_window_payload_should_fail() {
 		let schema_id = UNDELEGATED_PAGINATED_SCHEMA;
 		let page_id = 1;
 		let payload = generate_payload_bytes::<PaginatedPageSize>(Some(100));
+		let mortality_window: u32 = <Test as Config>::MortalityWindowSize::get();
 		let payload = PaginatedUpsertSignaturePayload {
 			payload,
 			target_hash: PageHash::default(),
 			msa_id,
-			expiration: (<Test as Config>::MortalityWindowSize::get() + 1).into(),
+			expiration: (mortality_window + 1).into(),
 			schema_id,
 			page_id,
 		};

--- a/pallets/time-release/Cargo.toml
+++ b/pallets/time-release/Cargo.toml
@@ -10,20 +10,25 @@ publish = false
 version = "0.0.0"
 
 [dependencies]
-codec = { package = "parity-scale-codec", version = "3.0.0", default-features = false, features = ["max-encoded-len"] }
-scale-info = { version = "2.1.2", default-features = false, features = ["derive"] }
+codec = { package = "parity-scale-codec", version = "3.0.0", default-features = false, features = [
+	"max-encoded-len",
+] }
+scale-info = { version = "2.1.2", default-features = false, features = [
+	"derive",
+] }
 
-frame-support = { git = "https://github.com/paritytech/substrate", default-features = false , branch = "polkadot-v0.9.36" }
-frame-system = { git = "https://github.com/paritytech/substrate", default-features = false , branch = "polkadot-v0.9.36" }
-sp-io = { git = "https://github.com/paritytech/substrate", default-features = false , branch = "polkadot-v0.9.36" }
-sp-runtime = { git = "https://github.com/paritytech/substrate", default-features = false , branch = "polkadot-v0.9.36" }
-sp-std = { git = "https://github.com/paritytech/substrate", default-features = false , branch = "polkadot-v0.9.36" }
+frame-support = { git = "https://github.com/paritytech/substrate", default-features = false, branch = "polkadot-v0.9.36" }
+frame-system = { git = "https://github.com/paritytech/substrate", default-features = false, branch = "polkadot-v0.9.36" }
+sp-io = { git = "https://github.com/paritytech/substrate", default-features = false, branch = "polkadot-v0.9.36" }
+sp-runtime = { git = "https://github.com/paritytech/substrate", default-features = false, branch = "polkadot-v0.9.36" }
+sp-std = { git = "https://github.com/paritytech/substrate", default-features = false, branch = "polkadot-v0.9.36" }
 frame-benchmarking = { default-features = false, git = "https://github.com/paritytech/substrate", optional = true, branch = "polkadot-v0.9.36" }
 
 [dev-dependencies]
 chrono = { version = "0.4.24" }
 pallet-balances = { git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.36" }
 sp-core = { git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.36" }
+common-primitives = { default-features = false, path = "../../common/primitives" }
 
 [features]
 default = ["std"]
@@ -36,14 +41,13 @@ std = [
 	"sp-runtime/std",
 	"sp-std/std",
 	"frame-benchmarking/std",
+	"common-primitives/std",
 ]
 runtime-benchmarks = [
 	"frame-support/runtime-benchmarks",
 	"frame-system/runtime-benchmarks",
 	"sp-runtime/runtime-benchmarks",
 	"frame-benchmarking/runtime-benchmarks",
+	"common-primitives/runtime-benchmarks",
 ]
-try-runtime = [
-	"frame-support/try-runtime",
-	"frame-system/try-runtime",
-]
+try-runtime = ["frame-support/try-runtime", "frame-system/try-runtime"]

--- a/pallets/time-release/src/mock.rs
+++ b/pallets/time-release/src/mock.rs
@@ -1,13 +1,14 @@
 //! Mocks for the Time-release module.
 
 use super::*;
+use common_primitives::node::Header;
 use frame_support::{
 	construct_runtime, parameter_types,
 	traits::{ConstU32, ConstU64, EnsureOrigin, Everything},
 };
 use frame_system::RawOrigin;
 use sp_core::H256;
-use sp_runtime::{testing::Header, traits::IdentityLookup};
+use sp_runtime::traits::IdentityLookup;
 
 use crate as pallet_time_release;
 
@@ -16,14 +17,14 @@ impl frame_system::Config for Test {
 	type RuntimeOrigin = RuntimeOrigin;
 	type RuntimeCall = RuntimeCall;
 	type Index = u64;
-	type BlockNumber = u64;
+	type BlockNumber = u32;
 	type Hash = H256;
 	type Hashing = ::sp_runtime::traits::BlakeTwo256;
 	type AccountId = AccountId;
 	type Lookup = IdentityLookup<Self::AccountId>;
 	type Header = Header;
 	type RuntimeEvent = RuntimeEvent;
-	type BlockHashCount = ConstU64<250>;
+	type BlockHashCount = ConstU32<250>;
 	type BlockWeights = ();
 	type BlockLength = ();
 	type Version = ();
@@ -75,12 +76,13 @@ impl EnsureOrigin<RuntimeOrigin> for EnsureAliceOrBob {
 	}
 }
 
+// Needs parameter_types! for the impls below
 parameter_types! {
-	pub static MockBlockNumberProvider: u64 = 0;
+	pub static MockBlockNumberProvider: u32 = 0;
 }
 
 impl BlockNumberProvider for MockBlockNumberProvider {
-	type BlockNumber = u64;
+	type BlockNumber = u32;
 
 	fn current_block_number() -> Self::BlockNumber {
 		Self::get()

--- a/pallets/time-release/src/tests.rs
+++ b/pallets/time-release/src/tests.rs
@@ -22,10 +22,10 @@ fn time_release_from_chain_spec_works() {
 		assert_eq!(
 			TimeRelease::release_schedules(&CHARLIE),
 			vec![
-				ReleaseSchedule { start: 2u64, period: 3u64, period_count: 1u32, per_period: 5u64 },
+				ReleaseSchedule { start: 2u32, period: 3u32, period_count: 1u32, per_period: 5u64 },
 				ReleaseSchedule {
-					start: 2u64 + 3u64,
-					period: 3u64,
+					start: 2u32 + 3u32,
+					period: 3u32,
 					period_count: 3u32,
 					per_period: 5u64,
 				}
@@ -53,7 +53,7 @@ fn transfer_works() {
 		System::set_block_number(1);
 
 		let schedule =
-			ReleaseSchedule { start: 0u64, period: 10u64, period_count: 1u32, per_period: 100u64 };
+			ReleaseSchedule { start: 0u32, period: 10u32, period_count: 1u32, per_period: 100u64 };
 		assert_ok!(TimeRelease::transfer(RuntimeOrigin::signed(ALICE), BOB, schedule.clone()));
 		assert_eq!(TimeRelease::release_schedules(&BOB), vec![schedule.clone()]);
 		System::assert_last_event(RuntimeEvent::TimeRelease(crate::Event::ReleaseScheduleAdded {
@@ -70,17 +70,17 @@ fn self_releasing() {
 		System::set_block_number(1);
 
 		let schedule = ReleaseSchedule {
-			start: 0u64,
-			period: 10u64,
+			start: 0u32,
+			period: 10u32,
 			period_count: 1u32,
 			per_period: ALICE_BALANCE,
 		};
 
 		let bad_schedule = ReleaseSchedule {
-			start: 0u64,
-			period: 10u64,
+			start: 0u32,
+			period: 10u32,
 			period_count: 1u32,
-			per_period: 10 * ALICE_BALANCE,
+			per_period: 64 * ALICE_BALANCE,
 		};
 
 		assert_noop!(
@@ -103,13 +103,13 @@ fn self_releasing() {
 fn add_new_release_schedule_merges_with_current_locked_balance_and_until() {
 	ExtBuilder::build().execute_with(|| {
 		let schedule =
-			ReleaseSchedule { start: 0u64, period: 10u64, period_count: 2u32, per_period: 10u64 };
+			ReleaseSchedule { start: 0u32, period: 10u32, period_count: 2u32, per_period: 10u64 };
 		assert_ok!(TimeRelease::transfer(RuntimeOrigin::signed(ALICE), BOB, schedule));
 
 		MockBlockNumberProvider::set(12);
 
 		let another_schedule =
-			ReleaseSchedule { start: 10u64, period: 13u64, period_count: 1u32, per_period: 7u64 };
+			ReleaseSchedule { start: 10u32, period: 13u32, period_count: 1u32, per_period: 7u64 };
 		assert_ok!(TimeRelease::transfer(RuntimeOrigin::signed(ALICE), BOB, another_schedule));
 
 		assert_eq!(
@@ -123,7 +123,7 @@ fn add_new_release_schedule_merges_with_current_locked_balance_and_until() {
 fn cannot_use_fund_if_not_claimed() {
 	ExtBuilder::build().execute_with(|| {
 		let schedule =
-			ReleaseSchedule { start: 10u64, period: 10u64, period_count: 1u32, per_period: 50u64 };
+			ReleaseSchedule { start: 10u32, period: 10u32, period_count: 1u32, per_period: 50u64 };
 		assert_ok!(TimeRelease::transfer(RuntimeOrigin::signed(ALICE), BOB, schedule));
 		assert!(
 			PalletBalances::ensure_can_withdraw(&BOB, 1, WithdrawReasons::TRANSFER, 49).is_err()
@@ -135,14 +135,14 @@ fn cannot_use_fund_if_not_claimed() {
 fn transfer_fails_if_zero_period_or_count() {
 	ExtBuilder::build().execute_with(|| {
 		let schedule =
-			ReleaseSchedule { start: 1u64, period: 0u64, period_count: 1u32, per_period: 100u64 };
+			ReleaseSchedule { start: 1u32, period: 0u32, period_count: 1u32, per_period: 100u64 };
 		assert_noop!(
 			TimeRelease::transfer(RuntimeOrigin::signed(ALICE), BOB, schedule),
 			Error::<Test>::ZeroReleasePeriod
 		);
 
 		let schedule =
-			ReleaseSchedule { start: 1u64, period: 1u64, period_count: 0u32, per_period: 100u64 };
+			ReleaseSchedule { start: 1u32, period: 1u32, period_count: 0u32, per_period: 100u64 };
 		assert_noop!(
 			TimeRelease::transfer(RuntimeOrigin::signed(ALICE), BOB, schedule),
 			Error::<Test>::ZeroReleasePeriodCount
@@ -154,7 +154,7 @@ fn transfer_fails_if_zero_period_or_count() {
 fn transfer_fails_if_transfer_err() {
 	ExtBuilder::build().execute_with(|| {
 		let schedule =
-			ReleaseSchedule { start: 1u64, period: 1u64, period_count: 1u32, per_period: 100u64 };
+			ReleaseSchedule { start: 1u32, period: 1u32, period_count: 1u32, per_period: 100u64 };
 		assert_noop!(
 			TimeRelease::transfer(RuntimeOrigin::signed(BOB), ALICE, schedule),
 			pallet_balances::Error::<Test, _>::InsufficientBalance,
@@ -166,14 +166,14 @@ fn transfer_fails_if_transfer_err() {
 fn transfer_fails_if_overflow() {
 	ExtBuilder::build().execute_with(|| {
 		let schedule =
-			ReleaseSchedule { start: 1u64, period: 1u64, period_count: 2u32, per_period: u64::MAX };
+			ReleaseSchedule { start: 1u32, period: 1u32, period_count: 2u32, per_period: u64::MAX };
 		assert_noop!(
 			TimeRelease::transfer(RuntimeOrigin::signed(ALICE), BOB, schedule),
 			ArithmeticError::Overflow,
 		);
 
 		let another_schedule =
-			ReleaseSchedule { start: u64::MAX, period: 1u64, period_count: 2u32, per_period: 1u64 };
+			ReleaseSchedule { start: u32::MAX, period: 1u32, period_count: 2u32, per_period: 1u64 };
 		assert_noop!(
 			TimeRelease::transfer(RuntimeOrigin::signed(ALICE), BOB, another_schedule),
 			ArithmeticError::Overflow,
@@ -185,7 +185,7 @@ fn transfer_fails_if_overflow() {
 fn transfer_fails_if_bad_origin() {
 	ExtBuilder::build().execute_with(|| {
 		let schedule =
-			ReleaseSchedule { start: 0u64, period: 10u64, period_count: 1u32, per_period: 100u64 };
+			ReleaseSchedule { start: 0u32, period: 10u32, period_count: 1u32, per_period: 100u64 };
 		assert_noop!(
 			TimeRelease::transfer(RuntimeOrigin::signed(CHARLIE), BOB, schedule),
 			BadOrigin
@@ -197,7 +197,7 @@ fn transfer_fails_if_bad_origin() {
 fn claim_works() {
 	ExtBuilder::build().execute_with(|| {
 		let schedule =
-			ReleaseSchedule { start: 0u64, period: 10u64, period_count: 2u32, per_period: 10u64 };
+			ReleaseSchedule { start: 0u32, period: 10u32, period_count: 2u32, per_period: 10u64 };
 		assert_ok!(TimeRelease::transfer(RuntimeOrigin::signed(ALICE), BOB, schedule));
 
 		MockBlockNumberProvider::set(11);
@@ -227,7 +227,7 @@ fn claim_works() {
 fn claim_for_works() {
 	ExtBuilder::build().execute_with(|| {
 		let schedule =
-			ReleaseSchedule { start: 0u64, period: 10u64, period_count: 2u32, per_period: 10u64 };
+			ReleaseSchedule { start: 0u32, period: 10u32, period_count: 2u32, per_period: 10u64 };
 		assert_ok!(TimeRelease::transfer(RuntimeOrigin::signed(ALICE), BOB, schedule));
 
 		assert_ok!(TimeRelease::claim_for(RuntimeOrigin::signed(ALICE), BOB));
@@ -252,11 +252,11 @@ fn claim_for_works() {
 fn update_release_schedules_works() {
 	ExtBuilder::build().execute_with(|| {
 		let schedule =
-			ReleaseSchedule { start: 0u64, period: 10u64, period_count: 2u32, per_period: 10u64 };
+			ReleaseSchedule { start: 0u32, period: 10u32, period_count: 2u32, per_period: 10u64 };
 		assert_ok!(TimeRelease::transfer(RuntimeOrigin::signed(ALICE), BOB, schedule));
 
 		let updated_schedule =
-			ReleaseSchedule { start: 0u64, period: 20u64, period_count: 2u32, per_period: 10u64 };
+			ReleaseSchedule { start: 0u32, period: 20u32, period_count: 2u32, per_period: 10u64 };
 		assert_ok!(TimeRelease::update_release_schedules(
 			RuntimeOrigin::root(),
 			BOB,
@@ -295,7 +295,7 @@ fn update_release_schedules_fails_if_unexpected_existing_locks() {
 fn transfer_check_for_min() {
 	ExtBuilder::build().execute_with(|| {
 		let schedule =
-			ReleaseSchedule { start: 1u64, period: 1u64, period_count: 1u32, per_period: 3u64 };
+			ReleaseSchedule { start: 1u32, period: 1u32, period_count: 1u32, per_period: 3u64 };
 		assert_noop!(
 			TimeRelease::transfer(RuntimeOrigin::signed(BOB), ALICE, schedule),
 			Error::<Test>::AmountLow
@@ -307,11 +307,11 @@ fn transfer_check_for_min() {
 fn multiple_release_schedule_claim_works() {
 	ExtBuilder::build().execute_with(|| {
 		let schedule =
-			ReleaseSchedule { start: 0u64, period: 10u64, period_count: 2u32, per_period: 10u64 };
+			ReleaseSchedule { start: 0u32, period: 10u32, period_count: 2u32, per_period: 10u64 };
 		assert_ok!(TimeRelease::transfer(RuntimeOrigin::signed(ALICE), BOB, schedule.clone()));
 
 		let schedule2 =
-			ReleaseSchedule { start: 0u64, period: 10u64, period_count: 3u32, per_period: 10u64 };
+			ReleaseSchedule { start: 0u32, period: 10u32, period_count: 3u32, per_period: 10u64 };
 		assert_ok!(TimeRelease::transfer(RuntimeOrigin::signed(ALICE), BOB, schedule2.clone()));
 
 		assert_eq!(TimeRelease::release_schedules(&BOB), vec![schedule, schedule2.clone()]);
@@ -338,7 +338,7 @@ fn exceeding_maximum_schedules_should_fail() {
 		set_balance::<Test>(&ALICE, 1000);
 
 		let schedule =
-			ReleaseSchedule { start: 0u64, period: 10u64, period_count: 2u32, per_period: 10u64 };
+			ReleaseSchedule { start: 0u32, period: 10u32, period_count: 2u32, per_period: 10u64 };
 
 		for _ in 0..49 {
 			assert_ok!(TimeRelease::transfer(RuntimeOrigin::signed(ALICE), BOB, schedule.clone()));
@@ -368,7 +368,7 @@ fn exceeding_maximum_schedules_should_fail() {
 #[test]
 fn cliff_release_works() {
 	const VESTING_AMOUNT: u64 = 12;
-	const VESTING_PERIOD: u64 = 20;
+	const VESTING_PERIOD: u32 = 20;
 
 	ExtBuilder::build().execute_with(|| {
 		let cliff_schedule = ReleaseSchedule {
@@ -437,7 +437,7 @@ fn alice_time_releaes_schedule() {
 			june_2024_release_start,
 			period_duration,
 			number_of_periods,
-			amount_released_per_period.into(),
+			amount_released_per_period,
 		);
 
 		set_balance::<Test>(&ALICE, total_award);
@@ -610,7 +610,7 @@ fn date_to_approximate_block_number(input_date: DateTime<Utc>) -> u32 {
 // Quarter 12: April 2026
 // Time-Relese schedules:
 // Monthly unlocks 1 / 24 of 100K starting July 1, 2024
-fn time_release_transfers_data<T: Config>() -> Vec<(DateTime<Utc>, Vec<ReleaseSchedule<u64, u64>>)>
+fn time_release_transfers_data<T: Config>() -> Vec<(DateTime<Utc>, Vec<ReleaseSchedule<u32, u64>>)>
 {
 	let total_award: u64 = 100_000;
 	vec![

--- a/runtime/common/src/constants.rs
+++ b/runtime/common/src/constants.rs
@@ -1,55 +1,21 @@
 use crate::prod_or_testnet_or_local;
-use common_primitives::{
-	node::{Balance, BlockNumber},
-	schema::SchemaId,
-};
+use common_primitives::node::BlockNumber;
 
 use frame_support::{
 	parameter_types,
 	sp_runtime::{Perbill, Permill},
-	traits::{ConstU32, ConstU8},
+	traits::{ConstU128, ConstU16, ConstU32, ConstU64, ConstU8},
 	weights::{constants::WEIGHT_REF_TIME_PER_SECOND, Weight},
 	PalletId,
 };
-use sp_core::{ConstU128, ConstU16};
 
 pub const FREQUENCY_ROCOCO_TOKEN: &str = "XRQCY";
 pub const FREQUENCY_LOCAL_TOKEN: &str = "UNIT";
 pub const FREQUENCY_TOKEN: &str = "FRQCY";
 pub const TOKEN_DECIMALS: u8 = 8;
 
-parameter_types! {
-	/// Clone + Debug + Eq  implementation for u32 types
-	pub const MaxDataSize: u32 = 30;
-}
-
-impl Clone for MaxDataSize {
-	fn clone(&self) -> Self {
-		MaxDataSize {}
-	}
-}
-
-impl Eq for MaxDataSize {
-	fn assert_receiver_is_total_eq(&self) {}
-}
-
-impl PartialEq for MaxDataSize {
-	fn eq(&self, other: &Self) -> bool {
-		self == other
-	}
-}
-
-impl sp_std::fmt::Debug for MaxDataSize {
-	#[cfg(feature = "std")]
-	fn fmt(&self, _: &mut sp_std::fmt::Formatter) -> sp_std::fmt::Result {
-		Ok(())
-	}
-
-	#[cfg(not(feature = "std"))]
-	fn fmt(&self, _: &mut sp_std::fmt::Formatter) -> sp_std::fmt::Result {
-		Ok(())
-	}
-}
+/// The maximum number of schema grants allowed per delegation
+pub type MaxSchemaGrants = ConstU32<30>;
 
 /// This determines the average expected block time that we are targeting.
 /// Blocks will be produced at a minimum duration defined by `SLOT_DURATION`.
@@ -121,10 +87,8 @@ pub type MSAMaxSignaturesStored = ConstU32<50_000>;
 // -end- MSA Pallet ---
 
 // --- Schemas Pallet ---
-parameter_types! {
-	/// The maximum number of schema registrations
-	pub const SchemasMaxRegistrations: SchemaId = 65_000;
-}
+/// The maximum number of schema registrations
+pub type SchemasMaxRegistrations = ConstU16<65_000>;
 /// The minimum schema model size (in bytes)
 pub type SchemasMinModelSizeBytes = ConstU32<8>;
 /// The maximum length of a schema model (in bytes)
@@ -143,18 +107,14 @@ pub type HandleSuffixMax = ConstU16<99>;
 
 // --- TimeRelease Pallet ---
 // Update
-parameter_types! {
-	pub const MinReleaseTransfer: Balance = 0;
-}
+pub type MinReleaseTransfer = ConstU128<0>;
 
 /// Update
 pub const MAX_RELEASE_SCHEDULES: u32 = 50;
 // -end- TimeRelease Pallet ---
 
 // --- Timestamp Pallet ---
-parameter_types! {
-	pub const MinimumPeriod: u64 = SLOT_DURATION / 2;
-}
+pub type MinimumPeriod = ConstU64<{ SLOT_DURATION / 2 }>;
 // -end- Timestamp Pallet ---
 
 // --- Authorship Pallet ---
@@ -175,10 +135,8 @@ pub type SchedulerMaxScheduledPerBlock = FIFTY;
 /// Expected to be removed in Polkadot v0.9.31
 pub type PreimageMaxSize = ConstU32<{ 4096 * 1024 }>;
 
-parameter_types! {
-	pub const PreimageBaseDeposit: Balance = currency::deposit(10, 64);
-	pub const PreimageByteDeposit: Balance = currency::deposit(0, 1);
-}
+pub type PreimageBaseDeposit = ConstU128<{ currency::deposit(10, 64) }>;
+pub type PreimageByteDeposit = ConstU128<{ currency::deposit(0, 1) }>;
 // -end- Preimage Pallet ---
 
 // --- Council ---
@@ -187,9 +145,7 @@ pub type CouncilMaxProposals = ConstU32<25>;
 // The maximum number of council members
 pub type CouncilMaxMembers = ConstU32<10>;
 
-parameter_types! {
-	pub const CouncilMotionDuration: BlockNumber = 5 * DAYS;
-}
+pub type CouncilMotionDuration = ConstU32<{ 5 * DAYS }>;
 // -end- Council ---
 
 // --- Technical Committee ---
@@ -198,23 +154,30 @@ pub type TCMaxProposals = ConstU32<25>;
 // The maximum number of technical committee members
 pub type TCMaxMembers = ConstU32<10>;
 
-parameter_types! {
-	pub const TCMotionDuration: BlockNumber = 5 * DAYS;
-}
+pub type TCMotionDuration = ConstU32<{ 5 * DAYS }>;
 // -end- Technical Committee ---
 
 // --- Democracy Pallet ---
 // Config from
 // https://github.com/paritytech/substrate/blob/367dab0d4bd7fd7b6c222dd15c753169c057dd42/bin/node/runtime/src/lib.rs#L880
-parameter_types! {
-	pub LaunchPeriod: BlockNumber = prod_or_testnet_or_local!(7 * DAYS, 1 * DAYS, 5 * MINUTES);
-	pub VotingPeriod: BlockNumber = prod_or_testnet_or_local!(7 * DAYS, 1 * DAYS, 5 * MINUTES);
-	pub FastTrackVotingPeriod: BlockNumber = prod_or_testnet_or_local!(3 * HOURS, 30 * MINUTES, 5 * MINUTES);
-	pub EnactmentPeriod: BlockNumber = prod_or_testnet_or_local!(8 * DAYS, 30 * HOURS, 10 * MINUTES);
-	pub CooloffPeriod: BlockNumber = prod_or_testnet_or_local!(7 * DAYS, 1 * DAYS, 5 * MINUTES);
-	pub MinimumDeposit: Balance = prod_or_testnet_or_local!(currency::deposit(5, 0), 100 * currency::deposit(5, 0), 100 * currency::deposit(5, 0));
-	pub SpendPeriod: BlockNumber = prod_or_testnet_or_local!(7 * DAYS, 10 * MINUTES, 10 * MINUTES);
-}
+pub type LaunchPeriod = ConstU32<{ prod_or_testnet_or_local!(7 * DAYS, 1 * DAYS, 5 * MINUTES) }>;
+pub type VotingPeriod = ConstU32<{ prod_or_testnet_or_local!(7 * DAYS, 1 * DAYS, 5 * MINUTES) }>;
+pub type FastTrackVotingPeriod =
+	ConstU32<{ prod_or_testnet_or_local!(3 * HOURS, 30 * MINUTES, 5 * MINUTES) }>;
+pub type EnactmentPeriod =
+	ConstU32<{ prod_or_testnet_or_local!(8 * DAYS, 30 * HOURS, 10 * MINUTES) }>;
+pub type CooloffPeriod = ConstU32<{ prod_or_testnet_or_local!(7 * DAYS, 1 * DAYS, 5 * MINUTES) }>;
+pub type MinimumDeposit = ConstU128<
+	{
+		prod_or_testnet_or_local!(
+			currency::deposit(5, 0),
+			100 * currency::deposit(5, 0),
+			100 * currency::deposit(5, 0)
+		)
+	},
+>;
+pub type SpendPeriod =
+	ConstU32<{ prod_or_testnet_or_local!(7 * DAYS, 10 * MINUTES, 10 * MINUTES) }>;
 pub type DemocracyMaxVotes = ConstU32<100>;
 pub type DemocracyMaxProposals = HUNDRED;
 // -end- Democracy Pallet ---
@@ -226,6 +189,7 @@ pub const TREASURY_PALLET_ID: PalletId = PalletId(*b"py/trsry");
 
 // https://wiki.polkadot.network/docs/learn-treasury
 // https://paritytech.github.io/substrate/master/pallet_treasury/pallet/trait.Config.html
+// Needs parameter_types! for the Permill and PalletId
 parameter_types! {
 
 	/// Keyless account that holds the money for the treasury
@@ -235,36 +199,33 @@ parameter_types! {
 	/// This will be transferred to OnSlash if the proposal is rejected
 	pub const ProposalBondPercent: Permill = Permill::from_percent(5);
 
-	/// Minimum bond for a treasury proposal
-	pub const ProposalBondMinimum: Balance = 100 * currency::DOLLARS;
-
-	/// Minimum bond for a treasury proposal
-	pub const ProposalBondMaximum: Balance = 1_000 * currency::DOLLARS;
-
 	/// How much of the treasury to burn, if funds remain at the end of the SpendPeriod
 	/// Set to zero until the economic system is setup and stabilized
 	pub const Burn: Permill = Permill::zero();
-
-	/// Maximum number of approved proposals per Spending Period
-	/// Set to 64 or 16 per week
-	pub const MaxApprovals: u32 = 64;
 }
+
+/// Maximum number of approved proposals per Spending Period
+/// Set to 64 or 16 per week
+pub type MaxApprovals = ConstU32<64>;
+
+/// Minimum bond for a treasury proposal
+pub type ProposalBondMinimum = ConstU128<{ 100 * currency::DOLLARS }>;
+
+/// Minimum bond for a treasury proposal
+pub type ProposalBondMaximum = ConstU128<{ 1_000 * currency::DOLLARS }>;
+
 // -end- Treasury Pallet ---
 
 // --- Transaction Payment Pallet ---
 // The fee multiplier
 pub type TransactionPaymentOperationalFeeMultiplier = ConstU8<5>;
 
-parameter_types! {
-	/// Relay Chain `TransactionByteFee` / 10
-	pub const TransactionByteFee: Balance = 10 * currency::MILLICENTS;
-}
+/// Relay Chain `TransactionByteFee` / 10
+pub type TransactionByteFee = ConstU128<{ 10 * currency::MILLICENTS }>;
 // -end- Transaction Payment Pallet ---
 
 // --- Frequency Transaction Payment Pallet ---
-parameter_types! {
-	pub const MaximumCapacityBatchLength: u8 = 2;
-}
+pub type MaximumCapacityBatchLength = ConstU8<2>;
 // -end- Frequency Transaction Payment Pallet ---
 
 // --- Session Pallet ---
@@ -281,15 +242,15 @@ pub type AuraMaxAuthorities = ConstU32<100_000>;
 // Values for each runtime environment are independently configurable.
 // Example CollatorMaxInvulnerables are 16 in production(mainnet),
 // 5 in rococo testnet and 5 in rococo local
+
+pub type CollatorMaxCandidates = ConstU32<50>;
+pub type CollatorMinCandidates = ConstU32<1>;
+pub type CollatorMaxInvulnerables = ConstU32<{ prod_or_testnet_or_local!(16, 5, 5) }>;
+pub type CollatorKickThreshold =
+	ConstU32<{ prod_or_testnet_or_local!(6 * HOURS, 6 * HOURS, 6 * HOURS) }>;
+
+// Needs parameter_types! for the PalletId and impls below
 parameter_types! {
-	pub CollatorMaxCandidates: u32 = 50;
-	pub CollatorMinCandidates: u32 = 1;
-	pub CollatorMaxInvulnerables: u32 = prod_or_testnet_or_local!(16, 5, 5);
-	pub CollatorKickThreshold: BlockNumber = prod_or_testnet_or_local!(
-		6 * HOURS,
-		6 * HOURS,
-		6 * HOURS
-	);
 	pub const NeverDepositIntoId: PalletId = PalletId(*b"NeverDep");
 	pub const MessagesMaxPayloadSizeBytes: u32 = 1024 * 50; // 50K
 }
@@ -306,6 +267,7 @@ impl Clone for MessagesMaxPayloadSizeBytes {
 }
 // -end- Messages Pallet ---
 
+// Needs parameter_types! to reduce pallet dependencies
 parameter_types! {
 	/// SS58 Prefix for the for Frequency Network
 	/// 90 is the prefix for the Frequency Network on Polkadot
@@ -314,6 +276,7 @@ parameter_types! {
 }
 
 // --- Stateful Storage Pallet ---
+// Needs parameter_types! for the impls below
 parameter_types! {
 	/// The maximum size of a page (in bytes) for an Itemized storage model (64KB)
 	pub const MaxItemizedPageSizeBytes: u32 = 64 * 1024;
@@ -321,13 +284,13 @@ parameter_types! {
 	pub const MaxPaginatedPageSizeBytes: u32 = 1 * 1024;
 	/// The maximum size of a single item in an itemized storage model (in bytes)
 	pub const MaxItemizedBlobSizeBytes: u32 = 1024;
-	/// The maximum number of pages in a Paginated storage model
-	pub const MaxPaginatedPageId: u32 = 16;
-	/// The maximum number of actions in itemized actions
-	pub const MaxItemizedActionsCount: u32 = 5;
-	/// The number of blocks for Stateful mortality is 24 hours
-	pub const StatefulMortalityWindowSize: u32 = 14400;
 }
+/// The maximum number of pages in a Paginated storage model
+pub type MaxPaginatedPageId = ConstU16<16>;
+/// The maximum number of actions in itemized actions
+pub type MaxItemizedActionsCount = ConstU32<5>;
+/// The number of blocks for Stateful mortality is 24 hours
+pub type StatefulMortalityWindowSize = ConstU32<14400>;
 // -end- Stateful Storage Pallet
 
 impl Default for MaxItemizedPageSizeBytes {
@@ -382,6 +345,7 @@ pub type CapacityUnstakingThawPeriod = ConstU16<30>; // 30 Epochs, or 30 days gi
 #[cfg(feature = "frequency-rococo-local")]
 pub type CapacityUnstakingThawPeriod = ConstU16<2>; // 2 Epochs
 
+// Needs parameter_types! for the Perbil
 parameter_types! {
 	// 1:50 Capacity:Token, must be declared this way instead of using `from_rational` because of
 	//  ```error[E0015]: cannot call non-const fn `Perbill::from_rational::<u32>` in constant functions```

--- a/runtime/frequency/src/lib.rs
+++ b/runtime/frequency/src/lib.rs
@@ -429,7 +429,7 @@ pub const VERSION: RuntimeVersion = RuntimeVersion {
 	spec_name: spec_name!("frequency"),
 	impl_name: create_runtime_str!("frequency"),
 	authoring_version: 1,
-	spec_version: 30,
+	spec_version: 32,
 	impl_version: 0,
 	apis: RUNTIME_API_VERSIONS,
 	transaction_version: 1,

--- a/runtime/frequency/src/lib.rs
+++ b/runtime/frequency/src/lib.rs
@@ -77,7 +77,7 @@ pub use pallet_time_release;
 use polkadot_runtime_common::{BlockHashCount, SlowAdjustingFeeUpdate};
 
 pub use common_runtime::{
-	constants::MaxDataSize,
+	constants::MaxSchemaGrants,
 	weights,
 	weights::{block_weights::BlockExecutionWeight, extrinsic_weights::ExtrinsicBaseWeight},
 };
@@ -442,6 +442,7 @@ pub fn native_version() -> NativeVersion {
 	NativeVersion { runtime_version: VERSION, can_author_with: Default::default() }
 }
 
+// Needs parameter_types! for the complex logic
 parameter_types! {
 	pub const Version: RuntimeVersion = VERSION;
 
@@ -533,7 +534,7 @@ impl pallet_msa::Config for Runtime {
 	// The maximum number of public keys per MSA
 	type MaxPublicKeysPerMsa = MsaMaxPublicKeysPerMsa;
 	// The maximum number of schema grants per delegation
-	type MaxSchemaGrantsPerDelegation = MaxDataSize;
+	type MaxSchemaGrantsPerDelegation = MaxSchemaGrants;
 	// The maximum provider name size (in bytes)
 	type MaxProviderNameSize = MsaMaxProviderNameSize;
 	// The type that provides schema related info
@@ -593,13 +594,11 @@ impl pallet_schemas::Config for Runtime {
 	type MaxSchemaSettingsPerSchema = MaxSchemaSettingsPerSchema;
 }
 
-parameter_types! {
-	// One storage item; key size is 32; value is size 4+4+16+32 bytes = 56 bytes.
-	pub const DepositBase: Balance = currency::deposit(1, 88);
-	// Additional storage item size of 32 bytes.
-	pub const DepositFactor: Balance = currency::deposit(0, 32);
-	pub const MaxSignatories: u32 = 100;
-}
+// One storage item; key size is 32; value is size 4+4+16+32 bytes = 56 bytes.
+pub type DepositBase = ConstU128<{ currency::deposit(1, 88) }>;
+// Additional storage item size of 32 bytes.
+pub type DepositFactor = ConstU128<{ currency::deposit(0, 32) }>;
+pub type MaxSignatories = ConstU32<100>;
 
 // See https://paritytech.github.io/substrate/master/pallet_multisig/pallet/trait.Config.html for
 // the descriptions of these configs.
@@ -613,11 +612,8 @@ impl pallet_multisig::Config for Runtime {
 	type WeightInfo = weights::pallet_multisig::SubstrateWeight<Runtime>;
 }
 
-parameter_types! {
-	//update
-	/// Need this declaration method for use + type safety in benchmarks
-	pub const MaxReleaseSchedules: u32 = MAX_RELEASE_SCHEDULES;
-}
+/// Need this declaration method for use + type safety in benchmarks
+pub type MaxReleaseSchedules = ConstU32<{ MAX_RELEASE_SCHEDULES }>;
 
 // See https://paritytech.github.io/substrate/master/pallet_vesting/index.html for
 // the descriptions of these configs.
@@ -663,6 +659,7 @@ impl pallet_balances::Config for Runtime {
 	type MaxReserves = BalancesMaxReserves;
 	type ReserveIdentifier = [u8; 8];
 }
+// Needs parameter_types! for the Weight type
 parameter_types! {
 	// The maximum weight that may be scheduled per block for any dispatchables of less priority than schedule::HARD_DEADLINE.
 	pub MaximumSchedulerWeight: Weight = Perbill::from_percent(10) * RuntimeBlockWeights::get().max_block;


### PR DESCRIPTION
# Goal
The goal of this PR is to reduce and remove code

Split off of #1448 

# Discussion
- Turns out that parameter_types! is not needed as much anymore so removed a bunch of them (based on https://github.com/paritytech/substrate/issues/10383 )
- Removed the need for custom implementations on `MaxSchemaGrantsPerDelegation`
- Aligned the BlockNumber (old u64) in testing with the BlockNumber (u32) in production