### PR TITLE
Bug: Fix missing extension warning in api-augment

### DIFF
--- a/js/api-augment/index.ts
+++ b/js/api-augment/index.ts
@@ -34,6 +34,10 @@ export const signedExtensions: ExtDef = {
     extrinsic: {},
     payload: {},
   },
+  HandlesSignedExtension: {
+    extrinsic: {},
+    payload: {},
+  },
 };
 
 /**

--- a/js/api-augment/package-lock.json
+++ b/js/api-augment/package-lock.json
@@ -9,24 +9,24 @@
       "version": "0.0.0",
       "license": "Apache-2.0",
       "dependencies": {
-        "@polkadot/api": "^10.3.2",
-        "@polkadot/rpc-provider": "^10.3.2",
-        "@polkadot/types": "^10.3.2"
+        "@polkadot/api": "^10.4.1",
+        "@polkadot/rpc-provider": "^10.4.1",
+        "@polkadot/types": "^10.4.1"
       },
       "devDependencies": {
-        "@polkadot/typegen": "^10.3.2",
+        "@polkadot/typegen": "^10.4.1",
         "@types/mocha": "^10.0.1",
-        "@typescript-eslint/eslint-plugin": "^5.42.0",
-        "@typescript-eslint/parser": "^5.42.0",
-        "eslint": "^8.26.0",
-        "eslint-config-prettier": "^8.5.0",
-        "eslint-plugin-import": "^2.26.0",
+        "@typescript-eslint/eslint-plugin": "^5.59.1",
+        "@typescript-eslint/parser": "^5.59.1",
+        "eslint": "^8.39.0",
+        "eslint-config-prettier": "^8.8.0",
+        "eslint-plugin-import": "^2.27.5",
         "eslint-plugin-mocha": "^10.1.0",
         "eslint-plugin-prettier": "^4.2.1",
-        "mocha": "10.0.0",
-        "prettier": "2.7.1",
+        "mocha": "10.2.0",
+        "prettier": "2.8.8",
         "ts-node": "^10.9.1",
-        "typescript": "^4.9.5"
+        "typescript": "^5.0.4"
       }
     },
     "node_modules/@cspotcode/source-map-support": {
@@ -40,16 +40,40 @@
         "node": ">=12"
       }
     },
+    "node_modules/@eslint-community/eslint-utils": {
+      "version": "4.4.0",
+      "resolved": "https://registry.npmjs.org/@eslint-community/eslint-utils/-/eslint-utils-4.4.0.tgz",
+      "integrity": "sha512-1/sA4dwrzBAyeUoQ6oxahHKmrZvsnLCg4RfxW3ZFGGmQkSNQPFNLV9CUEFQP1x9EYXHTo5p6xdhZM1Ne9p/AfA==",
+      "dev": true,
+      "dependencies": {
+        "eslint-visitor-keys": "^3.3.0"
+      },
+      "engines": {
+        "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+      },
+      "peerDependencies": {
+        "eslint": "^6.0.0 || ^7.0.0 || >=8.0.0"
+      }
+    },
+    "node_modules/@eslint-community/regexpp": {
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/@eslint-community/regexpp/-/regexpp-4.5.0.tgz",
+      "integrity": "sha512-vITaYzIcNmjn5tF5uxcZ/ft7/RXGrMUIS9HalWckEOF6ESiwXKoMzAQf2UW0aVd6rnOeExTJVd5hmWXucBKGXQ==",
+      "dev": true,
+      "engines": {
+        "node": "^12.0.0 || ^14.0.0 || >=16.0.0"
+      }
+    },
     "node_modules/@eslint/eslintrc": {
-      "version": "1.3.3",
-      "resolved": "https://registry.npmjs.org/@eslint/eslintrc/-/eslintrc-1.3.3.tgz",
-      "integrity": "sha512-uj3pT6Mg+3t39fvLrj8iuCIJ38zKO9FpGtJ4BBJebJhEwjoT+KLVNCcHT5QC9NGRIEi7fZ0ZR8YRb884auB4Lg==",
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/@eslint/eslintrc/-/eslintrc-2.0.2.tgz",
+      "integrity": "sha512-3W4f5tDUra+pA+FzgugqL2pRimUTDJWKr7BINqOpkZrC0uYI0NIc0/JFgBROCU07HR6GieA5m3/rsPIhDmCXTQ==",
       "dev": true,
       "dependencies": {
         "ajv": "^6.12.4",
         "debug": "^4.3.2",
-        "espree": "^9.4.0",
-        "globals": "^13.15.0",
+        "espree": "^9.5.1",
+        "globals": "^13.19.0",
         "ignore": "^5.2.0",
         "import-fresh": "^3.2.1",
         "js-yaml": "^4.1.0",
@@ -63,10 +87,19 @@
         "url": "https://opencollective.com/eslint"
       }
     },
+    "node_modules/@eslint/js": {
+      "version": "8.39.0",
+      "resolved": "https://registry.npmjs.org/@eslint/js/-/js-8.39.0.tgz",
+      "integrity": "sha512-kf9RB0Fg7NZfap83B3QOqOGg9QmD9yBudqQXzzOtn3i4y7ZUXe5ONeW34Gwi+TxhH4mvj72R1Zc300KUMa9Bng==",
+      "dev": true,
+      "engines": {
+        "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+      }
+    },
     "node_modules/@humanwhocodes/config-array": {
-      "version": "0.11.7",
-      "resolved": "https://registry.npmjs.org/@humanwhocodes/config-array/-/config-array-0.11.7.tgz",
-      "integrity": "sha512-kBbPWzN8oVMLb0hOUYXhmxggL/1cJE6ydvjDIGi9EnAGUyA7cLVKQg+d/Dsm+KZwx2czGHrCmMVLiyg8s5JPKw==",
+      "version": "0.11.8",
+      "resolved": "https://registry.npmjs.org/@humanwhocodes/config-array/-/config-array-0.11.8.tgz",
+      "integrity": "sha512-UybHIJzJnR5Qc/MsD9Kr+RpO2h+/P1GhOwdiLPXK5TWk5sgTdu88bTD9UP+CKbPPh5Rni1u0GjAdYQLemG8g+g==",
       "dev": true,
       "dependencies": {
         "@humanwhocodes/object-schema": "^1.2.1",
@@ -120,21 +153,24 @@
         "@jridgewell/sourcemap-codec": "^1.4.10"
       }
     },
-    "node_modules/@noble/hashes": {
-      "version": "1.3.0",
-      "resolved": "https://registry.npmjs.org/@noble/hashes/-/hashes-1.3.0.tgz",
-      "integrity": "sha512-ilHEACi9DwqJB0pw7kv+Apvh50jiiSyR/cQ3y4W7lOR5mhvn/50FLUfsnfJz0BDZtl/RR16kXvptiv6q1msYZg==",
+    "node_modules/@noble/curves": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/@noble/curves/-/curves-1.0.0.tgz",
+      "integrity": "sha512-2upgEu0iLiDVDZkNLeFV2+ht0BAVgQnEmCk6JsOch9Rp8xfkMCbvbAZlA2pBHQc73dbl+vFOXfqkf4uemdn0bw==",
       "funding": [
         {
           "type": "individual",
           "url": "https://paulmillr.com/funding/"
         }
-      ]
+      ],
+      "dependencies": {
+        "@noble/hashes": "1.3.0"
+      }
     },
-    "node_modules/@noble/secp256k1": {
-      "version": "1.7.1",
-      "resolved": "https://registry.npmjs.org/@noble/secp256k1/-/secp256k1-1.7.1.tgz",
-      "integrity": "sha512-hOUk6AyBFmqVrv7k5WAw/LpszxVbj9gGN4JRkIX52fdFAj1UA61KXmZDvqVEm+pOyec3+fIeZB02LYa/pWOArw==",
+    "node_modules/@noble/hashes": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/@noble/hashes/-/hashes-1.3.0.tgz",
+      "integrity": "sha512-ilHEACi9DwqJB0pw7kv+Apvh50jiiSyR/cQ3y4W7lOR5mhvn/50FLUfsnfJz0BDZtl/RR16kXvptiv6q1msYZg==",
       "funding": [
         {
           "type": "individual",
@@ -178,47 +214,47 @@
       }
     },
     "node_modules/@polkadot/api": {
-      "version": "10.3.2",
-      "resolved": "https://registry.npmjs.org/@polkadot/api/-/api-10.3.2.tgz",
-      "integrity": "sha512-7lJI9bHHfiepbQvEdgqrt60jmFCw/6FvSqi9R2S9RbYdz/LD0PVF1GavpyU0tWDUfFg+jUGi2Qw4DLml455BiQ==",
+      "version": "10.4.1",
+      "resolved": "https://registry.npmjs.org/@polkadot/api/-/api-10.4.1.tgz",
+      "integrity": "sha512-MFIhykqvU4l5oyLxEnMhtF07VWLXwBS02gVd9Q+Gh2RxXtskQnXlos00hZFdLaCQ7g8BNggoq0Woc2BGZQEG2A==",
       "dependencies": {
-        "@polkadot/api-augment": "10.3.2",
-        "@polkadot/api-base": "10.3.2",
-        "@polkadot/api-derive": "10.3.2",
-        "@polkadot/keyring": "^11.1.3",
-        "@polkadot/rpc-augment": "10.3.2",
-        "@polkadot/rpc-core": "10.3.2",
-        "@polkadot/rpc-provider": "10.3.2",
-        "@polkadot/types": "10.3.2",
-        "@polkadot/types-augment": "10.3.2",
-        "@polkadot/types-codec": "10.3.2",
-        "@polkadot/types-create": "10.3.2",
-        "@polkadot/types-known": "10.3.2",
-        "@polkadot/util": "^11.1.3",
-        "@polkadot/util-crypto": "^11.1.3",
+        "@polkadot/api-augment": "10.4.1",
+        "@polkadot/api-base": "10.4.1",
+        "@polkadot/api-derive": "10.4.1",
+        "@polkadot/keyring": "^12.0.1",
+        "@polkadot/rpc-augment": "10.4.1",
+        "@polkadot/rpc-core": "10.4.1",
+        "@polkadot/rpc-provider": "10.4.1",
+        "@polkadot/types": "10.4.1",
+        "@polkadot/types-augment": "10.4.1",
+        "@polkadot/types-codec": "10.4.1",
+        "@polkadot/types-create": "10.4.1",
+        "@polkadot/types-known": "10.4.1",
+        "@polkadot/util": "^12.0.1",
+        "@polkadot/util-crypto": "^12.0.1",
         "eventemitter3": "^5.0.0",
         "rxjs": "^7.8.0",
         "tslib": "^2.5.0"
       },
       "engines": {
-        "node": ">=14"
+        "node": ">=16"
       }
     },
     "node_modules/@polkadot/api-augment": {
-      "version": "10.3.2",
-      "resolved": "https://registry.npmjs.org/@polkadot/api-augment/-/api-augment-10.3.2.tgz",
-      "integrity": "sha512-73bzQnjVmOHf/PIzSQru2jqlkVivtIvXoABkq87QIDxsZvUIQPXXIHnVb9C96yJuLE4St22w4y1qI9XSwau96g==",
+      "version": "10.4.1",
+      "resolved": "https://registry.npmjs.org/@polkadot/api-augment/-/api-augment-10.4.1.tgz",
+      "integrity": "sha512-7TUFHiOsaAKwRCDXEwwYHIBi07Nd0+4vMDgP+/eKVrX5XkYCnEA+PdkE8uEpFY3LMoVVr08mPiYPn59gN0b5jw==",
       "dependencies": {
-        "@polkadot/api-base": "10.3.2",
-        "@polkadot/rpc-augment": "10.3.2",
-        "@polkadot/types": "10.3.2",
-        "@polkadot/types-augment": "10.3.2",
-        "@polkadot/types-codec": "10.3.2",
-        "@polkadot/util": "^11.1.3",
+        "@polkadot/api-base": "10.4.1",
+        "@polkadot/rpc-augment": "10.4.1",
+        "@polkadot/types": "10.4.1",
+        "@polkadot/types-augment": "10.4.1",
+        "@polkadot/types-codec": "10.4.1",
+        "@polkadot/util": "^12.0.1",
         "tslib": "^2.5.0"
       },
       "engines": {
-        "node": ">=14"
+        "node": ">=16"
       }
     },
     "node_modules/@polkadot/api-augment/node_modules/tslib": {
@@ -227,18 +263,18 @@
       "integrity": "sha512-336iVw3rtn2BUK7ORdIAHTyxHGRIHVReokCR3XjbckJMK7ms8FysBfhLR8IXnAgy7T0PTPNBWKiH514FOW/WSg=="
     },
     "node_modules/@polkadot/api-base": {
-      "version": "10.3.2",
-      "resolved": "https://registry.npmjs.org/@polkadot/api-base/-/api-base-10.3.2.tgz",
-      "integrity": "sha512-5UPVDmYrxLCfKmCKwaiKqK1s8x3nHbi5vulUDj31P9f///oWZGwjsXdp2hn4FGoEEi1pKuMUK+dRRMEMrj3gPA==",
+      "version": "10.4.1",
+      "resolved": "https://registry.npmjs.org/@polkadot/api-base/-/api-base-10.4.1.tgz",
+      "integrity": "sha512-4uItv9NeZDu60qN8dhPN8Q7HBOYZ0Ylf7+/lAnEMldoCx0RxNP2h1T2JwdW3C5ElTsztYzYVLKg0Iz5zJpbffQ==",
       "dependencies": {
-        "@polkadot/rpc-core": "10.3.2",
-        "@polkadot/types": "10.3.2",
-        "@polkadot/util": "^11.1.3",
+        "@polkadot/rpc-core": "10.4.1",
+        "@polkadot/types": "10.4.1",
+        "@polkadot/util": "^12.0.1",
         "rxjs": "^7.8.0",
         "tslib": "^2.5.0"
       },
       "engines": {
-        "node": ">=14"
+        "node": ">=16"
       }
     },
     "node_modules/@polkadot/api-base/node_modules/tslib": {
@@ -247,23 +283,23 @@
       "integrity": "sha512-336iVw3rtn2BUK7ORdIAHTyxHGRIHVReokCR3XjbckJMK7ms8FysBfhLR8IXnAgy7T0PTPNBWKiH514FOW/WSg=="
     },
     "node_modules/@polkadot/api-derive": {
-      "version": "10.3.2",
-      "resolved": "https://registry.npmjs.org/@polkadot/api-derive/-/api-derive-10.3.2.tgz",
-      "integrity": "sha512-vU6ymw/XykrPZseCgO2BgsX9niRfystXAVUltxO9m/aqZdmf3yeFl+77MwQd9zdLsPOmcoWpiEPRRKWQThqgSA==",
+      "version": "10.4.1",
+      "resolved": "https://registry.npmjs.org/@polkadot/api-derive/-/api-derive-10.4.1.tgz",
+      "integrity": "sha512-SR/L4H8oiYMyLaLzmm9Z3kb4tNLAOAIR2uBZshCo917CqMuvrkNVW+Wfh2dAtVsnoSc1FaSPfDwmKash6pqNUQ==",
       "dependencies": {
-        "@polkadot/api": "10.3.2",
-        "@polkadot/api-augment": "10.3.2",
-        "@polkadot/api-base": "10.3.2",
-        "@polkadot/rpc-core": "10.3.2",
-        "@polkadot/types": "10.3.2",
-        "@polkadot/types-codec": "10.3.2",
-        "@polkadot/util": "^11.1.3",
-        "@polkadot/util-crypto": "^11.1.3",
+        "@polkadot/api": "10.4.1",
+        "@polkadot/api-augment": "10.4.1",
+        "@polkadot/api-base": "10.4.1",
+        "@polkadot/rpc-core": "10.4.1",
+        "@polkadot/types": "10.4.1",
+        "@polkadot/types-codec": "10.4.1",
+        "@polkadot/util": "^12.0.1",
+        "@polkadot/util-crypto": "^12.0.1",
         "rxjs": "^7.8.0",
         "tslib": "^2.5.0"
       },
       "engines": {
-        "node": ">=14"
+        "node": ">=16"
       }
     },
     "node_modules/@polkadot/api-derive/node_modules/tslib": {
@@ -282,20 +318,20 @@
       "integrity": "sha512-336iVw3rtn2BUK7ORdIAHTyxHGRIHVReokCR3XjbckJMK7ms8FysBfhLR8IXnAgy7T0PTPNBWKiH514FOW/WSg=="
     },
     "node_modules/@polkadot/keyring": {
-      "version": "11.1.3",
-      "resolved": "https://registry.npmjs.org/@polkadot/keyring/-/keyring-11.1.3.tgz",
-      "integrity": "sha512-bzGz1cWDYK7MWhp0630W6KOwTC/wsvKKHBvWxReMT7iQwFHeLn5AemUOveqIPxF+esd/UfdN5aFDHApjYcyZsg==",
+      "version": "12.0.1",
+      "resolved": "https://registry.npmjs.org/@polkadot/keyring/-/keyring-12.0.1.tgz",
+      "integrity": "sha512-dq/2FKXVzET9qBmba9xOQyOW8UjcMvS9H7ZZbcxFgP/rJ6amLByOYLXXDARp6ZXL3zrsQ6D6iRx82mnYWnxhjg==",
       "dependencies": {
-        "@polkadot/util": "11.1.3",
-        "@polkadot/util-crypto": "11.1.3",
+        "@polkadot/util": "12.0.1",
+        "@polkadot/util-crypto": "12.0.1",
         "tslib": "^2.5.0"
       },
       "engines": {
-        "node": ">=14"
+        "node": ">=16"
       },
       "peerDependencies": {
-        "@polkadot/util": "11.1.3",
-        "@polkadot/util-crypto": "11.1.3"
+        "@polkadot/util": "12.0.1",
+        "@polkadot/util-crypto": "12.0.1"
       }
     },
     "node_modules/@polkadot/keyring/node_modules/tslib": {
@@ -304,16 +340,16 @@
       "integrity": "sha512-336iVw3rtn2BUK7ORdIAHTyxHGRIHVReokCR3XjbckJMK7ms8FysBfhLR8IXnAgy7T0PTPNBWKiH514FOW/WSg=="
     },
     "node_modules/@polkadot/networks": {
-      "version": "11.1.3",
-      "resolved": "https://registry.npmjs.org/@polkadot/networks/-/networks-11.1.3.tgz",
-      "integrity": "sha512-goLpX9SswAGGeh1jXB79wHEfWOF5rLIItMHYalujBmhQVxyAqbxP2tzQqPQXDLcnkWbgwkyYGLXaDD72GBqHZw==",
+      "version": "12.0.1",
+      "resolved": "https://registry.npmjs.org/@polkadot/networks/-/networks-12.0.1.tgz",
+      "integrity": "sha512-VJkrLzIVr8B6iHm/yH7lmNwsu/ullNhiTWalxX8Ayxd+yfKwm3dL6IzggFp1uyjykOYlMvlI28keZP32OlMfdg==",
       "dependencies": {
-        "@polkadot/util": "11.1.3",
+        "@polkadot/util": "12.0.1",
         "@substrate/ss58-registry": "^1.39.0",
         "tslib": "^2.5.0"
       },
       "engines": {
-        "node": ">=14"
+        "node": ">=16"
       }
     },
     "node_modules/@polkadot/networks/node_modules/tslib": {
@@ -322,18 +358,18 @@
       "integrity": "sha512-336iVw3rtn2BUK7ORdIAHTyxHGRIHVReokCR3XjbckJMK7ms8FysBfhLR8IXnAgy7T0PTPNBWKiH514FOW/WSg=="
     },
     "node_modules/@polkadot/rpc-augment": {
-      "version": "10.3.2",
-      "resolved": "https://registry.npmjs.org/@polkadot/rpc-augment/-/rpc-augment-10.3.2.tgz",
-      "integrity": "sha512-P8pUywOtVc5jSoMMhtZSYqyvLNaf2x/tsDaC0sct1yHg5KkXjTCnOgRTepjObgsQWWW5SjKudhhXr8Yfv2XbWQ==",
+      "version": "10.4.1",
+      "resolved": "https://registry.npmjs.org/@polkadot/rpc-augment/-/rpc-augment-10.4.1.tgz",
+      "integrity": "sha512-lwwSjyboTTDzrfmBxFgBq4ZcD8mhMKkofmVqS/ntvuJePrCnBPGQG9d+tfntizIO5OpCqFGk0lgYBwae+oQ+vw==",
       "dependencies": {
-        "@polkadot/rpc-core": "10.3.2",
-        "@polkadot/types": "10.3.2",
-        "@polkadot/types-codec": "10.3.2",
-        "@polkadot/util": "^11.1.3",
+        "@polkadot/rpc-core": "10.4.1",
+        "@polkadot/types": "10.4.1",
+        "@polkadot/types-codec": "10.4.1",
+        "@polkadot/util": "^12.0.1",
         "tslib": "^2.5.0"
       },
       "engines": {
-        "node": ">=14"
+        "node": ">=16"
       }
     },
     "node_modules/@polkadot/rpc-augment/node_modules/tslib": {
@@ -342,19 +378,19 @@
       "integrity": "sha512-336iVw3rtn2BUK7ORdIAHTyxHGRIHVReokCR3XjbckJMK7ms8FysBfhLR8IXnAgy7T0PTPNBWKiH514FOW/WSg=="
     },
     "node_modules/@polkadot/rpc-core": {
-      "version": "10.3.2",
-      "resolved": "https://registry.npmjs.org/@polkadot/rpc-core/-/rpc-core-10.3.2.tgz",
-      "integrity": "sha512-XUQ6QzcAG7NkhenOtV2zhJjrSsQntmJHfwt8Hp5JZdap/bTsRLGl66N4mrK0Lm5535OiDYFEGXxnLZM10IjtRA==",
+      "version": "10.4.1",
+      "resolved": "https://registry.npmjs.org/@polkadot/rpc-core/-/rpc-core-10.4.1.tgz",
+      "integrity": "sha512-jE3dBzfOFkiROMsiXpge/njvwPDCXF990VPFtlFqVWpr9ypXY7eZT1gduanN6YkXRjzcBVVPHaPfWLejie6hZA==",
       "dependencies": {
-        "@polkadot/rpc-augment": "10.3.2",
-        "@polkadot/rpc-provider": "10.3.2",
-        "@polkadot/types": "10.3.2",
-        "@polkadot/util": "^11.1.3",
+        "@polkadot/rpc-augment": "10.4.1",
+        "@polkadot/rpc-provider": "10.4.1",
+        "@polkadot/types": "10.4.1",
+        "@polkadot/util": "^12.0.1",
         "rxjs": "^7.8.0",
         "tslib": "^2.5.0"
       },
       "engines": {
-        "node": ">=14"
+        "node": ">=16"
       }
     },
     "node_modules/@polkadot/rpc-core/node_modules/tslib": {
@@ -363,28 +399,28 @@
       "integrity": "sha512-336iVw3rtn2BUK7ORdIAHTyxHGRIHVReokCR3XjbckJMK7ms8FysBfhLR8IXnAgy7T0PTPNBWKiH514FOW/WSg=="
     },
     "node_modules/@polkadot/rpc-provider": {
-      "version": "10.3.2",
-      "resolved": "https://registry.npmjs.org/@polkadot/rpc-provider/-/rpc-provider-10.3.2.tgz",
-      "integrity": "sha512-torI91dgZXPYIjUSU1/YzTK9mK3H/36JZhJFrdrw63PR3Lh5/cdQ8TFJ5gJ2naVXZB/GIOH7GAhm38ByL17wig==",
+      "version": "10.4.1",
+      "resolved": "https://registry.npmjs.org/@polkadot/rpc-provider/-/rpc-provider-10.4.1.tgz",
+      "integrity": "sha512-DwXs5dB1hp0P17I/Aqg+BnILQRMWlmMlABfSwwPprOh+16BBDw4P7bEuvaYw3gl/Zrxt4UhDcPl48jD+4j5OrQ==",
       "dependencies": {
-        "@polkadot/keyring": "^11.1.3",
-        "@polkadot/types": "10.3.2",
-        "@polkadot/types-support": "10.3.2",
-        "@polkadot/util": "^11.1.3",
-        "@polkadot/util-crypto": "^11.1.3",
-        "@polkadot/x-fetch": "^11.1.3",
-        "@polkadot/x-global": "^11.1.3",
-        "@polkadot/x-ws": "^11.1.3",
+        "@polkadot/keyring": "^12.0.1",
+        "@polkadot/types": "10.4.1",
+        "@polkadot/types-support": "10.4.1",
+        "@polkadot/util": "^12.0.1",
+        "@polkadot/util-crypto": "^12.0.1",
+        "@polkadot/x-fetch": "^12.0.1",
+        "@polkadot/x-global": "^12.0.1",
+        "@polkadot/x-ws": "^12.0.1",
         "eventemitter3": "^5.0.0",
         "mock-socket": "^9.2.1",
         "nock": "^13.3.0",
         "tslib": "^2.5.0"
       },
       "engines": {
-        "node": ">=14"
+        "node": ">=16"
       },
       "optionalDependencies": {
-        "@substrate/connect": "0.7.23"
+        "@substrate/connect": "0.7.24"
       }
     },
     "node_modules/@polkadot/rpc-provider/node_modules/eventemitter3": {
@@ -398,23 +434,23 @@
       "integrity": "sha512-336iVw3rtn2BUK7ORdIAHTyxHGRIHVReokCR3XjbckJMK7ms8FysBfhLR8IXnAgy7T0PTPNBWKiH514FOW/WSg=="
     },
     "node_modules/@polkadot/typegen": {
-      "version": "10.3.2",
-      "resolved": "https://registry.npmjs.org/@polkadot/typegen/-/typegen-10.3.2.tgz",
-      "integrity": "sha512-ho0oRXRTQfu85nOOHAZ/N1LMPzkn6gaT82PwUi2Rvt7hXCZVK5sYe6s9NSRK6eqlrp9gRXS55rmo+H7WQ7OIVw==",
+      "version": "10.4.1",
+      "resolved": "https://registry.npmjs.org/@polkadot/typegen/-/typegen-10.4.1.tgz",
+      "integrity": "sha512-M2DwurCqX4n7IAXWRK/T9yLERC6y+rKzg3YpIiQ6RdOz5Hmr0vimU/1KVunW/0I8gOI+dCvHR6ybXftRrLhabg==",
       "dev": true,
       "dependencies": {
-        "@polkadot/api": "10.3.2",
-        "@polkadot/api-augment": "10.3.2",
-        "@polkadot/rpc-augment": "10.3.2",
-        "@polkadot/rpc-provider": "10.3.2",
-        "@polkadot/types": "10.3.2",
-        "@polkadot/types-augment": "10.3.2",
-        "@polkadot/types-codec": "10.3.2",
-        "@polkadot/types-create": "10.3.2",
-        "@polkadot/types-support": "10.3.2",
-        "@polkadot/util": "^11.1.3",
-        "@polkadot/util-crypto": "^11.1.3",
-        "@polkadot/x-ws": "^11.1.3",
+        "@polkadot/api": "10.4.1",
+        "@polkadot/api-augment": "10.4.1",
+        "@polkadot/rpc-augment": "10.4.1",
+        "@polkadot/rpc-provider": "10.4.1",
+        "@polkadot/types": "10.4.1",
+        "@polkadot/types-augment": "10.4.1",
+        "@polkadot/types-codec": "10.4.1",
+        "@polkadot/types-create": "10.4.1",
+        "@polkadot/types-support": "10.4.1",
+        "@polkadot/util": "^12.0.1",
+        "@polkadot/util-crypto": "^12.0.1",
+        "@polkadot/x-ws": "^12.0.1",
         "handlebars": "^4.7.7",
         "tslib": "^2.5.0",
         "yargs": "^17.7.1"
@@ -427,7 +463,7 @@
         "polkadot-types-internal-metadata": "scripts/polkadot-types-internal-metadata.mjs"
       },
       "engines": {
-        "node": ">=14"
+        "node": ">=16"
       }
     },
     "node_modules/@polkadot/typegen/node_modules/cliui": {
@@ -478,35 +514,35 @@
       }
     },
     "node_modules/@polkadot/types": {
-      "version": "10.3.2",
-      "resolved": "https://registry.npmjs.org/@polkadot/types/-/types-10.3.2.tgz",
-      "integrity": "sha512-dwCB2S8yGS2gdvAMlqTiKB+ysGoiZgqhyD+hxpE2JsDtjDHb5q6BCAyeKGnG7BcUHdnspYAt9g0EcjRDkTt5Tw==",
+      "version": "10.4.1",
+      "resolved": "https://registry.npmjs.org/@polkadot/types/-/types-10.4.1.tgz",
+      "integrity": "sha512-w4spUa4CMLoPuIHOANR8X5F/Hfs4b4OnxsofA9SOl2aaQNRgu77Qu0y60rReu8HxBKD/FUBJJmRpZeY/2WQAAQ==",
       "dependencies": {
-        "@polkadot/keyring": "^11.1.3",
-        "@polkadot/types-augment": "10.3.2",
-        "@polkadot/types-codec": "10.3.2",
-        "@polkadot/types-create": "10.3.2",
-        "@polkadot/util": "^11.1.3",
-        "@polkadot/util-crypto": "^11.1.3",
+        "@polkadot/keyring": "^12.0.1",
+        "@polkadot/types-augment": "10.4.1",
+        "@polkadot/types-codec": "10.4.1",
+        "@polkadot/types-create": "10.4.1",
+        "@polkadot/util": "^12.0.1",
+        "@polkadot/util-crypto": "^12.0.1",
         "rxjs": "^7.8.0",
         "tslib": "^2.5.0"
       },
       "engines": {
-        "node": ">=14"
+        "node": ">=16"
       }
     },
     "node_modules/@polkadot/types-augment": {
-      "version": "10.3.2",
-      "resolved": "https://registry.npmjs.org/@polkadot/types-augment/-/types-augment-10.3.2.tgz",
-      "integrity": "sha512-ECtf8zYak+lJ6eMrQKigUB0FlqoQXPm1bJ5EKCw1Lkgf45sSgAkaY8rHgon4fzbxwVc3JQR7KUiumvRBd1dvnQ==",
+      "version": "10.4.1",
+      "resolved": "https://registry.npmjs.org/@polkadot/types-augment/-/types-augment-10.4.1.tgz",
+      "integrity": "sha512-4QWfxf6nA+sBf2X88S454N5Wpc4yTL+9uwdCP5PiqyDuCv96l+G0jQWurolywADJcKMKcnu8zHdQdv4rcgUyxQ==",
       "dependencies": {
-        "@polkadot/types": "10.3.2",
-        "@polkadot/types-codec": "10.3.2",
-        "@polkadot/util": "^11.1.3",
+        "@polkadot/types": "10.4.1",
+        "@polkadot/types-codec": "10.4.1",
+        "@polkadot/util": "^12.0.1",
         "tslib": "^2.5.0"
       },
       "engines": {
-        "node": ">=14"
+        "node": ">=16"
       }
     },
     "node_modules/@polkadot/types-augment/node_modules/tslib": {
@@ -515,16 +551,16 @@
       "integrity": "sha512-336iVw3rtn2BUK7ORdIAHTyxHGRIHVReokCR3XjbckJMK7ms8FysBfhLR8IXnAgy7T0PTPNBWKiH514FOW/WSg=="
     },
     "node_modules/@polkadot/types-codec": {
-      "version": "10.3.2",
-      "resolved": "https://registry.npmjs.org/@polkadot/types-codec/-/types-codec-10.3.2.tgz",
-      "integrity": "sha512-gsTyg11bcoAhCym8SlNcZ5bPrLUUq86HnWa3Yqq0+Sso+Skc0LO3FwBwbg+HS4EospMqoLnJEt+5CFBStr2M0A==",
+      "version": "10.4.1",
+      "resolved": "https://registry.npmjs.org/@polkadot/types-codec/-/types-codec-10.4.1.tgz",
+      "integrity": "sha512-h6OCSF6i0b/Q4uCOEEiibMkGefhb7daaDGwoxjTEOeSqDE9gMIkhkyXVjqcOGbsHsFaYqYhuJakRQe/LICykTw==",
       "dependencies": {
-        "@polkadot/util": "^11.1.3",
-        "@polkadot/x-bigint": "^11.1.3",
+        "@polkadot/util": "^12.0.1",
+        "@polkadot/x-bigint": "^12.0.1",
         "tslib": "^2.5.0"
       },
       "engines": {
-        "node": ">=14"
+        "node": ">=16"
       }
     },
     "node_modules/@polkadot/types-codec/node_modules/tslib": {
@@ -533,16 +569,16 @@
       "integrity": "sha512-336iVw3rtn2BUK7ORdIAHTyxHGRIHVReokCR3XjbckJMK7ms8FysBfhLR8IXnAgy7T0PTPNBWKiH514FOW/WSg=="
     },
     "node_modules/@polkadot/types-create": {
-      "version": "10.3.2",
-      "resolved": "https://registry.npmjs.org/@polkadot/types-create/-/types-create-10.3.2.tgz",
-      "integrity": "sha512-y0kdN75iFtjZ8VJ8+bq2csVIb03FWHQzUohoH0VFrDOs1dAqMTWKBiBTpkEN+Dd9ZyBjsQphgJlMbIEd6Prx+w==",
+      "version": "10.4.1",
+      "resolved": "https://registry.npmjs.org/@polkadot/types-create/-/types-create-10.4.1.tgz",
+      "integrity": "sha512-E15P4ZQSAIq90Gnc+ZVK7XmEWRIF9qbCAQvJQ6nxikb6u5A9AzePAZ4XwxjJ3JXC5/t0Wxnij+pddtfxOkUi2w==",
       "dependencies": {
-        "@polkadot/types-codec": "10.3.2",
-        "@polkadot/util": "^11.1.3",
+        "@polkadot/types-codec": "10.4.1",
+        "@polkadot/util": "^12.0.1",
         "tslib": "^2.5.0"
       },
       "engines": {
-        "node": ">=14"
+        "node": ">=16"
       }
     },
     "node_modules/@polkadot/types-create/node_modules/tslib": {
@@ -551,19 +587,19 @@
       "integrity": "sha512-336iVw3rtn2BUK7ORdIAHTyxHGRIHVReokCR3XjbckJMK7ms8FysBfhLR8IXnAgy7T0PTPNBWKiH514FOW/WSg=="
     },
     "node_modules/@polkadot/types-known": {
-      "version": "10.3.2",
-      "resolved": "https://registry.npmjs.org/@polkadot/types-known/-/types-known-10.3.2.tgz",
-      "integrity": "sha512-eNiYCLbGYzjPt4maJuNubhxjebiFoyoAFxzADOXSqQS5dg93GdEa2ZvSNlffp9XYoTi0fqkV2vuDfdvb6tD3Iw==",
+      "version": "10.4.1",
+      "resolved": "https://registry.npmjs.org/@polkadot/types-known/-/types-known-10.4.1.tgz",
+      "integrity": "sha512-vgxsJeZTdbNJ55CCICRcSeOJD6Qy4D2NaMhR2j24xxHRY1lL8uBfCE/ReIEY2Bxa8cCIjCtw5fXJiCWPjnQQoQ==",
       "dependencies": {
-        "@polkadot/networks": "^11.1.3",
-        "@polkadot/types": "10.3.2",
-        "@polkadot/types-codec": "10.3.2",
-        "@polkadot/types-create": "10.3.2",
-        "@polkadot/util": "^11.1.3",
+        "@polkadot/networks": "^12.0.1",
+        "@polkadot/types": "10.4.1",
+        "@polkadot/types-codec": "10.4.1",
+        "@polkadot/types-create": "10.4.1",
+        "@polkadot/util": "^12.0.1",
         "tslib": "^2.5.0"
       },
       "engines": {
-        "node": ">=14"
+        "node": ">=16"
       }
     },
     "node_modules/@polkadot/types-known/node_modules/tslib": {
@@ -572,15 +608,15 @@
       "integrity": "sha512-336iVw3rtn2BUK7ORdIAHTyxHGRIHVReokCR3XjbckJMK7ms8FysBfhLR8IXnAgy7T0PTPNBWKiH514FOW/WSg=="
     },
     "node_modules/@polkadot/types-support": {
-      "version": "10.3.2",
-      "resolved": "https://registry.npmjs.org/@polkadot/types-support/-/types-support-10.3.2.tgz",
-      "integrity": "sha512-gqYzfj5BfmFWU/f5TaK6MovF9vb4oiOecNKDMsFlH+i3cCUpIYeUDFhYRoPRnfVf4sjLNvgS2NYbl5t5+ymQIQ==",
+      "version": "10.4.1",
+      "resolved": "https://registry.npmjs.org/@polkadot/types-support/-/types-support-10.4.1.tgz",
+      "integrity": "sha512-kt/TGVAGaGD76eM/kye8qdYxQDZtpc6GS58xYvgnsk59KkCvaOzOE+hHFDXx0UDy4pPgXKquk1EHxwiFTKSb4g==",
       "dependencies": {
-        "@polkadot/util": "^11.1.3",
+        "@polkadot/util": "^12.0.1",
         "tslib": "^2.5.0"
       },
       "engines": {
-        "node": ">=14"
+        "node": ">=16"
       }
     },
     "node_modules/@polkadot/types-support/node_modules/tslib": {
@@ -594,43 +630,43 @@
       "integrity": "sha512-336iVw3rtn2BUK7ORdIAHTyxHGRIHVReokCR3XjbckJMK7ms8FysBfhLR8IXnAgy7T0PTPNBWKiH514FOW/WSg=="
     },
     "node_modules/@polkadot/util": {
-      "version": "11.1.3",
-      "resolved": "https://registry.npmjs.org/@polkadot/util/-/util-11.1.3.tgz",
-      "integrity": "sha512-Gsqzv1/fSoypS5tnJkM+NJQeT7O4iYlSniubUJnaZVOKsIbueTS1bMQ1y3/h8ISxbKBtICW5cZ6zCej6Q/jC3w==",
+      "version": "12.0.1",
+      "resolved": "https://registry.npmjs.org/@polkadot/util/-/util-12.0.1.tgz",
+      "integrity": "sha512-yG4VcZ9wWvgCOg9+tUoTk6s4lphhsniuQVmQ/dRRKry983QlIj5eUgu1PfSRCKX+qUMR8IWI6oENZjmWdg0n6w==",
       "dependencies": {
-        "@polkadot/x-bigint": "11.1.3",
-        "@polkadot/x-global": "11.1.3",
-        "@polkadot/x-textdecoder": "11.1.3",
-        "@polkadot/x-textencoder": "11.1.3",
+        "@polkadot/x-bigint": "12.0.1",
+        "@polkadot/x-global": "12.0.1",
+        "@polkadot/x-textdecoder": "12.0.1",
+        "@polkadot/x-textencoder": "12.0.1",
         "@types/bn.js": "^5.1.1",
         "bn.js": "^5.2.1",
         "tslib": "^2.5.0"
       },
       "engines": {
-        "node": ">=14"
+        "node": ">=16"
       }
     },
     "node_modules/@polkadot/util-crypto": {
-      "version": "11.1.3",
-      "resolved": "https://registry.npmjs.org/@polkadot/util-crypto/-/util-crypto-11.1.3.tgz",
-      "integrity": "sha512-hjH1y6jXQuceJ2NWx7+ei0sR4A7t844XwlNquPxZX3kQbQS+1t6tO4Eo3/95JhPsEaJOXduus02cYEF6gteEYQ==",
+      "version": "12.0.1",
+      "resolved": "https://registry.npmjs.org/@polkadot/util-crypto/-/util-crypto-12.0.1.tgz",
+      "integrity": "sha512-9zkxoAHUaGFcerMxKZu2rbBSB48YBx3dGzFMGnu/nTf3gL65a7r0wMy3R5iPhWF4AZ8RUjjcS/1a22mSB+PXTg==",
       "dependencies": {
+        "@noble/curves": "1.0.0",
         "@noble/hashes": "1.3.0",
-        "@noble/secp256k1": "1.7.1",
-        "@polkadot/networks": "11.1.3",
-        "@polkadot/util": "11.1.3",
-        "@polkadot/wasm-crypto": "^7.0.3",
-        "@polkadot/x-bigint": "11.1.3",
-        "@polkadot/x-randomvalues": "11.1.3",
+        "@polkadot/networks": "12.0.1",
+        "@polkadot/util": "12.0.1",
+        "@polkadot/wasm-crypto": "^7.1.1",
+        "@polkadot/wasm-util": "^7.1.1",
+        "@polkadot/x-bigint": "12.0.1",
+        "@polkadot/x-randomvalues": "12.0.1",
         "@scure/base": "1.1.1",
-        "tslib": "^2.5.0",
-        "tweetnacl": "^1.0.3"
+        "tslib": "^2.5.0"
       },
       "engines": {
-        "node": ">=14"
+        "node": ">=16"
       },
       "peerDependencies": {
-        "@polkadot/util": "11.1.3"
+        "@polkadot/util": "12.0.1"
       }
     },
     "node_modules/@polkadot/util-crypto/node_modules/tslib": {
@@ -644,14 +680,15 @@
       "integrity": "sha512-336iVw3rtn2BUK7ORdIAHTyxHGRIHVReokCR3XjbckJMK7ms8FysBfhLR8IXnAgy7T0PTPNBWKiH514FOW/WSg=="
     },
     "node_modules/@polkadot/wasm-bridge": {
-      "version": "7.0.3",
-      "resolved": "https://registry.npmjs.org/@polkadot/wasm-bridge/-/wasm-bridge-7.0.3.tgz",
-      "integrity": "sha512-q5qyhkGE9lHQmThNg6G5zCM4gYip2KtmR+De/URX7yWAO6snsinFqt066RFVuHvX1hZijrYSe/BGQABAUtH4pw==",
+      "version": "7.1.1",
+      "resolved": "https://registry.npmjs.org/@polkadot/wasm-bridge/-/wasm-bridge-7.1.1.tgz",
+      "integrity": "sha512-2YKaqrGaN+e+OjKxs1sAS822Jil6GJE8xhNTs8an7BtgEKtfBjQ/j2ZIe41ijRs4O05iI+OkxHpLEHhIm+wq0A==",
       "dependencies": {
+        "@polkadot/wasm-util": "7.1.1",
         "tslib": "^2.5.0"
       },
       "engines": {
-        "node": ">=14.0.0"
+        "node": ">=16"
       },
       "peerDependencies": {
         "@polkadot/util": "*",
@@ -664,19 +701,19 @@
       "integrity": "sha512-336iVw3rtn2BUK7ORdIAHTyxHGRIHVReokCR3XjbckJMK7ms8FysBfhLR8IXnAgy7T0PTPNBWKiH514FOW/WSg=="
     },
     "node_modules/@polkadot/wasm-crypto": {
-      "version": "7.0.3",
-      "resolved": "https://registry.npmjs.org/@polkadot/wasm-crypto/-/wasm-crypto-7.0.3.tgz",
-      "integrity": "sha512-mOCLCaL9cyrU72PCc9nMNAj3zdvOzau5mOGJjLahIz+mqlHAoAmEXCAJvJ2qCo7OFl8QiDToAEGhdDWQfiHUyg==",
+      "version": "7.1.1",
+      "resolved": "https://registry.npmjs.org/@polkadot/wasm-crypto/-/wasm-crypto-7.1.1.tgz",
+      "integrity": "sha512-qaYScOVR7gUr41bP7O7OzOVJFfb9gh6KBk9xVy7gl5U9XYAqq0xqp88g528hEUa7IjFW3QVg7EeI8KsRmm0zpA==",
       "dependencies": {
-        "@polkadot/wasm-bridge": "7.0.3",
-        "@polkadot/wasm-crypto-asmjs": "7.0.3",
-        "@polkadot/wasm-crypto-init": "7.0.3",
-        "@polkadot/wasm-crypto-wasm": "7.0.3",
-        "@polkadot/wasm-util": "7.0.3",
+        "@polkadot/wasm-bridge": "7.1.1",
+        "@polkadot/wasm-crypto-asmjs": "7.1.1",
+        "@polkadot/wasm-crypto-init": "7.1.1",
+        "@polkadot/wasm-crypto-wasm": "7.1.1",
+        "@polkadot/wasm-util": "7.1.1",
         "tslib": "^2.5.0"
       },
       "engines": {
-        "node": ">=14.0.0"
+        "node": ">=16"
       },
       "peerDependencies": {
         "@polkadot/util": "*",
@@ -684,14 +721,14 @@
       }
     },
     "node_modules/@polkadot/wasm-crypto-asmjs": {
-      "version": "7.0.3",
-      "resolved": "https://registry.npmjs.org/@polkadot/wasm-crypto-asmjs/-/wasm-crypto-asmjs-7.0.3.tgz",
-      "integrity": "sha512-ldMZjowYywn0Uj7jSr8a21rrlFFq/jWhCXVl21/KDcYGdFEfIajqbcrO5cHoT6w95sQgAwMWJwwDClXOaBjc/Q==",
+      "version": "7.1.1",
+      "resolved": "https://registry.npmjs.org/@polkadot/wasm-crypto-asmjs/-/wasm-crypto-asmjs-7.1.1.tgz",
+      "integrity": "sha512-LOKdussHjRx+bwT85iuL6huiKwWZ0x3XLvo0En2U16fT/g9mx74Nmp/YpIwkDRXJ0PUgHpuPYGNMH3x2vEVgBQ==",
       "dependencies": {
         "tslib": "^2.5.0"
       },
       "engines": {
-        "node": ">=14.0.0"
+        "node": ">=16"
       },
       "peerDependencies": {
         "@polkadot/util": "*"
@@ -703,17 +740,18 @@
       "integrity": "sha512-336iVw3rtn2BUK7ORdIAHTyxHGRIHVReokCR3XjbckJMK7ms8FysBfhLR8IXnAgy7T0PTPNBWKiH514FOW/WSg=="
     },
     "node_modules/@polkadot/wasm-crypto-init": {
-      "version": "7.0.3",
-      "resolved": "https://registry.npmjs.org/@polkadot/wasm-crypto-init/-/wasm-crypto-init-7.0.3.tgz",
-      "integrity": "sha512-W4ClfPrzOTqiX0x4h6rXjCt8UsVsbg3zU7LJFFjeLgrguPoKTLGw4h5O1rR2H7EuMFbuqdztzJn3qTjBcR03Cg==",
+      "version": "7.1.1",
+      "resolved": "https://registry.npmjs.org/@polkadot/wasm-crypto-init/-/wasm-crypto-init-7.1.1.tgz",
+      "integrity": "sha512-EgbnXCPNvqfXElhsipI1XqLdVnvk46MCr0cgNE9g1sQHfOh5N9Bsjv7J4bnbv5bIb7JlpXBc9MnTas70PasaCw==",
       "dependencies": {
-        "@polkadot/wasm-bridge": "7.0.3",
-        "@polkadot/wasm-crypto-asmjs": "7.0.3",
-        "@polkadot/wasm-crypto-wasm": "7.0.3",
+        "@polkadot/wasm-bridge": "7.1.1",
+        "@polkadot/wasm-crypto-asmjs": "7.1.1",
+        "@polkadot/wasm-crypto-wasm": "7.1.1",
+        "@polkadot/wasm-util": "7.1.1",
         "tslib": "^2.5.0"
       },
       "engines": {
-        "node": ">=14.0.0"
+        "node": ">=16"
       },
       "peerDependencies": {
         "@polkadot/util": "*",
@@ -726,15 +764,15 @@
       "integrity": "sha512-336iVw3rtn2BUK7ORdIAHTyxHGRIHVReokCR3XjbckJMK7ms8FysBfhLR8IXnAgy7T0PTPNBWKiH514FOW/WSg=="
     },
     "node_modules/@polkadot/wasm-crypto-wasm": {
-      "version": "7.0.3",
-      "resolved": "https://registry.npmjs.org/@polkadot/wasm-crypto-wasm/-/wasm-crypto-wasm-7.0.3.tgz",
-      "integrity": "sha512-FRjUADiA3wMkjJqQLgB0v9rbSADcb2PY/6dJi06iza9m41HebTN3x7f5D3gWTCfgJjzWLAPchY2Hwsa0WpTQkw==",
+      "version": "7.1.1",
+      "resolved": "https://registry.npmjs.org/@polkadot/wasm-crypto-wasm/-/wasm-crypto-wasm-7.1.1.tgz",
+      "integrity": "sha512-mbo6CEt/11Wh2NDGDhVzQFpOZLE/+Hl8tUf8Y38ddRo20xAHvs09KK+cNTFRurY0P2Tq5LnF9+VzuC0bZPyRqQ==",
       "dependencies": {
-        "@polkadot/wasm-util": "7.0.3",
+        "@polkadot/wasm-util": "7.1.1",
         "tslib": "^2.5.0"
       },
       "engines": {
-        "node": ">=14.0.0"
+        "node": ">=16"
       },
       "peerDependencies": {
         "@polkadot/util": "*"
@@ -751,14 +789,14 @@
       "integrity": "sha512-336iVw3rtn2BUK7ORdIAHTyxHGRIHVReokCR3XjbckJMK7ms8FysBfhLR8IXnAgy7T0PTPNBWKiH514FOW/WSg=="
     },
     "node_modules/@polkadot/wasm-util": {
-      "version": "7.0.3",
-      "resolved": "https://registry.npmjs.org/@polkadot/wasm-util/-/wasm-util-7.0.3.tgz",
-      "integrity": "sha512-L9U5nSbzr5xa2YSpveP/zZxhOB6i8ibssK+ihuG+7SICYtTC0B9wJp/UnjP/c6bEDlMV3yWiNXJPBTJMGmkmIQ==",
+      "version": "7.1.1",
+      "resolved": "https://registry.npmjs.org/@polkadot/wasm-util/-/wasm-util-7.1.1.tgz",
+      "integrity": "sha512-FOflVMo4sXTsXhXoY9rQKfPPCiTfE+dEsuGcm6Aecau0NL24Ze/guxX6vOSDN2E2I6kf60biQU016O2RKHqtwg==",
       "dependencies": {
         "tslib": "^2.5.0"
       },
       "engines": {
-        "node": ">=14.0.0"
+        "node": ">=16"
       },
       "peerDependencies": {
         "@polkadot/util": "*"
@@ -770,15 +808,15 @@
       "integrity": "sha512-336iVw3rtn2BUK7ORdIAHTyxHGRIHVReokCR3XjbckJMK7ms8FysBfhLR8IXnAgy7T0PTPNBWKiH514FOW/WSg=="
     },
     "node_modules/@polkadot/x-bigint": {
-      "version": "11.1.3",
-      "resolved": "https://registry.npmjs.org/@polkadot/x-bigint/-/x-bigint-11.1.3.tgz",
-      "integrity": "sha512-fRUUHfW9VFsXT7sLUUY7gSu8v+PvzNLRwvjnp+Ly8vFx9LTLuVGFCi+mpysuRTaPpqZZJlzBJ3fST7xTGh67Pg==",
+      "version": "12.0.1",
+      "resolved": "https://registry.npmjs.org/@polkadot/x-bigint/-/x-bigint-12.0.1.tgz",
+      "integrity": "sha512-i93iVkK/PHsh1XDtYqdvUhuom6W80dYPCEA0WcZl0yuxuZGWk3Az+mXRL/mZkK/uDp8RGC0wYQiUm0kkheeoqg==",
       "dependencies": {
-        "@polkadot/x-global": "11.1.3",
+        "@polkadot/x-global": "12.0.1",
         "tslib": "^2.5.0"
       },
       "engines": {
-        "node": ">=14"
+        "node": ">=16"
       }
     },
     "node_modules/@polkadot/x-bigint/node_modules/tslib": {
@@ -787,16 +825,16 @@
       "integrity": "sha512-336iVw3rtn2BUK7ORdIAHTyxHGRIHVReokCR3XjbckJMK7ms8FysBfhLR8IXnAgy7T0PTPNBWKiH514FOW/WSg=="
     },
     "node_modules/@polkadot/x-fetch": {
-      "version": "11.1.3",
-      "resolved": "https://registry.npmjs.org/@polkadot/x-fetch/-/x-fetch-11.1.3.tgz",
-      "integrity": "sha512-+Z0RxxsN7+l2ZmmDdHqOo0kgqvjXJ1bw8CwTVnq3t9nPgZKn2pC3Fq3xdj/sRWiLuf/UhgCxKfYfMmt5ek4kIg==",
+      "version": "12.0.1",
+      "resolved": "https://registry.npmjs.org/@polkadot/x-fetch/-/x-fetch-12.0.1.tgz",
+      "integrity": "sha512-JCCN1Q2mEenBXymLGC3f7F+L7Arp+36jPB7iGs6AZVmFBW8tX3uozVpETt4O4GMC56qZX5RHCPaemY4PVXcnlg==",
       "dependencies": {
-        "@polkadot/x-global": "11.1.3",
+        "@polkadot/x-global": "12.0.1",
         "node-fetch": "^3.3.1",
         "tslib": "^2.5.0"
       },
       "engines": {
-        "node": ">=14"
+        "node": ">=16"
       }
     },
     "node_modules/@polkadot/x-fetch/node_modules/tslib": {
@@ -805,14 +843,14 @@
       "integrity": "sha512-336iVw3rtn2BUK7ORdIAHTyxHGRIHVReokCR3XjbckJMK7ms8FysBfhLR8IXnAgy7T0PTPNBWKiH514FOW/WSg=="
     },
     "node_modules/@polkadot/x-global": {
-      "version": "11.1.3",
-      "resolved": "https://registry.npmjs.org/@polkadot/x-global/-/x-global-11.1.3.tgz",
-      "integrity": "sha512-R3aqtIjgzFHJ3TyX6wavhp+59oLbZiqczIHkaas/nJe21+SVARqFmIII6BwS7ty7+8Uu4fHliA9re+ZSUp+rwg==",
+      "version": "12.0.1",
+      "resolved": "https://registry.npmjs.org/@polkadot/x-global/-/x-global-12.0.1.tgz",
+      "integrity": "sha512-kj/mMv7UPKIq5SnnnzICVOjhhYgUZzE8bT/az1D7z6OXV3SEH+4dmRsDEavwYinGMO7fi5fCvDayRu8r7ne2ZA==",
       "dependencies": {
         "tslib": "^2.5.0"
       },
       "engines": {
-        "node": ">=14"
+        "node": ">=16"
       }
     },
     "node_modules/@polkadot/x-global/node_modules/tslib": {
@@ -821,15 +859,19 @@
       "integrity": "sha512-336iVw3rtn2BUK7ORdIAHTyxHGRIHVReokCR3XjbckJMK7ms8FysBfhLR8IXnAgy7T0PTPNBWKiH514FOW/WSg=="
     },
     "node_modules/@polkadot/x-randomvalues": {
-      "version": "11.1.3",
-      "resolved": "https://registry.npmjs.org/@polkadot/x-randomvalues/-/x-randomvalues-11.1.3.tgz",
-      "integrity": "sha512-kZjbRgxokMR9UTodZQKs6s3C/Q2YgeizcxpDCghM/VdvQUE8OVBGNzduF7SvBvQyg2Qbg8jMcSxXOY7UgcOWSg==",
+      "version": "12.0.1",
+      "resolved": "https://registry.npmjs.org/@polkadot/x-randomvalues/-/x-randomvalues-12.0.1.tgz",
+      "integrity": "sha512-5ZMRbVJNhlKpwYgfcjVynH0jRwiXXn1k2I/xCjr+F6MwBTcIsbNXtgMczJB2PBAJpJvBV9GVpJoZW4Gq6nXdEg==",
       "dependencies": {
-        "@polkadot/x-global": "11.1.3",
+        "@polkadot/x-global": "12.0.1",
         "tslib": "^2.5.0"
       },
       "engines": {
-        "node": ">=14"
+        "node": ">=16"
+      },
+      "peerDependencies": {
+        "@polkadot/util": "12.0.1",
+        "@polkadot/wasm-util": "*"
       }
     },
     "node_modules/@polkadot/x-randomvalues/node_modules/tslib": {
@@ -838,15 +880,15 @@
       "integrity": "sha512-336iVw3rtn2BUK7ORdIAHTyxHGRIHVReokCR3XjbckJMK7ms8FysBfhLR8IXnAgy7T0PTPNBWKiH514FOW/WSg=="
     },
     "node_modules/@polkadot/x-textdecoder": {
-      "version": "11.1.3",
-      "resolved": "https://registry.npmjs.org/@polkadot/x-textdecoder/-/x-textdecoder-11.1.3.tgz",
-      "integrity": "sha512-NhOjuXVfYRMw9l0VhCtZOtcWefZth58p5KpVOrFyJZd12fTsoMO5/746K7QoAjWRrLQTJ/LHCEKCtWww0LwVPw==",
+      "version": "12.0.1",
+      "resolved": "https://registry.npmjs.org/@polkadot/x-textdecoder/-/x-textdecoder-12.0.1.tgz",
+      "integrity": "sha512-CJkJid9UVpJB5TmT4GdnMdm9SsINg5zElTcVMV4F/rS7+SnkIE9X/M91DgvGzq+d+qvU84UNjOgs/ZN3aOKbuA==",
       "dependencies": {
-        "@polkadot/x-global": "11.1.3",
+        "@polkadot/x-global": "12.0.1",
         "tslib": "^2.5.0"
       },
       "engines": {
-        "node": ">=14"
+        "node": ">=16"
       }
     },
     "node_modules/@polkadot/x-textdecoder/node_modules/tslib": {
@@ -855,15 +897,15 @@
       "integrity": "sha512-336iVw3rtn2BUK7ORdIAHTyxHGRIHVReokCR3XjbckJMK7ms8FysBfhLR8IXnAgy7T0PTPNBWKiH514FOW/WSg=="
     },
     "node_modules/@polkadot/x-textencoder": {
-      "version": "11.1.3",
-      "resolved": "https://registry.npmjs.org/@polkadot/x-textencoder/-/x-textencoder-11.1.3.tgz",
-      "integrity": "sha512-7DmqjlPN8aQexLUKwoHeadihpUnW8hjpXEru+aEDxjgq9XIxPvb++NeBK+Mra9RzzZRuiT/K5z16HlwKN//ewg==",
+      "version": "12.0.1",
+      "resolved": "https://registry.npmjs.org/@polkadot/x-textencoder/-/x-textencoder-12.0.1.tgz",
+      "integrity": "sha512-nmS2tN36P4sc4WYiR9HHkgCBZcXksZF3dBsGTppWF6/ssgRmc2TZYoHBMUmdSq0OHg11kCKys94HXrWjPA/GCg==",
       "dependencies": {
-        "@polkadot/x-global": "11.1.3",
+        "@polkadot/x-global": "12.0.1",
         "tslib": "^2.5.0"
       },
       "engines": {
-        "node": ">=14"
+        "node": ">=16"
       }
     },
     "node_modules/@polkadot/x-textencoder/node_modules/tslib": {
@@ -872,16 +914,16 @@
       "integrity": "sha512-336iVw3rtn2BUK7ORdIAHTyxHGRIHVReokCR3XjbckJMK7ms8FysBfhLR8IXnAgy7T0PTPNBWKiH514FOW/WSg=="
     },
     "node_modules/@polkadot/x-ws": {
-      "version": "11.1.3",
-      "resolved": "https://registry.npmjs.org/@polkadot/x-ws/-/x-ws-11.1.3.tgz",
-      "integrity": "sha512-omNU2mIVX997HiHm2YxEdJdyCFnv+oTyKWZd0+FdS47rdfhVwD+H9/bS+rtQ9lIqfhODdGmw3fG//gq1KpYJcw==",
+      "version": "12.0.1",
+      "resolved": "https://registry.npmjs.org/@polkadot/x-ws/-/x-ws-12.0.1.tgz",
+      "integrity": "sha512-hRFNlgBRz549hXJNKykEG4kKgEGHxLRHLyS/+qAOdBefiXWoB7it9D6JgcFqoJpOHyHw3Y8b/kSxwmx+Ub1rTA==",
       "dependencies": {
-        "@polkadot/x-global": "11.1.3",
+        "@polkadot/x-global": "12.0.1",
         "tslib": "^2.5.0",
         "ws": "^8.13.0"
       },
       "engines": {
-        "node": ">=14"
+        "node": ">=16"
       }
     },
     "node_modules/@polkadot/x-ws/node_modules/tslib": {
@@ -901,14 +943,14 @@
       ]
     },
     "node_modules/@substrate/connect": {
-      "version": "0.7.23",
-      "resolved": "https://registry.npmjs.org/@substrate/connect/-/connect-0.7.23.tgz",
-      "integrity": "sha512-zlfI76HdUJszQWG7Dpwd0g7jjQv6LNZtE6Kd7OWv4OdpHJa1VpL2jGjg7YdLhwtx7qxqOuRiak1H+5KrsavzRQ==",
+      "version": "0.7.24",
+      "resolved": "https://registry.npmjs.org/@substrate/connect/-/connect-0.7.24.tgz",
+      "integrity": "sha512-vF82taiM0yME+ibiJgEv0xn/NZd9TQ4atXk1AQCe2z82SEKzw0Lwx9ZLFEOvlgnh+Nc2EtQi7y4cXJ+48rOqxw==",
       "optional": true,
       "dependencies": {
         "@substrate/connect-extension-protocol": "^1.0.1",
         "eventemitter3": "^4.0.7",
-        "smoldot": "1.0.1"
+        "smoldot": "1.0.2"
       }
     },
     "node_modules/@substrate/connect-extension-protocol": {
@@ -978,18 +1020,19 @@
       "dev": true
     },
     "node_modules/@typescript-eslint/eslint-plugin": {
-      "version": "5.42.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-5.42.0.tgz",
-      "integrity": "sha512-5TJh2AgL6+wpL8H/GTSjNb4WrjKoR2rqvFxR/DDTqYNk6uXn8BJMEcncLSpMbf/XV1aS0jAjYwn98uvVCiAywQ==",
+      "version": "5.59.1",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-5.59.1.tgz",
+      "integrity": "sha512-AVi0uazY5quFB9hlp2Xv+ogpfpk77xzsgsIEWyVS7uK/c7MZ5tw7ZPbapa0SbfkqE0fsAMkz5UwtgMLVk2BQAg==",
       "dev": true,
       "dependencies": {
-        "@typescript-eslint/scope-manager": "5.42.0",
-        "@typescript-eslint/type-utils": "5.42.0",
-        "@typescript-eslint/utils": "5.42.0",
+        "@eslint-community/regexpp": "^4.4.0",
+        "@typescript-eslint/scope-manager": "5.59.1",
+        "@typescript-eslint/type-utils": "5.59.1",
+        "@typescript-eslint/utils": "5.59.1",
         "debug": "^4.3.4",
+        "grapheme-splitter": "^1.0.4",
         "ignore": "^5.2.0",
         "natural-compare-lite": "^1.4.0",
-        "regexpp": "^3.2.0",
         "semver": "^7.3.7",
         "tsutils": "^3.21.0"
       },
@@ -1010,30 +1053,15 @@
         }
       }
     },
-    "node_modules/@typescript-eslint/eslint-plugin/node_modules/semver": {
-      "version": "7.3.8",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-7.3.8.tgz",
-      "integrity": "sha512-NB1ctGL5rlHrPJtFDVIVzTyQylMLu9N9VICA6HSFJo8MCGVTMW6gfpicwKmmK/dAjTOrqu5l63JJOpDSrAis3A==",
-      "dev": true,
-      "dependencies": {
-        "lru-cache": "^6.0.0"
-      },
-      "bin": {
-        "semver": "bin/semver.js"
-      },
-      "engines": {
-        "node": ">=10"
-      }
-    },
     "node_modules/@typescript-eslint/parser": {
-      "version": "5.42.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-5.42.0.tgz",
-      "integrity": "sha512-Ixh9qrOTDRctFg3yIwrLkgf33AHyEIn6lhyf5cCfwwiGtkWhNpVKlEZApi3inGQR/barWnY7qY8FbGKBO7p3JA==",
+      "version": "5.59.1",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-5.59.1.tgz",
+      "integrity": "sha512-nzjFAN8WEu6yPRDizIFyzAfgK7nybPodMNFGNH0M9tei2gYnYszRDqVA0xlnRjkl7Hkx2vYrEdb6fP2a21cG1g==",
       "dev": true,
       "dependencies": {
-        "@typescript-eslint/scope-manager": "5.42.0",
-        "@typescript-eslint/types": "5.42.0",
-        "@typescript-eslint/typescript-estree": "5.42.0",
+        "@typescript-eslint/scope-manager": "5.59.1",
+        "@typescript-eslint/types": "5.59.1",
+        "@typescript-eslint/typescript-estree": "5.59.1",
         "debug": "^4.3.4"
       },
       "engines": {
@@ -1053,13 +1081,13 @@
       }
     },
     "node_modules/@typescript-eslint/scope-manager": {
-      "version": "5.42.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-5.42.0.tgz",
-      "integrity": "sha512-l5/3IBHLH0Bv04y+H+zlcLiEMEMjWGaCX6WyHE5Uk2YkSGAMlgdUPsT/ywTSKgu9D1dmmKMYgYZijObfA39Wow==",
+      "version": "5.59.1",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-5.59.1.tgz",
+      "integrity": "sha512-mau0waO5frJctPuAzcxiNWqJR5Z8V0190FTSqRw1Q4Euop6+zTwHAf8YIXNwDOT29tyUDrQ65jSg9aTU/H0omA==",
       "dev": true,
       "dependencies": {
-        "@typescript-eslint/types": "5.42.0",
-        "@typescript-eslint/visitor-keys": "5.42.0"
+        "@typescript-eslint/types": "5.59.1",
+        "@typescript-eslint/visitor-keys": "5.59.1"
       },
       "engines": {
         "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
@@ -1070,13 +1098,13 @@
       }
     },
     "node_modules/@typescript-eslint/type-utils": {
-      "version": "5.42.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/type-utils/-/type-utils-5.42.0.tgz",
-      "integrity": "sha512-HW14TXC45dFVZxnVW8rnUGnvYyRC0E/vxXShFCthcC9VhVTmjqOmtqj6H5rm9Zxv+ORxKA/1aLGD7vmlLsdlOg==",
+      "version": "5.59.1",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/type-utils/-/type-utils-5.59.1.tgz",
+      "integrity": "sha512-ZMWQ+Oh82jWqWzvM3xU+9y5U7MEMVv6GLioM3R5NJk6uvP47kZ7YvlgSHJ7ERD6bOY7Q4uxWm25c76HKEwIjZw==",
       "dev": true,
       "dependencies": {
-        "@typescript-eslint/typescript-estree": "5.42.0",
-        "@typescript-eslint/utils": "5.42.0",
+        "@typescript-eslint/typescript-estree": "5.59.1",
+        "@typescript-eslint/utils": "5.59.1",
         "debug": "^4.3.4",
         "tsutils": "^3.21.0"
       },
@@ -1097,9 +1125,9 @@
       }
     },
     "node_modules/@typescript-eslint/types": {
-      "version": "5.42.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-5.42.0.tgz",
-      "integrity": "sha512-t4lzO9ZOAUcHY6bXQYRuu+3SSYdD9TS8ooApZft4WARt4/f2Cj/YpvbTe8A4GuhT4bNW72goDMOy7SW71mZwGw==",
+      "version": "5.59.1",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-5.59.1.tgz",
+      "integrity": "sha512-dg0ICB+RZwHlysIy/Dh1SP+gnXNzwd/KS0JprD3Lmgmdq+dJAJnUPe1gNG34p0U19HvRlGX733d/KqscrGC1Pg==",
       "dev": true,
       "engines": {
         "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
@@ -1110,13 +1138,13 @@
       }
     },
     "node_modules/@typescript-eslint/typescript-estree": {
-      "version": "5.42.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-5.42.0.tgz",
-      "integrity": "sha512-2O3vSq794x3kZGtV7i4SCWZWCwjEtkWfVqX4m5fbUBomOsEOyd6OAD1qU2lbvV5S8tgy/luJnOYluNyYVeOTTg==",
+      "version": "5.59.1",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-5.59.1.tgz",
+      "integrity": "sha512-lYLBBOCsFltFy7XVqzX0Ju+Lh3WPIAWxYpmH/Q7ZoqzbscLiCW00LeYCdsUnnfnj29/s1WovXKh2gwCoinHNGA==",
       "dev": true,
       "dependencies": {
-        "@typescript-eslint/types": "5.42.0",
-        "@typescript-eslint/visitor-keys": "5.42.0",
+        "@typescript-eslint/types": "5.59.1",
+        "@typescript-eslint/visitor-keys": "5.59.1",
         "debug": "^4.3.4",
         "globby": "^11.1.0",
         "is-glob": "^4.0.3",
@@ -1136,34 +1164,19 @@
         }
       }
     },
-    "node_modules/@typescript-eslint/typescript-estree/node_modules/semver": {
-      "version": "7.3.8",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-7.3.8.tgz",
-      "integrity": "sha512-NB1ctGL5rlHrPJtFDVIVzTyQylMLu9N9VICA6HSFJo8MCGVTMW6gfpicwKmmK/dAjTOrqu5l63JJOpDSrAis3A==",
-      "dev": true,
-      "dependencies": {
-        "lru-cache": "^6.0.0"
-      },
-      "bin": {
-        "semver": "bin/semver.js"
-      },
-      "engines": {
-        "node": ">=10"
-      }
-    },
     "node_modules/@typescript-eslint/utils": {
-      "version": "5.42.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/utils/-/utils-5.42.0.tgz",
-      "integrity": "sha512-JZ++3+h1vbeG1NUECXQZE3hg0kias9kOtcQr3+JVQ3whnjvKuMyktJAAIj6743OeNPnGBmjj7KEmiDL7qsdnCQ==",
+      "version": "5.59.1",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/utils/-/utils-5.59.1.tgz",
+      "integrity": "sha512-MkTe7FE+K1/GxZkP5gRj3rCztg45bEhsd8HYjczBuYm+qFHP5vtZmjx3B0yUCDotceQ4sHgTyz60Ycl225njmA==",
       "dev": true,
       "dependencies": {
+        "@eslint-community/eslint-utils": "^4.2.0",
         "@types/json-schema": "^7.0.9",
         "@types/semver": "^7.3.12",
-        "@typescript-eslint/scope-manager": "5.42.0",
-        "@typescript-eslint/types": "5.42.0",
-        "@typescript-eslint/typescript-estree": "5.42.0",
+        "@typescript-eslint/scope-manager": "5.59.1",
+        "@typescript-eslint/types": "5.59.1",
+        "@typescript-eslint/typescript-estree": "5.59.1",
         "eslint-scope": "^5.1.1",
-        "eslint-utils": "^3.0.0",
         "semver": "^7.3.7"
       },
       "engines": {
@@ -1177,50 +1190,13 @@
         "eslint": "^6.0.0 || ^7.0.0 || ^8.0.0"
       }
     },
-    "node_modules/@typescript-eslint/utils/node_modules/eslint-scope": {
-      "version": "5.1.1",
-      "resolved": "https://registry.npmjs.org/eslint-scope/-/eslint-scope-5.1.1.tgz",
-      "integrity": "sha512-2NxwbF/hZ0KpepYN0cNbo+FN6XoK7GaHlQhgx/hIZl6Va0bF45RQOOwhLIy8lQDbuCiadSLCBnH2CFYquit5bw==",
-      "dev": true,
-      "dependencies": {
-        "esrecurse": "^4.3.0",
-        "estraverse": "^4.1.1"
-      },
-      "engines": {
-        "node": ">=8.0.0"
-      }
-    },
-    "node_modules/@typescript-eslint/utils/node_modules/estraverse": {
-      "version": "4.3.0",
-      "resolved": "https://registry.npmjs.org/estraverse/-/estraverse-4.3.0.tgz",
-      "integrity": "sha512-39nnKffWz8xN1BU/2c79n9nB9HDzo0niYUqx6xyqUnyoAnQyyWpOTdZEeiCch8BBu515t4wp9ZmgVfVhn9EBpw==",
-      "dev": true,
-      "engines": {
-        "node": ">=4.0"
-      }
-    },
-    "node_modules/@typescript-eslint/utils/node_modules/semver": {
-      "version": "7.3.8",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-7.3.8.tgz",
-      "integrity": "sha512-NB1ctGL5rlHrPJtFDVIVzTyQylMLu9N9VICA6HSFJo8MCGVTMW6gfpicwKmmK/dAjTOrqu5l63JJOpDSrAis3A==",
-      "dev": true,
-      "dependencies": {
-        "lru-cache": "^6.0.0"
-      },
-      "bin": {
-        "semver": "bin/semver.js"
-      },
-      "engines": {
-        "node": ">=10"
-      }
-    },
     "node_modules/@typescript-eslint/visitor-keys": {
-      "version": "5.42.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-5.42.0.tgz",
-      "integrity": "sha512-QHbu5Hf/2lOEOwy+IUw0GoSCuAzByTAWWrOTKzTzsotiUnWFpuKnXcAhC9YztAf2EElQ0VvIK+pHJUPkM0q7jg==",
+      "version": "5.59.1",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-5.59.1.tgz",
+      "integrity": "sha512-6waEYwBTCWryx0VJmP7JaM4FpipLsFl9CvYf2foAE8Qh/Y0s+bxWysciwOs0LTBED4JCaNxTZ5rGadB14M6dwA==",
       "dev": true,
       "dependencies": {
-        "@typescript-eslint/types": "5.42.0",
+        "@typescript-eslint/types": "5.59.1",
         "eslint-visitor-keys": "^3.3.0"
       },
       "engines": {
@@ -1230,11 +1206,6 @@
         "type": "opencollective",
         "url": "https://opencollective.com/typescript-eslint"
       }
-    },
-    "node_modules/@ungap/promise-all-settled": {
-      "version": "1.1.2",
-      "dev": true,
-      "license": "ISC"
     },
     "node_modules/acorn": {
       "version": "8.8.0",
@@ -1334,15 +1305,29 @@
       "dev": true,
       "license": "Python-2.0"
     },
-    "node_modules/array-includes": {
-      "version": "3.1.5",
+    "node_modules/array-buffer-byte-length": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/array-buffer-byte-length/-/array-buffer-byte-length-1.0.0.tgz",
+      "integrity": "sha512-LPuwb2P+NrQw3XhxGc36+XSvuBPopovXYTR9Ew++Du9Yb/bx5AzBfrIsBoj0EZUifjQU+sHL21sseZ3jerWO/A==",
       "dev": true,
-      "license": "MIT",
+      "dependencies": {
+        "call-bind": "^1.0.2",
+        "is-array-buffer": "^3.0.1"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/array-includes": {
+      "version": "3.1.6",
+      "resolved": "https://registry.npmjs.org/array-includes/-/array-includes-3.1.6.tgz",
+      "integrity": "sha512-sgTbLvL6cNnw24FnbaDyjmvddQ2ML8arZsgaJhoABMoplz/4QRhtrYS+alr1BUM1Bwp6dhx8vVCBSLG+StwOFw==",
+      "dev": true,
       "dependencies": {
         "call-bind": "^1.0.2",
         "define-properties": "^1.1.4",
-        "es-abstract": "^1.19.5",
-        "get-intrinsic": "^1.1.1",
+        "es-abstract": "^1.20.4",
+        "get-intrinsic": "^1.1.3",
         "is-string": "^1.0.7"
       },
       "engines": {
@@ -1362,15 +1347,46 @@
       }
     },
     "node_modules/array.prototype.flat": {
-      "version": "1.3.0",
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/array.prototype.flat/-/array.prototype.flat-1.3.1.tgz",
+      "integrity": "sha512-roTU0KWIOmJ4DRLmwKd19Otg0/mT3qPNt0Qb3GWW8iObuZXxrjB/pzn0R3hqpRSWg4HCwqx+0vwOnWnvlOyeIA==",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
         "call-bind": "^1.0.2",
-        "define-properties": "^1.1.3",
-        "es-abstract": "^1.19.2",
+        "define-properties": "^1.1.4",
+        "es-abstract": "^1.20.4",
         "es-shim-unscopables": "^1.0.0"
       },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/array.prototype.flatmap": {
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/array.prototype.flatmap/-/array.prototype.flatmap-1.3.1.tgz",
+      "integrity": "sha512-8UGn9O1FDVvMNB0UlLv4voxRMze7+FpHyF5mSMRjWHUMlpoDViniy05870VlxhfgTnLbpuwTzvD76MTtWxB/mQ==",
+      "dev": true,
+      "dependencies": {
+        "call-bind": "^1.0.2",
+        "define-properties": "^1.1.4",
+        "es-abstract": "^1.20.4",
+        "es-shim-unscopables": "^1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/available-typed-arrays": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/available-typed-arrays/-/available-typed-arrays-1.0.5.tgz",
+      "integrity": "sha512-DMD0KiN46eipeziST1LPP/STfDU0sufISXmjSgvVsoU2tqxctQeASejWcfNtxYKqETM1UxQ8sp2OrSBWpHY6sw==",
+      "dev": true,
       "engines": {
         "node": ">= 0.4"
       },
@@ -1424,8 +1440,9 @@
     },
     "node_modules/call-bind": {
       "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/call-bind/-/call-bind-1.0.2.tgz",
+      "integrity": "sha512-7O+FbCihrB5WGbFYesctwmTKae6rOiIzmz1icreWJ+0aA7LJfuqhEso2T9ncpcFtzMQtzXf2QGGueWJGTYsqrA==",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
         "function-bind": "^1.1.1",
         "get-intrinsic": "^1.0.2"
@@ -1596,9 +1613,10 @@
       "license": "MIT"
     },
     "node_modules/define-properties": {
-      "version": "1.1.4",
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/define-properties/-/define-properties-1.2.0.tgz",
+      "integrity": "sha512-xvqAVKGfT1+UAvPwKTVw/njhdQ8ZhXK4lI0bCIuCMrp2up9nPnaDftrLtmpTazqd1o+UY4zgzU+avtMbDP+ldA==",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
         "has-property-descriptors": "^1.0.0",
         "object-keys": "^1.1.1"
@@ -1647,33 +1665,45 @@
       "license": "MIT"
     },
     "node_modules/es-abstract": {
-      "version": "1.20.1",
+      "version": "1.21.2",
+      "resolved": "https://registry.npmjs.org/es-abstract/-/es-abstract-1.21.2.tgz",
+      "integrity": "sha512-y/B5POM2iBnIxCiernH1G7rC9qQoM77lLIMQLuob0zhp8C56Po81+2Nj0WFKnd0pNReDTnkYryc+zhOzpEIROg==",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
+        "array-buffer-byte-length": "^1.0.0",
+        "available-typed-arrays": "^1.0.5",
         "call-bind": "^1.0.2",
+        "es-set-tostringtag": "^2.0.1",
         "es-to-primitive": "^1.2.1",
-        "function-bind": "^1.1.1",
         "function.prototype.name": "^1.1.5",
-        "get-intrinsic": "^1.1.1",
+        "get-intrinsic": "^1.2.0",
         "get-symbol-description": "^1.0.0",
+        "globalthis": "^1.0.3",
+        "gopd": "^1.0.1",
         "has": "^1.0.3",
         "has-property-descriptors": "^1.0.0",
+        "has-proto": "^1.0.1",
         "has-symbols": "^1.0.3",
-        "internal-slot": "^1.0.3",
-        "is-callable": "^1.2.4",
+        "internal-slot": "^1.0.5",
+        "is-array-buffer": "^3.0.2",
+        "is-callable": "^1.2.7",
         "is-negative-zero": "^2.0.2",
         "is-regex": "^1.1.4",
         "is-shared-array-buffer": "^1.0.2",
         "is-string": "^1.0.7",
+        "is-typed-array": "^1.1.10",
         "is-weakref": "^1.0.2",
-        "object-inspect": "^1.12.0",
+        "object-inspect": "^1.12.3",
         "object-keys": "^1.1.1",
-        "object.assign": "^4.1.2",
+        "object.assign": "^4.1.4",
         "regexp.prototype.flags": "^1.4.3",
-        "string.prototype.trimend": "^1.0.5",
-        "string.prototype.trimstart": "^1.0.5",
-        "unbox-primitive": "^1.0.2"
+        "safe-regex-test": "^1.0.0",
+        "string.prototype.trim": "^1.2.7",
+        "string.prototype.trimend": "^1.0.6",
+        "string.prototype.trimstart": "^1.0.6",
+        "typed-array-length": "^1.0.4",
+        "unbox-primitive": "^1.0.2",
+        "which-typed-array": "^1.1.9"
       },
       "engines": {
         "node": ">= 0.4"
@@ -1682,18 +1712,34 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/es-set-tostringtag": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/es-set-tostringtag/-/es-set-tostringtag-2.0.1.tgz",
+      "integrity": "sha512-g3OMbtlwY3QewlqAiMLI47KywjWZoEytKr8pf6iTC8uJq5bIAH52Z9pnQ8pVL6whrCto53JZDuUIsifGeLorTg==",
+      "dev": true,
+      "dependencies": {
+        "get-intrinsic": "^1.1.3",
+        "has": "^1.0.3",
+        "has-tostringtag": "^1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
     "node_modules/es-shim-unscopables": {
       "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/es-shim-unscopables/-/es-shim-unscopables-1.0.0.tgz",
+      "integrity": "sha512-Jm6GPcCdC30eMLbZ2x8z2WuRwAws3zTBBKuusffYVUrNj/GVSUAZ+xKMaUpfNDR5IbyNA5LJbaecoUVbmUcB1w==",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
         "has": "^1.0.3"
       }
     },
     "node_modules/es-to-primitive": {
       "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/es-to-primitive/-/es-to-primitive-1.2.1.tgz",
+      "integrity": "sha512-QCOllgZJtaUo9miYBcLChTUaHNjJF3PYs1VidD7AwiEj1kYxKeQTctLAezAOH5ZKRH0g2IgPn6KwB4IT8iRpvA==",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
         "is-callable": "^1.1.4",
         "is-date-object": "^1.0.1",
@@ -1726,13 +1772,16 @@
       }
     },
     "node_modules/eslint": {
-      "version": "8.26.0",
-      "resolved": "https://registry.npmjs.org/eslint/-/eslint-8.26.0.tgz",
-      "integrity": "sha512-kzJkpaw1Bfwheq4VXUezFriD1GxszX6dUekM7Z3aC2o4hju+tsR/XyTC3RcoSD7jmy9VkPU3+N6YjVU2e96Oyg==",
+      "version": "8.39.0",
+      "resolved": "https://registry.npmjs.org/eslint/-/eslint-8.39.0.tgz",
+      "integrity": "sha512-mwiok6cy7KTW7rBpo05k6+p4YVZByLNjAZ/ACB9DRCu4YDRwjXI01tWHp6KAUWelsBetTxKK/2sHB0vdS8Z2Og==",
       "dev": true,
       "dependencies": {
-        "@eslint/eslintrc": "^1.3.3",
-        "@humanwhocodes/config-array": "^0.11.6",
+        "@eslint-community/eslint-utils": "^4.2.0",
+        "@eslint-community/regexpp": "^4.4.0",
+        "@eslint/eslintrc": "^2.0.2",
+        "@eslint/js": "8.39.0",
+        "@humanwhocodes/config-array": "^0.11.8",
         "@humanwhocodes/module-importer": "^1.0.1",
         "@nodelib/fs.walk": "^1.2.8",
         "ajv": "^6.10.0",
@@ -1741,17 +1790,16 @@
         "debug": "^4.3.2",
         "doctrine": "^3.0.0",
         "escape-string-regexp": "^4.0.0",
-        "eslint-scope": "^7.1.1",
-        "eslint-utils": "^3.0.0",
-        "eslint-visitor-keys": "^3.3.0",
-        "espree": "^9.4.0",
-        "esquery": "^1.4.0",
+        "eslint-scope": "^7.2.0",
+        "eslint-visitor-keys": "^3.4.0",
+        "espree": "^9.5.1",
+        "esquery": "^1.4.2",
         "esutils": "^2.0.2",
         "fast-deep-equal": "^3.1.3",
         "file-entry-cache": "^6.0.1",
         "find-up": "^5.0.0",
         "glob-parent": "^6.0.2",
-        "globals": "^13.15.0",
+        "globals": "^13.19.0",
         "grapheme-splitter": "^1.0.4",
         "ignore": "^5.2.0",
         "import-fresh": "^3.0.0",
@@ -1766,7 +1814,6 @@
         "minimatch": "^3.1.2",
         "natural-compare": "^1.4.0",
         "optionator": "^0.9.1",
-        "regexpp": "^3.2.0",
         "strip-ansi": "^6.0.1",
         "strip-json-comments": "^3.1.0",
         "text-table": "^0.2.0"
@@ -1782,9 +1829,10 @@
       }
     },
     "node_modules/eslint-config-prettier": {
-      "version": "8.5.0",
+      "version": "8.8.0",
+      "resolved": "https://registry.npmjs.org/eslint-config-prettier/-/eslint-config-prettier-8.8.0.tgz",
+      "integrity": "sha512-wLbQiFre3tdGgpDv67NQKnJuTlcUVYHas3k+DZCc2U2BadthoEY4B7hLPvAxaqdyOGCzuLfii2fqGph10va7oA==",
       "dev": true,
-      "license": "MIT",
       "bin": {
         "eslint-config-prettier": "bin/cli.js"
       },
@@ -1793,104 +1841,71 @@
       }
     },
     "node_modules/eslint-import-resolver-node": {
-      "version": "0.3.6",
+      "version": "0.3.7",
+      "resolved": "https://registry.npmjs.org/eslint-import-resolver-node/-/eslint-import-resolver-node-0.3.7.tgz",
+      "integrity": "sha512-gozW2blMLJCeFpBwugLTGyvVjNoeo1knonXAcatC6bjPBZitotxdWf7Gimr25N4c0AAOo4eOUfaG82IJPDpqCA==",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
         "debug": "^3.2.7",
-        "resolve": "^1.20.0"
+        "is-core-module": "^2.11.0",
+        "resolve": "^1.22.1"
       }
     },
     "node_modules/eslint-import-resolver-node/node_modules/debug": {
       "version": "3.2.7",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-3.2.7.tgz",
+      "integrity": "sha512-CFjzYYAi4ThfiQvizrFQevTTXHtnCqWfe7x1AhgEscTz6ZbLbfoLRLPugTQyBth6f8ZERVUSyWHFD/7Wu4t1XQ==",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
         "ms": "^2.1.1"
       }
     },
     "node_modules/eslint-module-utils": {
-      "version": "2.7.3",
+      "version": "2.8.0",
+      "resolved": "https://registry.npmjs.org/eslint-module-utils/-/eslint-module-utils-2.8.0.tgz",
+      "integrity": "sha512-aWajIYfsqCKRDgUfjEXNN/JlrzauMuSEy5sbd7WXbtW3EH6A6MpwEh42c7qD+MqQo9QMJ6fWLAeIJynx0g6OAw==",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
-        "debug": "^3.2.7",
-        "find-up": "^2.1.0"
+        "debug": "^3.2.7"
       },
       "engines": {
         "node": ">=4"
+      },
+      "peerDependenciesMeta": {
+        "eslint": {
+          "optional": true
+        }
       }
     },
     "node_modules/eslint-module-utils/node_modules/debug": {
       "version": "3.2.7",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-3.2.7.tgz",
+      "integrity": "sha512-CFjzYYAi4ThfiQvizrFQevTTXHtnCqWfe7x1AhgEscTz6ZbLbfoLRLPugTQyBth6f8ZERVUSyWHFD/7Wu4t1XQ==",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
         "ms": "^2.1.1"
       }
     },
-    "node_modules/eslint-module-utils/node_modules/find-up": {
-      "version": "2.1.0",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "locate-path": "^2.0.0"
-      },
-      "engines": {
-        "node": ">=4"
-      }
-    },
-    "node_modules/eslint-module-utils/node_modules/locate-path": {
-      "version": "2.0.0",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "p-locate": "^2.0.0",
-        "path-exists": "^3.0.0"
-      },
-      "engines": {
-        "node": ">=4"
-      }
-    },
-    "node_modules/eslint-module-utils/node_modules/p-limit": {
-      "version": "1.3.0",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "p-try": "^1.0.0"
-      },
-      "engines": {
-        "node": ">=4"
-      }
-    },
-    "node_modules/eslint-module-utils/node_modules/p-locate": {
-      "version": "2.0.0",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "p-limit": "^1.1.0"
-      },
-      "engines": {
-        "node": ">=4"
-      }
-    },
     "node_modules/eslint-plugin-import": {
-      "version": "2.26.0",
+      "version": "2.27.5",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-import/-/eslint-plugin-import-2.27.5.tgz",
+      "integrity": "sha512-LmEt3GVofgiGuiE+ORpnvP+kAm3h6MLZJ4Q5HCyHADofsb4VzXFsRiWj3c0OFiV+3DWFh0qg3v9gcPlfc3zRow==",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
-        "array-includes": "^3.1.4",
-        "array.prototype.flat": "^1.2.5",
-        "debug": "^2.6.9",
+        "array-includes": "^3.1.6",
+        "array.prototype.flat": "^1.3.1",
+        "array.prototype.flatmap": "^1.3.1",
+        "debug": "^3.2.7",
         "doctrine": "^2.1.0",
-        "eslint-import-resolver-node": "^0.3.6",
-        "eslint-module-utils": "^2.7.3",
+        "eslint-import-resolver-node": "^0.3.7",
+        "eslint-module-utils": "^2.7.4",
         "has": "^1.0.3",
-        "is-core-module": "^2.8.1",
+        "is-core-module": "^2.11.0",
         "is-glob": "^4.0.3",
         "minimatch": "^3.1.2",
-        "object.values": "^1.1.5",
-        "resolve": "^1.22.0",
+        "object.values": "^1.1.6",
+        "resolve": "^1.22.1",
+        "semver": "^6.3.0",
         "tsconfig-paths": "^3.14.1"
       },
       "engines": {
@@ -1901,17 +1916,22 @@
       }
     },
     "node_modules/eslint-plugin-import/node_modules/debug": {
-      "version": "2.6.9",
+      "version": "3.2.7",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-3.2.7.tgz",
+      "integrity": "sha512-CFjzYYAi4ThfiQvizrFQevTTXHtnCqWfe7x1AhgEscTz6ZbLbfoLRLPugTQyBth6f8ZERVUSyWHFD/7Wu4t1XQ==",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
-        "ms": "2.0.0"
+        "ms": "^2.1.1"
       }
     },
-    "node_modules/eslint-plugin-import/node_modules/ms": {
-      "version": "2.0.0",
+    "node_modules/eslint-plugin-import/node_modules/semver": {
+      "version": "6.3.0",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.0.tgz",
+      "integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw==",
       "dev": true,
-      "license": "MIT"
+      "bin": {
+        "semver": "bin/semver.js"
+      }
     },
     "node_modules/eslint-plugin-mocha": {
       "version": "10.1.0",
@@ -1950,15 +1970,16 @@
       }
     },
     "node_modules/eslint-scope": {
-      "version": "7.1.1",
+      "version": "5.1.1",
+      "resolved": "https://registry.npmjs.org/eslint-scope/-/eslint-scope-5.1.1.tgz",
+      "integrity": "sha512-2NxwbF/hZ0KpepYN0cNbo+FN6XoK7GaHlQhgx/hIZl6Va0bF45RQOOwhLIy8lQDbuCiadSLCBnH2CFYquit5bw==",
       "dev": true,
-      "license": "BSD-2-Clause",
       "dependencies": {
         "esrecurse": "^4.3.0",
-        "estraverse": "^5.2.0"
+        "estraverse": "^4.1.1"
       },
       "engines": {
-        "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+        "node": ">=8.0.0"
       }
     },
     "node_modules/eslint-utils": {
@@ -1987,12 +2008,15 @@
       }
     },
     "node_modules/eslint-visitor-keys": {
-      "version": "3.3.0",
-      "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-3.3.0.tgz",
-      "integrity": "sha512-mQ+suqKJVyeuwGYHAdjMFqjCyfl8+Ldnxuyp3ldiMBFKkvytrXUZWaiPCEav8qDHKty44bD+qV1IP4T+w+xXRA==",
+      "version": "3.4.0",
+      "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-3.4.0.tgz",
+      "integrity": "sha512-HPpKPUBQcAsZOsHAFwTtIKcYlCje62XB7SEAcxjtmW6TD1WVpkS6i6/hOVtTZIl4zGj/mBqpFVGvaDneik+VoQ==",
       "dev": true,
       "engines": {
         "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/eslint"
       }
     },
     "node_modules/eslint/node_modules/doctrine": {
@@ -2004,6 +2028,31 @@
       },
       "engines": {
         "node": ">=6.0.0"
+      }
+    },
+    "node_modules/eslint/node_modules/eslint-scope": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/eslint-scope/-/eslint-scope-7.2.0.tgz",
+      "integrity": "sha512-DYj5deGlHBfMt15J7rdtyKNq/Nqlv5KfU4iodrQ019XESsRnwXH9KAE0y3cwtUHDo2ob7CypAnCqefh6vioWRw==",
+      "dev": true,
+      "dependencies": {
+        "esrecurse": "^4.3.0",
+        "estraverse": "^5.2.0"
+      },
+      "engines": {
+        "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/eslint"
+      }
+    },
+    "node_modules/eslint/node_modules/estraverse": {
+      "version": "5.3.0",
+      "resolved": "https://registry.npmjs.org/estraverse/-/estraverse-5.3.0.tgz",
+      "integrity": "sha512-MMdARuVEQziNTeJD8DgMqmhwR11BRQ/cBP+pLtYdSTnf3MIO8fFeiINEbX36ZdNlfU/7A9f3gUw49B3oQsvwBA==",
+      "dev": true,
+      "engines": {
+        "node": ">=4.0"
       }
     },
     "node_modules/eslint/node_modules/glob-parent": {
@@ -2018,14 +2067,14 @@
       }
     },
     "node_modules/espree": {
-      "version": "9.4.0",
-      "resolved": "https://registry.npmjs.org/espree/-/espree-9.4.0.tgz",
-      "integrity": "sha512-DQmnRpLj7f6TgN/NYb0MTzJXL+vJF9h3pHy4JhCIs3zwcgez8xmGg3sXHcEO97BrmO2OSvCwMdfdlyl+E9KjOw==",
+      "version": "9.5.1",
+      "resolved": "https://registry.npmjs.org/espree/-/espree-9.5.1.tgz",
+      "integrity": "sha512-5yxtHSZXRSW5pvv3hAlXM5+/Oswi1AUFqBmbibKb5s6bp3rGIDkyXU6xCoyuuLhijr4SFwPrXRoZjz0AZDN9tg==",
       "dev": true,
       "dependencies": {
         "acorn": "^8.8.0",
         "acorn-jsx": "^5.3.2",
-        "eslint-visitor-keys": "^3.3.0"
+        "eslint-visitor-keys": "^3.4.0"
       },
       "engines": {
         "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
@@ -2035,9 +2084,10 @@
       }
     },
     "node_modules/esquery": {
-      "version": "1.4.0",
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/esquery/-/esquery-1.5.0.tgz",
+      "integrity": "sha512-YQLXUplAwJgCydQ78IMJywZCceoqk1oH01OERdSAJc/7U2AylwjhSCLDEtqwg811idIS/9fIU5GjG73IgjKMVg==",
       "dev": true,
-      "license": "BSD-3-Clause",
       "dependencies": {
         "estraverse": "^5.1.0"
       },
@@ -2045,10 +2095,20 @@
         "node": ">=0.10"
       }
     },
+    "node_modules/esquery/node_modules/estraverse": {
+      "version": "5.3.0",
+      "resolved": "https://registry.npmjs.org/estraverse/-/estraverse-5.3.0.tgz",
+      "integrity": "sha512-MMdARuVEQziNTeJD8DgMqmhwR11BRQ/cBP+pLtYdSTnf3MIO8fFeiINEbX36ZdNlfU/7A9f3gUw49B3oQsvwBA==",
+      "dev": true,
+      "engines": {
+        "node": ">=4.0"
+      }
+    },
     "node_modules/esrecurse": {
       "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/esrecurse/-/esrecurse-4.3.0.tgz",
+      "integrity": "sha512-KmfKL3b6G+RXvP8N1vr3Tq1kL/oCFgn2NYXEtqP8/L3pKapUA4G8cFVaoF3SU323CD4XypR/ffioHmkti6/Tag==",
       "dev": true,
-      "license": "BSD-2-Clause",
       "dependencies": {
         "estraverse": "^5.2.0"
       },
@@ -2056,10 +2116,20 @@
         "node": ">=4.0"
       }
     },
-    "node_modules/estraverse": {
+    "node_modules/esrecurse/node_modules/estraverse": {
       "version": "5.3.0",
+      "resolved": "https://registry.npmjs.org/estraverse/-/estraverse-5.3.0.tgz",
+      "integrity": "sha512-MMdARuVEQziNTeJD8DgMqmhwR11BRQ/cBP+pLtYdSTnf3MIO8fFeiINEbX36ZdNlfU/7A9f3gUw49B3oQsvwBA==",
       "dev": true,
-      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=4.0"
+      }
+    },
+    "node_modules/estraverse": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/estraverse/-/estraverse-4.3.0.tgz",
+      "integrity": "sha512-39nnKffWz8xN1BU/2c79n9nB9HDzo0niYUqx6xyqUnyoAnQyyWpOTdZEeiCch8BBu515t4wp9ZmgVfVhn9EBpw==",
+      "dev": true,
       "engines": {
         "node": ">=4.0"
       }
@@ -2217,6 +2287,15 @@
       "dev": true,
       "license": "ISC"
     },
+    "node_modules/for-each": {
+      "version": "0.3.3",
+      "resolved": "https://registry.npmjs.org/for-each/-/for-each-0.3.3.tgz",
+      "integrity": "sha512-jqYfLp7mo9vIyQf8ykW2v7A+2N4QjeCeI5+Dz9XraiO1ign81wjiH7Fb9vSOWvQfNtmSa4H2RoQTrrXivdUZmw==",
+      "dev": true,
+      "dependencies": {
+        "is-callable": "^1.1.3"
+      }
+    },
     "node_modules/formdata-polyfill": {
       "version": "4.0.10",
       "resolved": "https://registry.npmjs.org/formdata-polyfill/-/formdata-polyfill-4.0.10.tgz",
@@ -2249,13 +2328,15 @@
     },
     "node_modules/function-bind": {
       "version": "1.1.1",
-      "dev": true,
-      "license": "MIT"
+      "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.1.tgz",
+      "integrity": "sha512-yIovAzMX49sF8Yl58fSCWJ5svSLuaibPxXQJFLmBObTuCr0Mf1KiPopGM9NiFjiYBCbfaa2Fh6breQ6ANVTI0A==",
+      "dev": true
     },
     "node_modules/function.prototype.name": {
       "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/function.prototype.name/-/function.prototype.name-1.1.5.tgz",
+      "integrity": "sha512-uN7m/BzVKQnCUF/iW8jYea67v++2u7m5UgENbHRtdDVclOUP+FMPlCNdmk0h/ysGyo2tavMJEDqJAkJdRa1vMA==",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
         "call-bind": "^1.0.2",
         "define-properties": "^1.1.3",
@@ -2271,8 +2352,9 @@
     },
     "node_modules/functions-have-names": {
       "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/functions-have-names/-/functions-have-names-1.2.3.tgz",
+      "integrity": "sha512-xckBUXyTIqT97tq2x2AMb+g163b5JFysYk0x4qxNFwbfQkmNZoiRHb6sPzI9/QV33WeuvVYBUIiD4NzNIyqaRQ==",
       "dev": true,
-      "license": "MIT",
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
       }
@@ -2286,9 +2368,10 @@
       }
     },
     "node_modules/get-intrinsic": {
-      "version": "1.1.2",
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.2.0.tgz",
+      "integrity": "sha512-L049y6nFOuom5wGyRc3/gdTLO94dySVKRACj1RmJZBQXlbTMhtNIgkWkUHq+jYmZvKf14EW1EoJnnjbmoHij0Q==",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
         "function-bind": "^1.1.1",
         "has": "^1.0.3",
@@ -2300,8 +2383,9 @@
     },
     "node_modules/get-symbol-description": {
       "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/get-symbol-description/-/get-symbol-description-1.0.0.tgz",
+      "integrity": "sha512-2EmdH1YvIQiZpltCNgkuiUnyukzxM/R6NDJX31Ke3BG1Nq5b0S2PhX59UKi9vZpPDQVdqn+1IcaAwnzTT5vCjw==",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
         "call-bind": "^1.0.2",
         "get-intrinsic": "^1.1.1"
@@ -2359,6 +2443,21 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/globalthis": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/globalthis/-/globalthis-1.0.3.tgz",
+      "integrity": "sha512-sFdI5LyBiNTHjRd7cGPWapiHWMOXKyuBNX/cWJ3NfzrZQVa8GI/8cofCl74AOVqq9W5kNmguTIzJ/1s2gyI9wA==",
+      "dev": true,
+      "dependencies": {
+        "define-properties": "^1.1.3"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
     "node_modules/globby": {
       "version": "11.1.0",
       "resolved": "https://registry.npmjs.org/globby/-/globby-11.1.0.tgz",
@@ -2377,6 +2476,18 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/gopd": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/gopd/-/gopd-1.0.1.tgz",
+      "integrity": "sha512-d65bNlIadxvpb/A2abVdlqKqV563juRnZ1Wtk6s1sIR8uNsXR70xqIzVqxVf1eTqDunwT2MkczEeaezCKTZhwA==",
+      "dev": true,
+      "dependencies": {
+        "get-intrinsic": "^1.1.3"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
       }
     },
     "node_modules/grapheme-splitter": {
@@ -2407,8 +2518,9 @@
     },
     "node_modules/has": {
       "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/has/-/has-1.0.3.tgz",
+      "integrity": "sha512-f2dvO0VU6Oej7RkWJGrehjbzMAjFp5/VKPp5tTpWIV4JHHZK1/BxbFRtf/siA2SWTe09caDmVtYYzWEIbBS4zw==",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
         "function-bind": "^1.1.1"
       },
@@ -2418,8 +2530,9 @@
     },
     "node_modules/has-bigints": {
       "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/has-bigints/-/has-bigints-1.0.2.tgz",
+      "integrity": "sha512-tSvCKtBr9lkF0Ex0aQiP9N+OpV4zi2r/Nee5VkRDbaqv35RLYMzbwQfFSZZH0kR+Rd6302UJZ2p/bJCEoR3VoQ==",
       "dev": true,
-      "license": "MIT",
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
       }
@@ -2434,8 +2547,9 @@
     },
     "node_modules/has-property-descriptors": {
       "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/has-property-descriptors/-/has-property-descriptors-1.0.0.tgz",
+      "integrity": "sha512-62DVLZGoiEBDHQyqG4w9xCuZ7eJEwNmJRWw2VY84Oedb7WFcA27fiEVe8oUQx9hAUJ4ekurquucTGwsyO1XGdQ==",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
         "get-intrinsic": "^1.1.1"
       },
@@ -2443,10 +2557,23 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/has-proto": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/has-proto/-/has-proto-1.0.1.tgz",
+      "integrity": "sha512-7qE+iP+O+bgF9clE5+UoBFzE65mlBiVj3tKCrlNQ0Ogwm0BjpT/gK4SlLYDMybDh5I3TCTKnPPa0oMG7JDYrhg==",
+      "dev": true,
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
     "node_modules/has-symbols": {
       "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.0.3.tgz",
+      "integrity": "sha512-l3LCuF6MgDNwTDKkdYGEihYjt5pRPbEg46rtlmnSPlUbgmB8LOIrKJbYYFBSbnPaJexMKtiPO8hmeRjRz2Td+A==",
       "dev": true,
-      "license": "MIT",
       "engines": {
         "node": ">= 0.4"
       },
@@ -2456,8 +2583,9 @@
     },
     "node_modules/has-tostringtag": {
       "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/has-tostringtag/-/has-tostringtag-1.0.0.tgz",
+      "integrity": "sha512-kFjcSNhnlGV1kyoGk7OXKSawH5JOb/LzUc5w9B02hOTO0dfFRjbHQKvg1d6cf3HbeUmtU9VbbV3qzZ2Teh97WQ==",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
         "has-symbols": "^1.0.2"
       },
@@ -2523,11 +2651,12 @@
       "license": "ISC"
     },
     "node_modules/internal-slot": {
-      "version": "1.0.3",
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/internal-slot/-/internal-slot-1.0.5.tgz",
+      "integrity": "sha512-Y+R5hJrzs52QCG2laLn4udYVnxsfny9CpOhNhUvk/SSSVyF6T27FzRbF0sroPidSu3X8oEAkOn2K804mjpt6UQ==",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
-        "get-intrinsic": "^1.1.0",
+        "get-intrinsic": "^1.2.0",
         "has": "^1.0.3",
         "side-channel": "^1.0.4"
       },
@@ -2535,10 +2664,25 @@
         "node": ">= 0.4"
       }
     },
+    "node_modules/is-array-buffer": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/is-array-buffer/-/is-array-buffer-3.0.2.tgz",
+      "integrity": "sha512-y+FyyR/w8vfIRq4eQcM1EYgSTnmHXPqaF+IgzgraytCFq5Xh8lllDVmAZolPJiZttZLeFSINPYMaEJ7/vWUa1w==",
+      "dev": true,
+      "dependencies": {
+        "call-bind": "^1.0.2",
+        "get-intrinsic": "^1.2.0",
+        "is-typed-array": "^1.1.10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
     "node_modules/is-bigint": {
       "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/is-bigint/-/is-bigint-1.0.4.tgz",
+      "integrity": "sha512-zB9CruMamjym81i2JZ3UMn54PKGsQzsJeo6xvN3HJJ4CAsQNB6iRutp2To77OfCNuoxspsIhzaPoO1zyCEhFOg==",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
         "has-bigints": "^1.0.1"
       },
@@ -2560,8 +2704,9 @@
     },
     "node_modules/is-boolean-object": {
       "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/is-boolean-object/-/is-boolean-object-1.1.2.tgz",
+      "integrity": "sha512-gDYaKHJmnj4aWxyj6YHyXVpdQawtVLHU5cb+eztPGczf6cjuTdwve5ZIEfgXqH4e57An1D1AKf8CZ3kYrQRqYA==",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
         "call-bind": "^1.0.2",
         "has-tostringtag": "^1.0.0"
@@ -2574,9 +2719,10 @@
       }
     },
     "node_modules/is-callable": {
-      "version": "1.2.4",
+      "version": "1.2.7",
+      "resolved": "https://registry.npmjs.org/is-callable/-/is-callable-1.2.7.tgz",
+      "integrity": "sha512-1BC0BVFhS/p0qtw6enp8e+8OD0UrK0oFLztSjNzhcKA3WDuJxxAPXzPuPtKkjEY9UUoEWlX/8fgKeu2S8i9JTA==",
       "dev": true,
-      "license": "MIT",
       "engines": {
         "node": ">= 0.4"
       },
@@ -2585,9 +2731,10 @@
       }
     },
     "node_modules/is-core-module": {
-      "version": "2.9.0",
+      "version": "2.12.0",
+      "resolved": "https://registry.npmjs.org/is-core-module/-/is-core-module-2.12.0.tgz",
+      "integrity": "sha512-RECHCBCd/viahWmwj6enj19sKbHfJrddi/6cBDsNTKbNq0f7VeaUkBo60BqzvPqo/W54ChS62Z5qyun7cfOMqQ==",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
         "has": "^1.0.3"
       },
@@ -2597,8 +2744,9 @@
     },
     "node_modules/is-date-object": {
       "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/is-date-object/-/is-date-object-1.0.5.tgz",
+      "integrity": "sha512-9YQaSxsAiSwcvS33MBk3wTCVnWK+HhF8VZR2jRxehM16QcVOdHqPn4VPHmRK4lSr38n9JriurInLcP90xsYNfQ==",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
         "has-tostringtag": "^1.0.0"
       },
@@ -2638,8 +2786,9 @@
     },
     "node_modules/is-negative-zero": {
       "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/is-negative-zero/-/is-negative-zero-2.0.2.tgz",
+      "integrity": "sha512-dqJvarLawXsFbNDeJW7zAz8ItJ9cd28YufuuFzh0G8pNHjJMnY08Dv7sYX2uF5UpQOwieAeOExEYAWWfu7ZZUA==",
       "dev": true,
-      "license": "MIT",
       "engines": {
         "node": ">= 0.4"
       },
@@ -2657,8 +2806,9 @@
     },
     "node_modules/is-number-object": {
       "version": "1.0.7",
+      "resolved": "https://registry.npmjs.org/is-number-object/-/is-number-object-1.0.7.tgz",
+      "integrity": "sha512-k1U0IRzLMo7ZlYIfzRu23Oh6MiIFasgpb9X76eqfFZAqwH44UI4KTBvBYIZ1dSL9ZzChTB9ShHfLkR4pdW5krQ==",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
         "has-tostringtag": "^1.0.0"
       },
@@ -2688,8 +2838,9 @@
     },
     "node_modules/is-regex": {
       "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/is-regex/-/is-regex-1.1.4.tgz",
+      "integrity": "sha512-kvRdxDsxZjhzUX07ZnLydzS1TU/TJlTUHHY4YLL87e37oUA49DfkLqgy+VjFocowy29cKvcSiu+kIv728jTTVg==",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
         "call-bind": "^1.0.2",
         "has-tostringtag": "^1.0.0"
@@ -2703,8 +2854,9 @@
     },
     "node_modules/is-shared-array-buffer": {
       "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/is-shared-array-buffer/-/is-shared-array-buffer-1.0.2.tgz",
+      "integrity": "sha512-sqN2UDu1/0y6uvXyStCOzyhAjCSlHceFoMKJW8W9EU9cvic/QdsZ0kEU93HEy3IUEFZIiH/3w+AH/UQbPHNdhA==",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
         "call-bind": "^1.0.2"
       },
@@ -2714,8 +2866,9 @@
     },
     "node_modules/is-string": {
       "version": "1.0.7",
+      "resolved": "https://registry.npmjs.org/is-string/-/is-string-1.0.7.tgz",
+      "integrity": "sha512-tE2UXzivje6ofPW7l23cjDOMa09gb7xlAqG6jG5ej6uPV32TlWP3NKPigtaGeHNu9fohccRYvIiZMfOOnOYUtg==",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
         "has-tostringtag": "^1.0.0"
       },
@@ -2728,10 +2881,30 @@
     },
     "node_modules/is-symbol": {
       "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/is-symbol/-/is-symbol-1.0.4.tgz",
+      "integrity": "sha512-C/CPBqKWnvdcxqIARxyOh4v1UUEOCHpgDa0WYgpKDFMszcrPcffg5uhwSgPCLD2WWxmq6isisz87tzT01tuGhg==",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
         "has-symbols": "^1.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/is-typed-array": {
+      "version": "1.1.10",
+      "resolved": "https://registry.npmjs.org/is-typed-array/-/is-typed-array-1.1.10.tgz",
+      "integrity": "sha512-PJqgEHiWZvMpaFZ3uTc8kHPM4+4ADTlDniuQL7cU/UDA0Ql7F70yGfHph3cLNe+c9toaigv+DFzTJKhc2CtO6A==",
+      "dev": true,
+      "dependencies": {
+        "available-typed-arrays": "^1.0.5",
+        "call-bind": "^1.0.2",
+        "for-each": "^0.3.3",
+        "gopd": "^1.0.1",
+        "has-tostringtag": "^1.0.0"
       },
       "engines": {
         "node": ">= 0.4"
@@ -2753,8 +2926,9 @@
     },
     "node_modules/is-weakref": {
       "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/is-weakref/-/is-weakref-1.0.2.tgz",
+      "integrity": "sha512-qctsuLZmIQ0+vSSMfoVvyFe2+GSEvnmZ2ezTup1SBse9+twCCeial6EEi3Nc2KFcf6+qz2FBPnjXsk8xhKSaPQ==",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
         "call-bind": "^1.0.2"
       },
@@ -2918,12 +3092,11 @@
       "license": "MIT"
     },
     "node_modules/mocha": {
-      "version": "10.0.0",
-      "resolved": "https://registry.npmjs.org/mocha/-/mocha-10.0.0.tgz",
-      "integrity": "sha512-0Wl+elVUD43Y0BqPZBzZt8Tnkw9CMUdNYnUsTfOM1vuhJVZL+kiesFYsqwBkEEuEixaiPe5ZQdqDgX2jddhmoA==",
+      "version": "10.2.0",
+      "resolved": "https://registry.npmjs.org/mocha/-/mocha-10.2.0.tgz",
+      "integrity": "sha512-IDY7fl/BecMwFHzoqF2sg/SHHANeBoMMXFlS9r0OXKDssYE1M5O43wUY/9BVPeIvfH2zmEbBfseqN9gBQZzXkg==",
       "dev": true,
       "dependencies": {
-        "@ungap/promise-all-settled": "1.1.2",
         "ansi-colors": "4.1.1",
         "browser-stdout": "1.3.1",
         "chokidar": "3.5.3",
@@ -3083,29 +3256,32 @@
       }
     },
     "node_modules/object-inspect": {
-      "version": "1.12.2",
+      "version": "1.12.3",
+      "resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-1.12.3.tgz",
+      "integrity": "sha512-geUvdk7c+eizMNUDkRpW1wJwgfOiOeHbxBR/hLXK1aT6zmVSO0jsQcs7fj6MGw89jC/cjGfLcNOrtMYtGqm81g==",
       "dev": true,
-      "license": "MIT",
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
       }
     },
     "node_modules/object-keys": {
       "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/object-keys/-/object-keys-1.1.1.tgz",
+      "integrity": "sha512-NuAESUOUMrlIXOfHKzD6bpPu3tYt3xvjNdRIQ+FeT0lNb4K8WR70CaDxhuNguS2XG+GjkyMwOzsN5ZktImfhLA==",
       "dev": true,
-      "license": "MIT",
       "engines": {
         "node": ">= 0.4"
       }
     },
     "node_modules/object.assign": {
-      "version": "4.1.2",
+      "version": "4.1.4",
+      "resolved": "https://registry.npmjs.org/object.assign/-/object.assign-4.1.4.tgz",
+      "integrity": "sha512-1mxKf0e58bvyjSCtKYY4sRe9itRk3PJpquJOjeIkz885CczcI4IvJJDLPS72oowuSh+pBxUFROpX+TU++hxhZQ==",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
-        "call-bind": "^1.0.0",
-        "define-properties": "^1.1.3",
-        "has-symbols": "^1.0.1",
+        "call-bind": "^1.0.2",
+        "define-properties": "^1.1.4",
+        "has-symbols": "^1.0.3",
         "object-keys": "^1.1.1"
       },
       "engines": {
@@ -3116,13 +3292,14 @@
       }
     },
     "node_modules/object.values": {
-      "version": "1.1.5",
+      "version": "1.1.6",
+      "resolved": "https://registry.npmjs.org/object.values/-/object.values-1.1.6.tgz",
+      "integrity": "sha512-FVVTkD1vENCsAcwNs9k6jea2uHC/X0+JcjG8YA60FN5CMaJmG95wT9jek/xX9nornqGRrBkKtzuAu2wuHpKqvw==",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
         "call-bind": "^1.0.2",
-        "define-properties": "^1.1.3",
-        "es-abstract": "^1.19.1"
+        "define-properties": "^1.1.4",
+        "es-abstract": "^1.20.4"
       },
       "engines": {
         "node": ">= 0.4"
@@ -3183,14 +3360,6 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
-    "node_modules/p-try": {
-      "version": "1.0.0",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=4"
-      }
-    },
     "node_modules/pako": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/pako/-/pako-2.1.0.tgz",
@@ -3207,14 +3376,6 @@
       },
       "engines": {
         "node": ">=6"
-      }
-    },
-    "node_modules/path-exists": {
-      "version": "3.0.0",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=4"
       }
     },
     "node_modules/path-is-absolute": {
@@ -3235,8 +3396,9 @@
     },
     "node_modules/path-parse": {
       "version": "1.0.7",
-      "dev": true,
-      "license": "MIT"
+      "resolved": "https://registry.npmjs.org/path-parse/-/path-parse-1.0.7.tgz",
+      "integrity": "sha512-LDJzPVEEEPR+y48z93A0Ed0yXb8pAByGWo/k5YYdYgpY2/2EsOsksJrq7lOHxryrVOn1ejG6oAp8ahvOIQD8sw==",
+      "dev": true
     },
     "node_modules/path-type": {
       "version": "4.0.0",
@@ -3267,9 +3429,9 @@
       }
     },
     "node_modules/prettier": {
-      "version": "2.7.1",
-      "resolved": "https://registry.npmjs.org/prettier/-/prettier-2.7.1.tgz",
-      "integrity": "sha512-ujppO+MkdPqoVINuDFDRLClm7D78qbDt0/NR+wp5FqEZOoTNAjPHWj17QRhu7geIHJfcNhRk1XVQmF8Bp3ye+g==",
+      "version": "2.8.8",
+      "resolved": "https://registry.npmjs.org/prettier/-/prettier-2.8.8.tgz",
+      "integrity": "sha512-tdN8qQGvNjw4CHbY+XXk0JgCXn9QiF21a55rBe5LJAU+kDyC4WQn4+awm2Xfk2lQMk5fKup9XgzTZtGkjBdP9Q==",
       "dev": true,
       "bin": {
         "prettier": "bin-prettier.js"
@@ -3301,9 +3463,9 @@
       }
     },
     "node_modules/punycode": {
-      "version": "2.1.1",
-      "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.1.1.tgz",
-      "integrity": "sha512-XRsRjdf+j5ml+y/6GKHPZbrF/8p2Yga0JPtdqTIY2Xe5ohJPD9saDJJLPvp9+NSBprVvevdXZybnj2cv8OEd0A==",
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.3.0.tgz",
+      "integrity": "sha512-rRV+zQD8tVFys26lAGR9WUuS4iUAngJScM+ZRSKtvl5tKeZ2t5bvdNFdNHBW9FWR4guGHlgmsZ1G7BSm2wTbuA==",
       "dev": true,
       "engines": {
         "node": ">=6"
@@ -3355,30 +3517,20 @@
       }
     },
     "node_modules/regexp.prototype.flags": {
-      "version": "1.4.3",
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/regexp.prototype.flags/-/regexp.prototype.flags-1.5.0.tgz",
+      "integrity": "sha512-0SutC3pNudRKgquxGoRGIz946MZVHqbNfPjBdxeOhBrdgDKlRoXmYLQN9xRbrR09ZXWeGAdPuif7egofn6v5LA==",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
         "call-bind": "^1.0.2",
-        "define-properties": "^1.1.3",
-        "functions-have-names": "^1.2.2"
+        "define-properties": "^1.2.0",
+        "functions-have-names": "^1.2.3"
       },
       "engines": {
         "node": ">= 0.4"
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
-      }
-    },
-    "node_modules/regexpp": {
-      "version": "3.2.0",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=8"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/mysticatea"
       }
     },
     "node_modules/require-directory": {
@@ -3390,11 +3542,12 @@
       }
     },
     "node_modules/resolve": {
-      "version": "1.22.1",
+      "version": "1.22.2",
+      "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.22.2.tgz",
+      "integrity": "sha512-Sb+mjNHOULsBv818T40qSPeRiuWLyaGMa5ewydRLFimneixmVy2zdivRl+AF6jaYPC8ERxGDmFSiqui6SfPd+g==",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
-        "is-core-module": "^2.9.0",
+        "is-core-module": "^2.11.0",
         "path-parse": "^1.0.7",
         "supports-preserve-symlinks-flag": "^1.0.0"
       },
@@ -3480,6 +3633,35 @@
       "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==",
       "dev": true
     },
+    "node_modules/safe-regex-test": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/safe-regex-test/-/safe-regex-test-1.0.0.tgz",
+      "integrity": "sha512-JBUUzyOgEwXQY1NuPtvcj/qcBDbDmEvWufhlnXZIm75DEHp+afM1r1ujJpJsV/gSM4t59tpDyPi1sd6ZaPFfsA==",
+      "dev": true,
+      "dependencies": {
+        "call-bind": "^1.0.2",
+        "get-intrinsic": "^1.1.3",
+        "is-regex": "^1.1.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/semver": {
+      "version": "7.5.0",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.5.0.tgz",
+      "integrity": "sha512-+XC0AD/R7Q2mPSRuy2Id0+CGTZ98+8f+KvwirxOKIEyid+XSx6HbC63p+O4IndTHuX5Z+JxQ0TghCkO5Cg/2HA==",
+      "dev": true,
+      "dependencies": {
+        "lru-cache": "^6.0.0"
+      },
+      "bin": {
+        "semver": "bin/semver.js"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
     "node_modules/serialize-javascript": {
       "version": "6.0.0",
       "dev": true,
@@ -3509,8 +3691,9 @@
     },
     "node_modules/side-channel": {
       "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/side-channel/-/side-channel-1.0.4.tgz",
+      "integrity": "sha512-q5XPytqFEIKHkGdiMIrY10mvLRvnQh42/+GoBlFW3b2LXLE2xxJpZFdm94we0BaoV3RwJyGqg5wS7epxTv0Zvw==",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
         "call-bind": "^1.0.0",
         "get-intrinsic": "^1.0.2",
@@ -3530,9 +3713,9 @@
       }
     },
     "node_modules/smoldot": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/smoldot/-/smoldot-1.0.1.tgz",
-      "integrity": "sha512-48M9tLU+5q0XHFUCuGULraghfqQU/yARkdcYZzulFB38f2aw4ujTHzlbE+bhiJ8+h63uoXdAQO0WeCsWDTXGkA==",
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/smoldot/-/smoldot-1.0.2.tgz",
+      "integrity": "sha512-IHhMzvXwyl6I5GA4JvfzM2OOp9wBO06AmjqT4nCoNms5PiLe74f/A+jIZIJKyY6eBhMpmECizyfeTneHO2wMFQ==",
       "optional": true,
       "dependencies": {
         "pako": "^2.0.4",
@@ -3560,27 +3743,46 @@
         "node": ">=8"
       }
     },
-    "node_modules/string.prototype.trimend": {
-      "version": "1.0.5",
+    "node_modules/string.prototype.trim": {
+      "version": "1.2.7",
+      "resolved": "https://registry.npmjs.org/string.prototype.trim/-/string.prototype.trim-1.2.7.tgz",
+      "integrity": "sha512-p6TmeT1T3411M8Cgg9wBTMRtY2q9+PNy9EV1i2lIXUN/btt763oIfxwN3RR8VU6wHX8j/1CFy0L+YuThm6bgOg==",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
         "call-bind": "^1.0.2",
         "define-properties": "^1.1.4",
-        "es-abstract": "^1.19.5"
+        "es-abstract": "^1.20.4"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/string.prototype.trimend": {
+      "version": "1.0.6",
+      "resolved": "https://registry.npmjs.org/string.prototype.trimend/-/string.prototype.trimend-1.0.6.tgz",
+      "integrity": "sha512-JySq+4mrPf9EsDBEDYMOb/lM7XQLulwg5R/m1r0PXEFqrV0qHvl58sdTilSXtKOflCsK2E8jxf+GKC0T07RWwQ==",
+      "dev": true,
+      "dependencies": {
+        "call-bind": "^1.0.2",
+        "define-properties": "^1.1.4",
+        "es-abstract": "^1.20.4"
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
       }
     },
     "node_modules/string.prototype.trimstart": {
-      "version": "1.0.5",
+      "version": "1.0.6",
+      "resolved": "https://registry.npmjs.org/string.prototype.trimstart/-/string.prototype.trimstart-1.0.6.tgz",
+      "integrity": "sha512-omqjMDaY92pbn5HOX7f9IccLA+U1tA9GvtU4JrodiXFfYB7jPzzHpRzpglLAjtUV6bB557zwClJezTqnAiYnQA==",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
         "call-bind": "^1.0.2",
         "define-properties": "^1.1.4",
-        "es-abstract": "^1.19.5"
+        "es-abstract": "^1.20.4"
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
@@ -3632,8 +3834,9 @@
     },
     "node_modules/supports-preserve-symlinks-flag": {
       "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/supports-preserve-symlinks-flag/-/supports-preserve-symlinks-flag-1.0.0.tgz",
+      "integrity": "sha512-ot0WnXS9fgdkgIcePe6RHNk1WA8+muPa6cSjeR3V8K27q9BB1rTE3R1p7Hv0z1ZyAc8s6Vvv8DIyWf681MAt0w==",
       "dev": true,
-      "license": "MIT",
       "engines": {
         "node": ">= 0.4"
       },
@@ -3738,11 +3941,6 @@
         "typescript": ">=2.8.0 || >= 3.2.0-dev || >= 3.3.0-dev || >= 3.4.0-dev || >= 3.5.0-dev || >= 3.6.0-dev || >= 3.6.0-beta || >= 3.7.0-dev || >= 3.7.0-beta"
       }
     },
-    "node_modules/tweetnacl": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/tweetnacl/-/tweetnacl-1.0.3.tgz",
-      "integrity": "sha512-6rt+RN7aOi1nGMyC4Xa5DdYiukl2UWCbcJft7YhxReBGQD7OAM8Pbxw6YMo4r2diNEA8FEmu32YOn9rhaiE5yw=="
-    },
     "node_modules/type-check": {
       "version": "0.4.0",
       "dev": true,
@@ -3766,17 +3964,31 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/typed-array-length": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/typed-array-length/-/typed-array-length-1.0.4.tgz",
+      "integrity": "sha512-KjZypGq+I/H7HI5HlOoGHkWUUGq+Q0TPhQurLbyrVrvnKTBgzLhIJ7j6J/XTQOi0d1RjyZ0wdas8bKs2p0x3Ng==",
+      "dev": true,
+      "dependencies": {
+        "call-bind": "^1.0.2",
+        "for-each": "^0.3.3",
+        "is-typed-array": "^1.1.9"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
     "node_modules/typescript": {
-      "version": "4.9.5",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.9.5.tgz",
-      "integrity": "sha512-1FXk9E2Hm+QzZQ7z+McJiHL4NW1F2EzMu9Nq9i3zAaGqibafqYwCVU6WyWAuyQRRzOlxou8xZSyXLEN8oKj24g==",
+      "version": "5.0.4",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.0.4.tgz",
+      "integrity": "sha512-cW9T5W9xY37cc+jfEnaUvX91foxtHkza3Nw3wkoF4sSlKn0MONdkdEndig/qPBWXNkmplh3NzayQzCiHM4/hqw==",
       "dev": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
       },
       "engines": {
-        "node": ">=4.2.0"
+        "node": ">=12.20"
       }
     },
     "node_modules/uglify-js": {
@@ -3793,8 +4005,9 @@
     },
     "node_modules/unbox-primitive": {
       "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/unbox-primitive/-/unbox-primitive-1.0.2.tgz",
+      "integrity": "sha512-61pPlCD9h51VoreyJ0BReideM3MDKMKnh6+V9L08331ipq6Q8OFXZYiqP6n/tbHx4s5I9uRhcye6BrbkizkBDw==",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
         "call-bind": "^1.0.2",
         "has-bigints": "^1.0.2",
@@ -3843,14 +4056,35 @@
     },
     "node_modules/which-boxed-primitive": {
       "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/which-boxed-primitive/-/which-boxed-primitive-1.0.2.tgz",
+      "integrity": "sha512-bwZdv0AKLpplFY2KZRX6TvyuN7ojjr7lwkg6ml0roIy9YeuSr7JS372qlNW18UQYzgYK9ziGcerWqZOmEn9VNg==",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
         "is-bigint": "^1.0.1",
         "is-boolean-object": "^1.1.0",
         "is-number-object": "^1.0.4",
         "is-string": "^1.0.5",
         "is-symbol": "^1.0.3"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/which-typed-array": {
+      "version": "1.1.9",
+      "resolved": "https://registry.npmjs.org/which-typed-array/-/which-typed-array-1.1.9.tgz",
+      "integrity": "sha512-w9c4xkx6mPidwp7180ckYWfMmvxpjlZuIudNtDf4N/tTAUB8VJbX25qZoAsrtGuYNnGw3pa0AXgbGKRB8/EceA==",
+      "dev": true,
+      "dependencies": {
+        "available-typed-arrays": "^1.0.5",
+        "call-bind": "^1.0.2",
+        "for-each": "^0.3.3",
+        "gopd": "^1.0.1",
+        "has-tostringtag": "^1.0.0",
+        "is-typed-array": "^1.1.10"
+      },
+      "engines": {
+        "node": ">= 0.4"
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"

--- a/js/api-augment/package.json
+++ b/js/api-augment/package.json
@@ -33,23 +33,23 @@
   "author": "LibertyDSNP",
   "license": "Apache-2.0",
   "dependencies": {
-    "@polkadot/api": "^10.3.2",
-    "@polkadot/rpc-provider": "^10.3.2",
-    "@polkadot/types": "^10.3.2"
+    "@polkadot/api": "^10.4.1",
+    "@polkadot/rpc-provider": "^10.4.1",
+    "@polkadot/types": "^10.4.1"
   },
   "devDependencies": {
-    "@polkadot/typegen": "^10.3.2",
+    "@polkadot/typegen": "^10.4.1",
     "@types/mocha": "^10.0.1",
-    "@typescript-eslint/eslint-plugin": "^5.42.0",
-    "@typescript-eslint/parser": "^5.42.0",
-    "eslint": "^8.26.0",
-    "eslint-config-prettier": "^8.5.0",
-    "eslint-plugin-import": "^2.26.0",
+    "@typescript-eslint/eslint-plugin": "^5.59.1",
+    "@typescript-eslint/parser": "^5.59.1",
+    "eslint": "^8.39.0",
+    "eslint-config-prettier": "^8.8.0",
+    "eslint-plugin-import": "^2.27.5",
     "eslint-plugin-mocha": "^10.1.0",
     "eslint-plugin-prettier": "^4.2.1",
-    "mocha": "10.0.0",
-    "prettier": "2.7.1",
+    "mocha": "10.2.0",
+    "prettier": "2.8.8",
     "ts-node": "^10.9.1",
-    "typescript": "^4.9.5"
+    "typescript": "^5.0.4"
   }
 }


### PR DESCRIPTION
# Goal
The goal of this PR is to remove the warning from the api-augment package about the `HandlesSignedExtension`

Closes #1456 

# Discussion
- Added `HandlesSignedExtension`
- Updated packages

## Testing
- `make js`
- Create a new package that uses the tgz file that is created
- Use it to run the small script below
- Don't see the error!

```ts
import { options } from '@frequency-chain/api-augment';
import { ApiPromise, WsProvider } from "@polkadot/api";

// const WEBSOCKET_URL = 'wss://0.rpc.frequency.xyz'; // Mainnet
const WEBSOCKET_URL = 'wss://rpc.rococo.frequency.xyz'; // Rococo


const getApi = async () => {
  const api = await ApiPromise.create({
    provider: new WsProvider(WEBSOCKET_URL),
    ...options,
  });
  await api.isReady;
  return api;
}

const main = async () => {
  console.log("Connecting to the API...");
  const api = await getApi();
  const blockNumber = await api.query.system.number();
  console.log({
    blockNumber: blockNumber.toHuman(),
  })
}

main().catch(console.error).finally(process.exit);
```
