### PR TITLE
pin polkadotjs api to running version

### DIFF
--- a/integration-tests/package-lock.json
+++ b/integration-tests/package-lock.json
@@ -11,15 +11,15 @@
             "license": "Apache-2.0",
             "dependencies": {
                 "@frequency-chain/api-augment": "file:../js/api-augment/dist/frequency-chain-api-augment-0.0.0.tgz",
-                "@polkadot/api": "10.3.2",
-                "@polkadot/types": "10.3.2",
-                "@polkadot/util": "10.4.2",
+                "@polkadot/api": "10.4.1",
+                "@polkadot/types": "10.4.1",
+                "@polkadot/util": "10.4.1",
                 "ipfs": "^0.66.0",
                 "multiformats": "^11.0.1",
                 "rxjs": "^7.8.0"
             },
             "devDependencies": {
-                "@polkadot/typegen": "10.3.2",
+                "@polkadot/typegen": "10.4.1",
                 "@types/mocha": "^10.0.0",
                 "@typescript-eslint/eslint-plugin": "^5.48.1",
                 "@typescript-eslint/parser": "^5.48.1",
@@ -99,9 +99,9 @@
             "integrity": "sha512-HazVq9zwTVwGmqdwYzu7WyQ6FQVZ7SwET0KKQuKm55jD0IfUpZgN0OPIiZG3zV1iSrVYcN0bdwLRXI/VNCYsUA=="
         },
         "node_modules/@babel/runtime": {
-            "version": "7.21.0",
-            "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.21.0.tgz",
-            "integrity": "sha512-xwII0//EObnq89Ji5AKYQaRYiW/nZ3llSv29d49IuxPhKbtJoLP+9QUUZ4nVragQVtaVGeZrpB+ZtG/Pdy/POw==",
+            "version": "7.21.5",
+            "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.21.5.tgz",
+            "integrity": "sha512-8jI69toZqqcsnqGGqwGS4Qb1VwLOEp4hz+CXPywcvjs60u3B4Pom/U/7rm4W8tMOYEB+E9wgD0mW1l3r8qlI9Q==",
             "dependencies": {
                 "regenerator-runtime": "^0.13.11"
             },
@@ -304,12 +304,12 @@
         "node_modules/@frequency-chain/api-augment": {
             "version": "0.0.0",
             "resolved": "file:../js/api-augment/dist/frequency-chain-api-augment-0.0.0.tgz",
-            "integrity": "sha512-qEpa46lUZo/csNMn01yBuLufU5EO5vvhLp/EFaBfdbiSYEFS4BnCV76bPyEcBc7OppaGN3pWruaeeh+bFnklAQ==",
+            "integrity": "sha512-+gHRGdalUyu+ZuFWDPtve/NfR3AIhDIpoQTugjdRlsNfAcvLRAPBgH8SPOpXqe877mzD8CstmqpUwNlw3aoXag==",
             "license": "Apache-2.0",
             "dependencies": {
-                "@polkadot/api": "^10.3.2",
-                "@polkadot/rpc-provider": "^10.3.2",
-                "@polkadot/types": "^10.3.2"
+                "@polkadot/api": "10.4.1",
+                "@polkadot/rpc-provider": "10.4.1",
+                "@polkadot/types": "10.4.1"
             }
         },
         "node_modules/@grpc/grpc-js": {
@@ -2409,6 +2409,20 @@
                 "npm": ">=7.0.0"
             }
         },
+        "node_modules/@noble/curves": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/@noble/curves/-/curves-1.0.0.tgz",
+            "integrity": "sha512-2upgEu0iLiDVDZkNLeFV2+ht0BAVgQnEmCk6JsOch9Rp8xfkMCbvbAZlA2pBHQc73dbl+vFOXfqkf4uemdn0bw==",
+            "funding": [
+                {
+                    "type": "individual",
+                    "url": "https://paulmillr.com/funding/"
+                }
+            ],
+            "dependencies": {
+                "@noble/hashes": "1.3.0"
+            }
+        },
         "node_modules/@noble/ed25519": {
             "version": "1.7.3",
             "resolved": "https://registry.npmjs.org/@noble/ed25519/-/ed25519-1.7.3.tgz",
@@ -2510,764 +2524,557 @@
             }
         },
         "node_modules/@polkadot/api": {
-            "version": "10.3.2",
-            "resolved": "https://registry.npmjs.org/@polkadot/api/-/api-10.3.2.tgz",
-            "integrity": "sha512-7lJI9bHHfiepbQvEdgqrt60jmFCw/6FvSqi9R2S9RbYdz/LD0PVF1GavpyU0tWDUfFg+jUGi2Qw4DLml455BiQ==",
+            "version": "10.4.1",
+            "resolved": "https://registry.npmjs.org/@polkadot/api/-/api-10.4.1.tgz",
+            "integrity": "sha512-MFIhykqvU4l5oyLxEnMhtF07VWLXwBS02gVd9Q+Gh2RxXtskQnXlos00hZFdLaCQ7g8BNggoq0Woc2BGZQEG2A==",
             "dependencies": {
-                "@polkadot/api-augment": "10.3.2",
-                "@polkadot/api-base": "10.3.2",
-                "@polkadot/api-derive": "10.3.2",
-                "@polkadot/keyring": "^11.1.3",
-                "@polkadot/rpc-augment": "10.3.2",
-                "@polkadot/rpc-core": "10.3.2",
-                "@polkadot/rpc-provider": "10.3.2",
-                "@polkadot/types": "10.3.2",
-                "@polkadot/types-augment": "10.3.2",
-                "@polkadot/types-codec": "10.3.2",
-                "@polkadot/types-create": "10.3.2",
-                "@polkadot/types-known": "10.3.2",
-                "@polkadot/util": "^11.1.3",
-                "@polkadot/util-crypto": "^11.1.3",
+                "@polkadot/api-augment": "10.4.1",
+                "@polkadot/api-base": "10.4.1",
+                "@polkadot/api-derive": "10.4.1",
+                "@polkadot/keyring": "^12.0.1",
+                "@polkadot/rpc-augment": "10.4.1",
+                "@polkadot/rpc-core": "10.4.1",
+                "@polkadot/rpc-provider": "10.4.1",
+                "@polkadot/types": "10.4.1",
+                "@polkadot/types-augment": "10.4.1",
+                "@polkadot/types-codec": "10.4.1",
+                "@polkadot/types-create": "10.4.1",
+                "@polkadot/types-known": "10.4.1",
+                "@polkadot/util": "^12.0.1",
+                "@polkadot/util-crypto": "^12.0.1",
                 "eventemitter3": "^5.0.0",
                 "rxjs": "^7.8.0",
                 "tslib": "^2.5.0"
             },
             "engines": {
-                "node": ">=14"
+                "node": ">=16"
             }
         },
         "node_modules/@polkadot/api-augment": {
-            "version": "10.3.2",
-            "resolved": "https://registry.npmjs.org/@polkadot/api-augment/-/api-augment-10.3.2.tgz",
-            "integrity": "sha512-73bzQnjVmOHf/PIzSQru2jqlkVivtIvXoABkq87QIDxsZvUIQPXXIHnVb9C96yJuLE4St22w4y1qI9XSwau96g==",
+            "version": "10.4.1",
+            "resolved": "https://registry.npmjs.org/@polkadot/api-augment/-/api-augment-10.4.1.tgz",
+            "integrity": "sha512-7TUFHiOsaAKwRCDXEwwYHIBi07Nd0+4vMDgP+/eKVrX5XkYCnEA+PdkE8uEpFY3LMoVVr08mPiYPn59gN0b5jw==",
             "dependencies": {
-                "@polkadot/api-base": "10.3.2",
-                "@polkadot/rpc-augment": "10.3.2",
-                "@polkadot/types": "10.3.2",
-                "@polkadot/types-augment": "10.3.2",
-                "@polkadot/types-codec": "10.3.2",
-                "@polkadot/util": "^11.1.3",
+                "@polkadot/api-base": "10.4.1",
+                "@polkadot/rpc-augment": "10.4.1",
+                "@polkadot/types": "10.4.1",
+                "@polkadot/types-augment": "10.4.1",
+                "@polkadot/types-codec": "10.4.1",
+                "@polkadot/util": "^12.0.1",
                 "tslib": "^2.5.0"
             },
             "engines": {
-                "node": ">=14"
+                "node": ">=16"
             }
         },
         "node_modules/@polkadot/api-augment/node_modules/@polkadot/util": {
-            "version": "11.1.3",
-            "resolved": "https://registry.npmjs.org/@polkadot/util/-/util-11.1.3.tgz",
-            "integrity": "sha512-Gsqzv1/fSoypS5tnJkM+NJQeT7O4iYlSniubUJnaZVOKsIbueTS1bMQ1y3/h8ISxbKBtICW5cZ6zCej6Q/jC3w==",
+            "version": "12.1.2",
+            "resolved": "https://registry.npmjs.org/@polkadot/util/-/util-12.1.2.tgz",
+            "integrity": "sha512-Da8q+0WVWSuMMS3hLAwnIid8FKRGLmwhD69jikye47zeEXCtvp4e/bjD0YbINNKHoeIRsApchJtqmbaEoxXjIQ==",
             "dependencies": {
-                "@polkadot/x-bigint": "11.1.3",
-                "@polkadot/x-global": "11.1.3",
-                "@polkadot/x-textdecoder": "11.1.3",
-                "@polkadot/x-textencoder": "11.1.3",
+                "@polkadot/x-bigint": "12.1.2",
+                "@polkadot/x-global": "12.1.2",
+                "@polkadot/x-textdecoder": "12.1.2",
+                "@polkadot/x-textencoder": "12.1.2",
                 "@types/bn.js": "^5.1.1",
                 "bn.js": "^5.2.1",
                 "tslib": "^2.5.0"
             },
             "engines": {
-                "node": ">=14"
-            }
-        },
-        "node_modules/@polkadot/api-augment/node_modules/@polkadot/x-bigint": {
-            "version": "11.1.3",
-            "resolved": "https://registry.npmjs.org/@polkadot/x-bigint/-/x-bigint-11.1.3.tgz",
-            "integrity": "sha512-fRUUHfW9VFsXT7sLUUY7gSu8v+PvzNLRwvjnp+Ly8vFx9LTLuVGFCi+mpysuRTaPpqZZJlzBJ3fST7xTGh67Pg==",
-            "dependencies": {
-                "@polkadot/x-global": "11.1.3",
-                "tslib": "^2.5.0"
-            },
-            "engines": {
-                "node": ">=14"
-            }
-        },
-        "node_modules/@polkadot/api-augment/node_modules/@polkadot/x-global": {
-            "version": "11.1.3",
-            "resolved": "https://registry.npmjs.org/@polkadot/x-global/-/x-global-11.1.3.tgz",
-            "integrity": "sha512-R3aqtIjgzFHJ3TyX6wavhp+59oLbZiqczIHkaas/nJe21+SVARqFmIII6BwS7ty7+8Uu4fHliA9re+ZSUp+rwg==",
-            "dependencies": {
-                "tslib": "^2.5.0"
-            },
-            "engines": {
-                "node": ">=14"
+                "node": ">=16"
             }
         },
         "node_modules/@polkadot/api-augment/node_modules/@polkadot/x-textdecoder": {
-            "version": "11.1.3",
-            "resolved": "https://registry.npmjs.org/@polkadot/x-textdecoder/-/x-textdecoder-11.1.3.tgz",
-            "integrity": "sha512-NhOjuXVfYRMw9l0VhCtZOtcWefZth58p5KpVOrFyJZd12fTsoMO5/746K7QoAjWRrLQTJ/LHCEKCtWww0LwVPw==",
+            "version": "12.1.2",
+            "resolved": "https://registry.npmjs.org/@polkadot/x-textdecoder/-/x-textdecoder-12.1.2.tgz",
+            "integrity": "sha512-O5ygxEHdPCIQVzH7T+xVALBfCwrT5tVms7Yjp6EMT697A9gpD3U2aPr4YinsQO6JFwYpQNzvm2wjW+7EEzYitw==",
             "dependencies": {
-                "@polkadot/x-global": "11.1.3",
+                "@polkadot/x-global": "12.1.2",
                 "tslib": "^2.5.0"
             },
             "engines": {
-                "node": ">=14"
+                "node": ">=16"
             }
         },
         "node_modules/@polkadot/api-augment/node_modules/@polkadot/x-textencoder": {
-            "version": "11.1.3",
-            "resolved": "https://registry.npmjs.org/@polkadot/x-textencoder/-/x-textencoder-11.1.3.tgz",
-            "integrity": "sha512-7DmqjlPN8aQexLUKwoHeadihpUnW8hjpXEru+aEDxjgq9XIxPvb++NeBK+Mra9RzzZRuiT/K5z16HlwKN//ewg==",
+            "version": "12.1.2",
+            "resolved": "https://registry.npmjs.org/@polkadot/x-textencoder/-/x-textencoder-12.1.2.tgz",
+            "integrity": "sha512-N+9HIXT0eUQbfg/SfGrNRK8aLFpd2QngJzTxo8CljpjCvQ2ddqzBVFA8o/lKTaXVzX84EmPDzjIV+yJlOXnglA==",
             "dependencies": {
-                "@polkadot/x-global": "11.1.3",
+                "@polkadot/x-global": "12.1.2",
                 "tslib": "^2.5.0"
             },
             "engines": {
-                "node": ">=14"
+                "node": ">=16"
             }
         },
         "node_modules/@polkadot/api-base": {
-            "version": "10.3.2",
-            "resolved": "https://registry.npmjs.org/@polkadot/api-base/-/api-base-10.3.2.tgz",
-            "integrity": "sha512-5UPVDmYrxLCfKmCKwaiKqK1s8x3nHbi5vulUDj31P9f///oWZGwjsXdp2hn4FGoEEi1pKuMUK+dRRMEMrj3gPA==",
+            "version": "10.4.1",
+            "resolved": "https://registry.npmjs.org/@polkadot/api-base/-/api-base-10.4.1.tgz",
+            "integrity": "sha512-4uItv9NeZDu60qN8dhPN8Q7HBOYZ0Ylf7+/lAnEMldoCx0RxNP2h1T2JwdW3C5ElTsztYzYVLKg0Iz5zJpbffQ==",
             "dependencies": {
-                "@polkadot/rpc-core": "10.3.2",
-                "@polkadot/types": "10.3.2",
-                "@polkadot/util": "^11.1.3",
+                "@polkadot/rpc-core": "10.4.1",
+                "@polkadot/types": "10.4.1",
+                "@polkadot/util": "^12.0.1",
                 "rxjs": "^7.8.0",
                 "tslib": "^2.5.0"
             },
             "engines": {
-                "node": ">=14"
+                "node": ">=16"
             }
         },
         "node_modules/@polkadot/api-base/node_modules/@polkadot/util": {
-            "version": "11.1.3",
-            "resolved": "https://registry.npmjs.org/@polkadot/util/-/util-11.1.3.tgz",
-            "integrity": "sha512-Gsqzv1/fSoypS5tnJkM+NJQeT7O4iYlSniubUJnaZVOKsIbueTS1bMQ1y3/h8ISxbKBtICW5cZ6zCej6Q/jC3w==",
+            "version": "12.1.2",
+            "resolved": "https://registry.npmjs.org/@polkadot/util/-/util-12.1.2.tgz",
+            "integrity": "sha512-Da8q+0WVWSuMMS3hLAwnIid8FKRGLmwhD69jikye47zeEXCtvp4e/bjD0YbINNKHoeIRsApchJtqmbaEoxXjIQ==",
             "dependencies": {
-                "@polkadot/x-bigint": "11.1.3",
-                "@polkadot/x-global": "11.1.3",
-                "@polkadot/x-textdecoder": "11.1.3",
-                "@polkadot/x-textencoder": "11.1.3",
+                "@polkadot/x-bigint": "12.1.2",
+                "@polkadot/x-global": "12.1.2",
+                "@polkadot/x-textdecoder": "12.1.2",
+                "@polkadot/x-textencoder": "12.1.2",
                 "@types/bn.js": "^5.1.1",
                 "bn.js": "^5.2.1",
                 "tslib": "^2.5.0"
             },
             "engines": {
-                "node": ">=14"
-            }
-        },
-        "node_modules/@polkadot/api-base/node_modules/@polkadot/x-bigint": {
-            "version": "11.1.3",
-            "resolved": "https://registry.npmjs.org/@polkadot/x-bigint/-/x-bigint-11.1.3.tgz",
-            "integrity": "sha512-fRUUHfW9VFsXT7sLUUY7gSu8v+PvzNLRwvjnp+Ly8vFx9LTLuVGFCi+mpysuRTaPpqZZJlzBJ3fST7xTGh67Pg==",
-            "dependencies": {
-                "@polkadot/x-global": "11.1.3",
-                "tslib": "^2.5.0"
-            },
-            "engines": {
-                "node": ">=14"
-            }
-        },
-        "node_modules/@polkadot/api-base/node_modules/@polkadot/x-global": {
-            "version": "11.1.3",
-            "resolved": "https://registry.npmjs.org/@polkadot/x-global/-/x-global-11.1.3.tgz",
-            "integrity": "sha512-R3aqtIjgzFHJ3TyX6wavhp+59oLbZiqczIHkaas/nJe21+SVARqFmIII6BwS7ty7+8Uu4fHliA9re+ZSUp+rwg==",
-            "dependencies": {
-                "tslib": "^2.5.0"
-            },
-            "engines": {
-                "node": ">=14"
+                "node": ">=16"
             }
         },
         "node_modules/@polkadot/api-base/node_modules/@polkadot/x-textdecoder": {
-            "version": "11.1.3",
-            "resolved": "https://registry.npmjs.org/@polkadot/x-textdecoder/-/x-textdecoder-11.1.3.tgz",
-            "integrity": "sha512-NhOjuXVfYRMw9l0VhCtZOtcWefZth58p5KpVOrFyJZd12fTsoMO5/746K7QoAjWRrLQTJ/LHCEKCtWww0LwVPw==",
+            "version": "12.1.2",
+            "resolved": "https://registry.npmjs.org/@polkadot/x-textdecoder/-/x-textdecoder-12.1.2.tgz",
+            "integrity": "sha512-O5ygxEHdPCIQVzH7T+xVALBfCwrT5tVms7Yjp6EMT697A9gpD3U2aPr4YinsQO6JFwYpQNzvm2wjW+7EEzYitw==",
             "dependencies": {
-                "@polkadot/x-global": "11.1.3",
+                "@polkadot/x-global": "12.1.2",
                 "tslib": "^2.5.0"
             },
             "engines": {
-                "node": ">=14"
+                "node": ">=16"
             }
         },
         "node_modules/@polkadot/api-base/node_modules/@polkadot/x-textencoder": {
-            "version": "11.1.3",
-            "resolved": "https://registry.npmjs.org/@polkadot/x-textencoder/-/x-textencoder-11.1.3.tgz",
-            "integrity": "sha512-7DmqjlPN8aQexLUKwoHeadihpUnW8hjpXEru+aEDxjgq9XIxPvb++NeBK+Mra9RzzZRuiT/K5z16HlwKN//ewg==",
+            "version": "12.1.2",
+            "resolved": "https://registry.npmjs.org/@polkadot/x-textencoder/-/x-textencoder-12.1.2.tgz",
+            "integrity": "sha512-N+9HIXT0eUQbfg/SfGrNRK8aLFpd2QngJzTxo8CljpjCvQ2ddqzBVFA8o/lKTaXVzX84EmPDzjIV+yJlOXnglA==",
             "dependencies": {
-                "@polkadot/x-global": "11.1.3",
+                "@polkadot/x-global": "12.1.2",
                 "tslib": "^2.5.0"
             },
             "engines": {
-                "node": ">=14"
+                "node": ">=16"
             }
         },
         "node_modules/@polkadot/api-derive": {
-            "version": "10.3.2",
-            "resolved": "https://registry.npmjs.org/@polkadot/api-derive/-/api-derive-10.3.2.tgz",
-            "integrity": "sha512-vU6ymw/XykrPZseCgO2BgsX9niRfystXAVUltxO9m/aqZdmf3yeFl+77MwQd9zdLsPOmcoWpiEPRRKWQThqgSA==",
+            "version": "10.4.1",
+            "resolved": "https://registry.npmjs.org/@polkadot/api-derive/-/api-derive-10.4.1.tgz",
+            "integrity": "sha512-SR/L4H8oiYMyLaLzmm9Z3kb4tNLAOAIR2uBZshCo917CqMuvrkNVW+Wfh2dAtVsnoSc1FaSPfDwmKash6pqNUQ==",
             "dependencies": {
-                "@polkadot/api": "10.3.2",
-                "@polkadot/api-augment": "10.3.2",
-                "@polkadot/api-base": "10.3.2",
-                "@polkadot/rpc-core": "10.3.2",
-                "@polkadot/types": "10.3.2",
-                "@polkadot/types-codec": "10.3.2",
-                "@polkadot/util": "^11.1.3",
-                "@polkadot/util-crypto": "^11.1.3",
+                "@polkadot/api": "10.4.1",
+                "@polkadot/api-augment": "10.4.1",
+                "@polkadot/api-base": "10.4.1",
+                "@polkadot/rpc-core": "10.4.1",
+                "@polkadot/types": "10.4.1",
+                "@polkadot/types-codec": "10.4.1",
+                "@polkadot/util": "^12.0.1",
+                "@polkadot/util-crypto": "^12.0.1",
                 "rxjs": "^7.8.0",
                 "tslib": "^2.5.0"
             },
             "engines": {
-                "node": ">=14"
+                "node": ">=16"
             }
         },
         "node_modules/@polkadot/api-derive/node_modules/@polkadot/util": {
-            "version": "11.1.3",
-            "resolved": "https://registry.npmjs.org/@polkadot/util/-/util-11.1.3.tgz",
-            "integrity": "sha512-Gsqzv1/fSoypS5tnJkM+NJQeT7O4iYlSniubUJnaZVOKsIbueTS1bMQ1y3/h8ISxbKBtICW5cZ6zCej6Q/jC3w==",
+            "version": "12.1.2",
+            "resolved": "https://registry.npmjs.org/@polkadot/util/-/util-12.1.2.tgz",
+            "integrity": "sha512-Da8q+0WVWSuMMS3hLAwnIid8FKRGLmwhD69jikye47zeEXCtvp4e/bjD0YbINNKHoeIRsApchJtqmbaEoxXjIQ==",
             "dependencies": {
-                "@polkadot/x-bigint": "11.1.3",
-                "@polkadot/x-global": "11.1.3",
-                "@polkadot/x-textdecoder": "11.1.3",
-                "@polkadot/x-textencoder": "11.1.3",
+                "@polkadot/x-bigint": "12.1.2",
+                "@polkadot/x-global": "12.1.2",
+                "@polkadot/x-textdecoder": "12.1.2",
+                "@polkadot/x-textencoder": "12.1.2",
                 "@types/bn.js": "^5.1.1",
                 "bn.js": "^5.2.1",
                 "tslib": "^2.5.0"
             },
             "engines": {
-                "node": ">=14"
-            }
-        },
-        "node_modules/@polkadot/api-derive/node_modules/@polkadot/x-bigint": {
-            "version": "11.1.3",
-            "resolved": "https://registry.npmjs.org/@polkadot/x-bigint/-/x-bigint-11.1.3.tgz",
-            "integrity": "sha512-fRUUHfW9VFsXT7sLUUY7gSu8v+PvzNLRwvjnp+Ly8vFx9LTLuVGFCi+mpysuRTaPpqZZJlzBJ3fST7xTGh67Pg==",
-            "dependencies": {
-                "@polkadot/x-global": "11.1.3",
-                "tslib": "^2.5.0"
-            },
-            "engines": {
-                "node": ">=14"
-            }
-        },
-        "node_modules/@polkadot/api-derive/node_modules/@polkadot/x-global": {
-            "version": "11.1.3",
-            "resolved": "https://registry.npmjs.org/@polkadot/x-global/-/x-global-11.1.3.tgz",
-            "integrity": "sha512-R3aqtIjgzFHJ3TyX6wavhp+59oLbZiqczIHkaas/nJe21+SVARqFmIII6BwS7ty7+8Uu4fHliA9re+ZSUp+rwg==",
-            "dependencies": {
-                "tslib": "^2.5.0"
-            },
-            "engines": {
-                "node": ">=14"
+                "node": ">=16"
             }
         },
         "node_modules/@polkadot/api-derive/node_modules/@polkadot/x-textdecoder": {
-            "version": "11.1.3",
-            "resolved": "https://registry.npmjs.org/@polkadot/x-textdecoder/-/x-textdecoder-11.1.3.tgz",
-            "integrity": "sha512-NhOjuXVfYRMw9l0VhCtZOtcWefZth58p5KpVOrFyJZd12fTsoMO5/746K7QoAjWRrLQTJ/LHCEKCtWww0LwVPw==",
+            "version": "12.1.2",
+            "resolved": "https://registry.npmjs.org/@polkadot/x-textdecoder/-/x-textdecoder-12.1.2.tgz",
+            "integrity": "sha512-O5ygxEHdPCIQVzH7T+xVALBfCwrT5tVms7Yjp6EMT697A9gpD3U2aPr4YinsQO6JFwYpQNzvm2wjW+7EEzYitw==",
             "dependencies": {
-                "@polkadot/x-global": "11.1.3",
+                "@polkadot/x-global": "12.1.2",
                 "tslib": "^2.5.0"
             },
             "engines": {
-                "node": ">=14"
+                "node": ">=16"
             }
         },
         "node_modules/@polkadot/api-derive/node_modules/@polkadot/x-textencoder": {
-            "version": "11.1.3",
-            "resolved": "https://registry.npmjs.org/@polkadot/x-textencoder/-/x-textencoder-11.1.3.tgz",
-            "integrity": "sha512-7DmqjlPN8aQexLUKwoHeadihpUnW8hjpXEru+aEDxjgq9XIxPvb++NeBK+Mra9RzzZRuiT/K5z16HlwKN//ewg==",
+            "version": "12.1.2",
+            "resolved": "https://registry.npmjs.org/@polkadot/x-textencoder/-/x-textencoder-12.1.2.tgz",
+            "integrity": "sha512-N+9HIXT0eUQbfg/SfGrNRK8aLFpd2QngJzTxo8CljpjCvQ2ddqzBVFA8o/lKTaXVzX84EmPDzjIV+yJlOXnglA==",
             "dependencies": {
-                "@polkadot/x-global": "11.1.3",
+                "@polkadot/x-global": "12.1.2",
                 "tslib": "^2.5.0"
             },
             "engines": {
-                "node": ">=14"
+                "node": ">=16"
             }
         },
         "node_modules/@polkadot/api/node_modules/@polkadot/util": {
-            "version": "11.1.3",
-            "resolved": "https://registry.npmjs.org/@polkadot/util/-/util-11.1.3.tgz",
-            "integrity": "sha512-Gsqzv1/fSoypS5tnJkM+NJQeT7O4iYlSniubUJnaZVOKsIbueTS1bMQ1y3/h8ISxbKBtICW5cZ6zCej6Q/jC3w==",
+            "version": "12.1.2",
+            "resolved": "https://registry.npmjs.org/@polkadot/util/-/util-12.1.2.tgz",
+            "integrity": "sha512-Da8q+0WVWSuMMS3hLAwnIid8FKRGLmwhD69jikye47zeEXCtvp4e/bjD0YbINNKHoeIRsApchJtqmbaEoxXjIQ==",
             "dependencies": {
-                "@polkadot/x-bigint": "11.1.3",
-                "@polkadot/x-global": "11.1.3",
-                "@polkadot/x-textdecoder": "11.1.3",
-                "@polkadot/x-textencoder": "11.1.3",
+                "@polkadot/x-bigint": "12.1.2",
+                "@polkadot/x-global": "12.1.2",
+                "@polkadot/x-textdecoder": "12.1.2",
+                "@polkadot/x-textencoder": "12.1.2",
                 "@types/bn.js": "^5.1.1",
                 "bn.js": "^5.2.1",
                 "tslib": "^2.5.0"
             },
             "engines": {
-                "node": ">=14"
-            }
-        },
-        "node_modules/@polkadot/api/node_modules/@polkadot/x-bigint": {
-            "version": "11.1.3",
-            "resolved": "https://registry.npmjs.org/@polkadot/x-bigint/-/x-bigint-11.1.3.tgz",
-            "integrity": "sha512-fRUUHfW9VFsXT7sLUUY7gSu8v+PvzNLRwvjnp+Ly8vFx9LTLuVGFCi+mpysuRTaPpqZZJlzBJ3fST7xTGh67Pg==",
-            "dependencies": {
-                "@polkadot/x-global": "11.1.3",
-                "tslib": "^2.5.0"
-            },
-            "engines": {
-                "node": ">=14"
-            }
-        },
-        "node_modules/@polkadot/api/node_modules/@polkadot/x-global": {
-            "version": "11.1.3",
-            "resolved": "https://registry.npmjs.org/@polkadot/x-global/-/x-global-11.1.3.tgz",
-            "integrity": "sha512-R3aqtIjgzFHJ3TyX6wavhp+59oLbZiqczIHkaas/nJe21+SVARqFmIII6BwS7ty7+8Uu4fHliA9re+ZSUp+rwg==",
-            "dependencies": {
-                "tslib": "^2.5.0"
-            },
-            "engines": {
-                "node": ">=14"
+                "node": ">=16"
             }
         },
         "node_modules/@polkadot/api/node_modules/@polkadot/x-textdecoder": {
-            "version": "11.1.3",
-            "resolved": "https://registry.npmjs.org/@polkadot/x-textdecoder/-/x-textdecoder-11.1.3.tgz",
-            "integrity": "sha512-NhOjuXVfYRMw9l0VhCtZOtcWefZth58p5KpVOrFyJZd12fTsoMO5/746K7QoAjWRrLQTJ/LHCEKCtWww0LwVPw==",
+            "version": "12.1.2",
+            "resolved": "https://registry.npmjs.org/@polkadot/x-textdecoder/-/x-textdecoder-12.1.2.tgz",
+            "integrity": "sha512-O5ygxEHdPCIQVzH7T+xVALBfCwrT5tVms7Yjp6EMT697A9gpD3U2aPr4YinsQO6JFwYpQNzvm2wjW+7EEzYitw==",
             "dependencies": {
-                "@polkadot/x-global": "11.1.3",
+                "@polkadot/x-global": "12.1.2",
                 "tslib": "^2.5.0"
             },
             "engines": {
-                "node": ">=14"
+                "node": ">=16"
             }
         },
         "node_modules/@polkadot/api/node_modules/@polkadot/x-textencoder": {
-            "version": "11.1.3",
-            "resolved": "https://registry.npmjs.org/@polkadot/x-textencoder/-/x-textencoder-11.1.3.tgz",
-            "integrity": "sha512-7DmqjlPN8aQexLUKwoHeadihpUnW8hjpXEru+aEDxjgq9XIxPvb++NeBK+Mra9RzzZRuiT/K5z16HlwKN//ewg==",
+            "version": "12.1.2",
+            "resolved": "https://registry.npmjs.org/@polkadot/x-textencoder/-/x-textencoder-12.1.2.tgz",
+            "integrity": "sha512-N+9HIXT0eUQbfg/SfGrNRK8aLFpd2QngJzTxo8CljpjCvQ2ddqzBVFA8o/lKTaXVzX84EmPDzjIV+yJlOXnglA==",
             "dependencies": {
-                "@polkadot/x-global": "11.1.3",
+                "@polkadot/x-global": "12.1.2",
                 "tslib": "^2.5.0"
             },
             "engines": {
-                "node": ">=14"
+                "node": ">=16"
             }
         },
         "node_modules/@polkadot/keyring": {
-            "version": "11.1.3",
-            "resolved": "https://registry.npmjs.org/@polkadot/keyring/-/keyring-11.1.3.tgz",
-            "integrity": "sha512-bzGz1cWDYK7MWhp0630W6KOwTC/wsvKKHBvWxReMT7iQwFHeLn5AemUOveqIPxF+esd/UfdN5aFDHApjYcyZsg==",
+            "version": "12.1.2",
+            "resolved": "https://registry.npmjs.org/@polkadot/keyring/-/keyring-12.1.2.tgz",
+            "integrity": "sha512-HskFoZwLwRWPthEQK50uOiOsbdIt0AY3gcrDmSS2ltkpUDY9qzlb/fAj0+QGtTrK36v5gHT8OD56Pd4l0FDMFw==",
             "dependencies": {
-                "@polkadot/util": "11.1.3",
-                "@polkadot/util-crypto": "11.1.3",
+                "@polkadot/util": "12.1.2",
+                "@polkadot/util-crypto": "12.1.2",
                 "tslib": "^2.5.0"
             },
             "engines": {
-                "node": ">=14"
+                "node": ">=16"
             },
             "peerDependencies": {
-                "@polkadot/util": "11.1.3",
-                "@polkadot/util-crypto": "11.1.3"
+                "@polkadot/util": "12.1.2",
+                "@polkadot/util-crypto": "12.1.2"
             }
         },
         "node_modules/@polkadot/keyring/node_modules/@polkadot/util": {
-            "version": "11.1.3",
-            "resolved": "https://registry.npmjs.org/@polkadot/util/-/util-11.1.3.tgz",
-            "integrity": "sha512-Gsqzv1/fSoypS5tnJkM+NJQeT7O4iYlSniubUJnaZVOKsIbueTS1bMQ1y3/h8ISxbKBtICW5cZ6zCej6Q/jC3w==",
+            "version": "12.1.2",
+            "resolved": "https://registry.npmjs.org/@polkadot/util/-/util-12.1.2.tgz",
+            "integrity": "sha512-Da8q+0WVWSuMMS3hLAwnIid8FKRGLmwhD69jikye47zeEXCtvp4e/bjD0YbINNKHoeIRsApchJtqmbaEoxXjIQ==",
             "dependencies": {
-                "@polkadot/x-bigint": "11.1.3",
-                "@polkadot/x-global": "11.1.3",
-                "@polkadot/x-textdecoder": "11.1.3",
-                "@polkadot/x-textencoder": "11.1.3",
+                "@polkadot/x-bigint": "12.1.2",
+                "@polkadot/x-global": "12.1.2",
+                "@polkadot/x-textdecoder": "12.1.2",
+                "@polkadot/x-textencoder": "12.1.2",
                 "@types/bn.js": "^5.1.1",
                 "bn.js": "^5.2.1",
                 "tslib": "^2.5.0"
             },
             "engines": {
-                "node": ">=14"
-            }
-        },
-        "node_modules/@polkadot/keyring/node_modules/@polkadot/x-bigint": {
-            "version": "11.1.3",
-            "resolved": "https://registry.npmjs.org/@polkadot/x-bigint/-/x-bigint-11.1.3.tgz",
-            "integrity": "sha512-fRUUHfW9VFsXT7sLUUY7gSu8v+PvzNLRwvjnp+Ly8vFx9LTLuVGFCi+mpysuRTaPpqZZJlzBJ3fST7xTGh67Pg==",
-            "dependencies": {
-                "@polkadot/x-global": "11.1.3",
-                "tslib": "^2.5.0"
-            },
-            "engines": {
-                "node": ">=14"
-            }
-        },
-        "node_modules/@polkadot/keyring/node_modules/@polkadot/x-global": {
-            "version": "11.1.3",
-            "resolved": "https://registry.npmjs.org/@polkadot/x-global/-/x-global-11.1.3.tgz",
-            "integrity": "sha512-R3aqtIjgzFHJ3TyX6wavhp+59oLbZiqczIHkaas/nJe21+SVARqFmIII6BwS7ty7+8Uu4fHliA9re+ZSUp+rwg==",
-            "dependencies": {
-                "tslib": "^2.5.0"
-            },
-            "engines": {
-                "node": ">=14"
+                "node": ">=16"
             }
         },
         "node_modules/@polkadot/keyring/node_modules/@polkadot/x-textdecoder": {
-            "version": "11.1.3",
-            "resolved": "https://registry.npmjs.org/@polkadot/x-textdecoder/-/x-textdecoder-11.1.3.tgz",
-            "integrity": "sha512-NhOjuXVfYRMw9l0VhCtZOtcWefZth58p5KpVOrFyJZd12fTsoMO5/746K7QoAjWRrLQTJ/LHCEKCtWww0LwVPw==",
+            "version": "12.1.2",
+            "resolved": "https://registry.npmjs.org/@polkadot/x-textdecoder/-/x-textdecoder-12.1.2.tgz",
+            "integrity": "sha512-O5ygxEHdPCIQVzH7T+xVALBfCwrT5tVms7Yjp6EMT697A9gpD3U2aPr4YinsQO6JFwYpQNzvm2wjW+7EEzYitw==",
             "dependencies": {
-                "@polkadot/x-global": "11.1.3",
+                "@polkadot/x-global": "12.1.2",
                 "tslib": "^2.5.0"
             },
             "engines": {
-                "node": ">=14"
+                "node": ">=16"
             }
         },
         "node_modules/@polkadot/keyring/node_modules/@polkadot/x-textencoder": {
-            "version": "11.1.3",
-            "resolved": "https://registry.npmjs.org/@polkadot/x-textencoder/-/x-textencoder-11.1.3.tgz",
-            "integrity": "sha512-7DmqjlPN8aQexLUKwoHeadihpUnW8hjpXEru+aEDxjgq9XIxPvb++NeBK+Mra9RzzZRuiT/K5z16HlwKN//ewg==",
+            "version": "12.1.2",
+            "resolved": "https://registry.npmjs.org/@polkadot/x-textencoder/-/x-textencoder-12.1.2.tgz",
+            "integrity": "sha512-N+9HIXT0eUQbfg/SfGrNRK8aLFpd2QngJzTxo8CljpjCvQ2ddqzBVFA8o/lKTaXVzX84EmPDzjIV+yJlOXnglA==",
             "dependencies": {
-                "@polkadot/x-global": "11.1.3",
+                "@polkadot/x-global": "12.1.2",
                 "tslib": "^2.5.0"
             },
             "engines": {
-                "node": ">=14"
+                "node": ">=16"
             }
         },
         "node_modules/@polkadot/networks": {
-            "version": "11.1.3",
-            "resolved": "https://registry.npmjs.org/@polkadot/networks/-/networks-11.1.3.tgz",
-            "integrity": "sha512-goLpX9SswAGGeh1jXB79wHEfWOF5rLIItMHYalujBmhQVxyAqbxP2tzQqPQXDLcnkWbgwkyYGLXaDD72GBqHZw==",
+            "version": "12.1.2",
+            "resolved": "https://registry.npmjs.org/@polkadot/networks/-/networks-12.1.2.tgz",
+            "integrity": "sha512-9gC5GYGFKXHY4oQaMfYvLLxGJ55slT3V8Zc6uk96KKysEvpSMDXdPUAKZJ3SXN9Iz3KaEa9x6RD5ZEf5j6BJ6g==",
             "dependencies": {
-                "@polkadot/util": "11.1.3",
-                "@substrate/ss58-registry": "^1.39.0",
+                "@polkadot/util": "12.1.2",
+                "@substrate/ss58-registry": "^1.40.0",
                 "tslib": "^2.5.0"
             },
             "engines": {
-                "node": ">=14"
+                "node": ">=16"
             }
         },
         "node_modules/@polkadot/networks/node_modules/@polkadot/util": {
-            "version": "11.1.3",
-            "resolved": "https://registry.npmjs.org/@polkadot/util/-/util-11.1.3.tgz",
-            "integrity": "sha512-Gsqzv1/fSoypS5tnJkM+NJQeT7O4iYlSniubUJnaZVOKsIbueTS1bMQ1y3/h8ISxbKBtICW5cZ6zCej6Q/jC3w==",
+            "version": "12.1.2",
+            "resolved": "https://registry.npmjs.org/@polkadot/util/-/util-12.1.2.tgz",
+            "integrity": "sha512-Da8q+0WVWSuMMS3hLAwnIid8FKRGLmwhD69jikye47zeEXCtvp4e/bjD0YbINNKHoeIRsApchJtqmbaEoxXjIQ==",
             "dependencies": {
-                "@polkadot/x-bigint": "11.1.3",
-                "@polkadot/x-global": "11.1.3",
-                "@polkadot/x-textdecoder": "11.1.3",
-                "@polkadot/x-textencoder": "11.1.3",
+                "@polkadot/x-bigint": "12.1.2",
+                "@polkadot/x-global": "12.1.2",
+                "@polkadot/x-textdecoder": "12.1.2",
+                "@polkadot/x-textencoder": "12.1.2",
                 "@types/bn.js": "^5.1.1",
                 "bn.js": "^5.2.1",
                 "tslib": "^2.5.0"
             },
             "engines": {
-                "node": ">=14"
-            }
-        },
-        "node_modules/@polkadot/networks/node_modules/@polkadot/x-bigint": {
-            "version": "11.1.3",
-            "resolved": "https://registry.npmjs.org/@polkadot/x-bigint/-/x-bigint-11.1.3.tgz",
-            "integrity": "sha512-fRUUHfW9VFsXT7sLUUY7gSu8v+PvzNLRwvjnp+Ly8vFx9LTLuVGFCi+mpysuRTaPpqZZJlzBJ3fST7xTGh67Pg==",
-            "dependencies": {
-                "@polkadot/x-global": "11.1.3",
-                "tslib": "^2.5.0"
-            },
-            "engines": {
-                "node": ">=14"
-            }
-        },
-        "node_modules/@polkadot/networks/node_modules/@polkadot/x-global": {
-            "version": "11.1.3",
-            "resolved": "https://registry.npmjs.org/@polkadot/x-global/-/x-global-11.1.3.tgz",
-            "integrity": "sha512-R3aqtIjgzFHJ3TyX6wavhp+59oLbZiqczIHkaas/nJe21+SVARqFmIII6BwS7ty7+8Uu4fHliA9re+ZSUp+rwg==",
-            "dependencies": {
-                "tslib": "^2.5.0"
-            },
-            "engines": {
-                "node": ">=14"
+                "node": ">=16"
             }
         },
         "node_modules/@polkadot/networks/node_modules/@polkadot/x-textdecoder": {
-            "version": "11.1.3",
-            "resolved": "https://registry.npmjs.org/@polkadot/x-textdecoder/-/x-textdecoder-11.1.3.tgz",
-            "integrity": "sha512-NhOjuXVfYRMw9l0VhCtZOtcWefZth58p5KpVOrFyJZd12fTsoMO5/746K7QoAjWRrLQTJ/LHCEKCtWww0LwVPw==",
+            "version": "12.1.2",
+            "resolved": "https://registry.npmjs.org/@polkadot/x-textdecoder/-/x-textdecoder-12.1.2.tgz",
+            "integrity": "sha512-O5ygxEHdPCIQVzH7T+xVALBfCwrT5tVms7Yjp6EMT697A9gpD3U2aPr4YinsQO6JFwYpQNzvm2wjW+7EEzYitw==",
             "dependencies": {
-                "@polkadot/x-global": "11.1.3",
+                "@polkadot/x-global": "12.1.2",
                 "tslib": "^2.5.0"
             },
             "engines": {
-                "node": ">=14"
+                "node": ">=16"
             }
         },
         "node_modules/@polkadot/networks/node_modules/@polkadot/x-textencoder": {
-            "version": "11.1.3",
-            "resolved": "https://registry.npmjs.org/@polkadot/x-textencoder/-/x-textencoder-11.1.3.tgz",
-            "integrity": "sha512-7DmqjlPN8aQexLUKwoHeadihpUnW8hjpXEru+aEDxjgq9XIxPvb++NeBK+Mra9RzzZRuiT/K5z16HlwKN//ewg==",
+            "version": "12.1.2",
+            "resolved": "https://registry.npmjs.org/@polkadot/x-textencoder/-/x-textencoder-12.1.2.tgz",
+            "integrity": "sha512-N+9HIXT0eUQbfg/SfGrNRK8aLFpd2QngJzTxo8CljpjCvQ2ddqzBVFA8o/lKTaXVzX84EmPDzjIV+yJlOXnglA==",
             "dependencies": {
-                "@polkadot/x-global": "11.1.3",
+                "@polkadot/x-global": "12.1.2",
                 "tslib": "^2.5.0"
             },
             "engines": {
-                "node": ">=14"
+                "node": ">=16"
             }
         },
         "node_modules/@polkadot/rpc-augment": {
-            "version": "10.3.2",
-            "resolved": "https://registry.npmjs.org/@polkadot/rpc-augment/-/rpc-augment-10.3.2.tgz",
-            "integrity": "sha512-P8pUywOtVc5jSoMMhtZSYqyvLNaf2x/tsDaC0sct1yHg5KkXjTCnOgRTepjObgsQWWW5SjKudhhXr8Yfv2XbWQ==",
+            "version": "10.4.1",
+            "resolved": "https://registry.npmjs.org/@polkadot/rpc-augment/-/rpc-augment-10.4.1.tgz",
+            "integrity": "sha512-lwwSjyboTTDzrfmBxFgBq4ZcD8mhMKkofmVqS/ntvuJePrCnBPGQG9d+tfntizIO5OpCqFGk0lgYBwae+oQ+vw==",
             "dependencies": {
-                "@polkadot/rpc-core": "10.3.2",
-                "@polkadot/types": "10.3.2",
-                "@polkadot/types-codec": "10.3.2",
-                "@polkadot/util": "^11.1.3",
+                "@polkadot/rpc-core": "10.4.1",
+                "@polkadot/types": "10.4.1",
+                "@polkadot/types-codec": "10.4.1",
+                "@polkadot/util": "^12.0.1",
                 "tslib": "^2.5.0"
             },
             "engines": {
-                "node": ">=14"
+                "node": ">=16"
             }
         },
         "node_modules/@polkadot/rpc-augment/node_modules/@polkadot/util": {
-            "version": "11.1.3",
-            "resolved": "https://registry.npmjs.org/@polkadot/util/-/util-11.1.3.tgz",
-            "integrity": "sha512-Gsqzv1/fSoypS5tnJkM+NJQeT7O4iYlSniubUJnaZVOKsIbueTS1bMQ1y3/h8ISxbKBtICW5cZ6zCej6Q/jC3w==",
+            "version": "12.1.2",
+            "resolved": "https://registry.npmjs.org/@polkadot/util/-/util-12.1.2.tgz",
+            "integrity": "sha512-Da8q+0WVWSuMMS3hLAwnIid8FKRGLmwhD69jikye47zeEXCtvp4e/bjD0YbINNKHoeIRsApchJtqmbaEoxXjIQ==",
             "dependencies": {
-                "@polkadot/x-bigint": "11.1.3",
-                "@polkadot/x-global": "11.1.3",
-                "@polkadot/x-textdecoder": "11.1.3",
-                "@polkadot/x-textencoder": "11.1.3",
+                "@polkadot/x-bigint": "12.1.2",
+                "@polkadot/x-global": "12.1.2",
+                "@polkadot/x-textdecoder": "12.1.2",
+                "@polkadot/x-textencoder": "12.1.2",
                 "@types/bn.js": "^5.1.1",
                 "bn.js": "^5.2.1",
                 "tslib": "^2.5.0"
             },
             "engines": {
-                "node": ">=14"
-            }
-        },
-        "node_modules/@polkadot/rpc-augment/node_modules/@polkadot/x-bigint": {
-            "version": "11.1.3",
-            "resolved": "https://registry.npmjs.org/@polkadot/x-bigint/-/x-bigint-11.1.3.tgz",
-            "integrity": "sha512-fRUUHfW9VFsXT7sLUUY7gSu8v+PvzNLRwvjnp+Ly8vFx9LTLuVGFCi+mpysuRTaPpqZZJlzBJ3fST7xTGh67Pg==",
-            "dependencies": {
-                "@polkadot/x-global": "11.1.3",
-                "tslib": "^2.5.0"
-            },
-            "engines": {
-                "node": ">=14"
-            }
-        },
-        "node_modules/@polkadot/rpc-augment/node_modules/@polkadot/x-global": {
-            "version": "11.1.3",
-            "resolved": "https://registry.npmjs.org/@polkadot/x-global/-/x-global-11.1.3.tgz",
-            "integrity": "sha512-R3aqtIjgzFHJ3TyX6wavhp+59oLbZiqczIHkaas/nJe21+SVARqFmIII6BwS7ty7+8Uu4fHliA9re+ZSUp+rwg==",
-            "dependencies": {
-                "tslib": "^2.5.0"
-            },
-            "engines": {
-                "node": ">=14"
+                "node": ">=16"
             }
         },
         "node_modules/@polkadot/rpc-augment/node_modules/@polkadot/x-textdecoder": {
-            "version": "11.1.3",
-            "resolved": "https://registry.npmjs.org/@polkadot/x-textdecoder/-/x-textdecoder-11.1.3.tgz",
-            "integrity": "sha512-NhOjuXVfYRMw9l0VhCtZOtcWefZth58p5KpVOrFyJZd12fTsoMO5/746K7QoAjWRrLQTJ/LHCEKCtWww0LwVPw==",
+            "version": "12.1.2",
+            "resolved": "https://registry.npmjs.org/@polkadot/x-textdecoder/-/x-textdecoder-12.1.2.tgz",
+            "integrity": "sha512-O5ygxEHdPCIQVzH7T+xVALBfCwrT5tVms7Yjp6EMT697A9gpD3U2aPr4YinsQO6JFwYpQNzvm2wjW+7EEzYitw==",
             "dependencies": {
-                "@polkadot/x-global": "11.1.3",
+                "@polkadot/x-global": "12.1.2",
                 "tslib": "^2.5.0"
             },
             "engines": {
-                "node": ">=14"
+                "node": ">=16"
             }
         },
         "node_modules/@polkadot/rpc-augment/node_modules/@polkadot/x-textencoder": {
-            "version": "11.1.3",
-            "resolved": "https://registry.npmjs.org/@polkadot/x-textencoder/-/x-textencoder-11.1.3.tgz",
-            "integrity": "sha512-7DmqjlPN8aQexLUKwoHeadihpUnW8hjpXEru+aEDxjgq9XIxPvb++NeBK+Mra9RzzZRuiT/K5z16HlwKN//ewg==",
+            "version": "12.1.2",
+            "resolved": "https://registry.npmjs.org/@polkadot/x-textencoder/-/x-textencoder-12.1.2.tgz",
+            "integrity": "sha512-N+9HIXT0eUQbfg/SfGrNRK8aLFpd2QngJzTxo8CljpjCvQ2ddqzBVFA8o/lKTaXVzX84EmPDzjIV+yJlOXnglA==",
             "dependencies": {
-                "@polkadot/x-global": "11.1.3",
+                "@polkadot/x-global": "12.1.2",
                 "tslib": "^2.5.0"
             },
             "engines": {
-                "node": ">=14"
+                "node": ">=16"
             }
         },
         "node_modules/@polkadot/rpc-core": {
-            "version": "10.3.2",
-            "resolved": "https://registry.npmjs.org/@polkadot/rpc-core/-/rpc-core-10.3.2.tgz",
-            "integrity": "sha512-XUQ6QzcAG7NkhenOtV2zhJjrSsQntmJHfwt8Hp5JZdap/bTsRLGl66N4mrK0Lm5535OiDYFEGXxnLZM10IjtRA==",
+            "version": "10.4.1",
+            "resolved": "https://registry.npmjs.org/@polkadot/rpc-core/-/rpc-core-10.4.1.tgz",
+            "integrity": "sha512-jE3dBzfOFkiROMsiXpge/njvwPDCXF990VPFtlFqVWpr9ypXY7eZT1gduanN6YkXRjzcBVVPHaPfWLejie6hZA==",
             "dependencies": {
-                "@polkadot/rpc-augment": "10.3.2",
-                "@polkadot/rpc-provider": "10.3.2",
-                "@polkadot/types": "10.3.2",
-                "@polkadot/util": "^11.1.3",
+                "@polkadot/rpc-augment": "10.4.1",
+                "@polkadot/rpc-provider": "10.4.1",
+                "@polkadot/types": "10.4.1",
+                "@polkadot/util": "^12.0.1",
                 "rxjs": "^7.8.0",
                 "tslib": "^2.5.0"
             },
             "engines": {
-                "node": ">=14"
+                "node": ">=16"
             }
         },
         "node_modules/@polkadot/rpc-core/node_modules/@polkadot/util": {
-            "version": "11.1.3",
-            "resolved": "https://registry.npmjs.org/@polkadot/util/-/util-11.1.3.tgz",
-            "integrity": "sha512-Gsqzv1/fSoypS5tnJkM+NJQeT7O4iYlSniubUJnaZVOKsIbueTS1bMQ1y3/h8ISxbKBtICW5cZ6zCej6Q/jC3w==",
+            "version": "12.1.2",
+            "resolved": "https://registry.npmjs.org/@polkadot/util/-/util-12.1.2.tgz",
+            "integrity": "sha512-Da8q+0WVWSuMMS3hLAwnIid8FKRGLmwhD69jikye47zeEXCtvp4e/bjD0YbINNKHoeIRsApchJtqmbaEoxXjIQ==",
             "dependencies": {
-                "@polkadot/x-bigint": "11.1.3",
-                "@polkadot/x-global": "11.1.3",
-                "@polkadot/x-textdecoder": "11.1.3",
-                "@polkadot/x-textencoder": "11.1.3",
+                "@polkadot/x-bigint": "12.1.2",
+                "@polkadot/x-global": "12.1.2",
+                "@polkadot/x-textdecoder": "12.1.2",
+                "@polkadot/x-textencoder": "12.1.2",
                 "@types/bn.js": "^5.1.1",
                 "bn.js": "^5.2.1",
                 "tslib": "^2.5.0"
             },
             "engines": {
-                "node": ">=14"
-            }
-        },
-        "node_modules/@polkadot/rpc-core/node_modules/@polkadot/x-bigint": {
-            "version": "11.1.3",
-            "resolved": "https://registry.npmjs.org/@polkadot/x-bigint/-/x-bigint-11.1.3.tgz",
-            "integrity": "sha512-fRUUHfW9VFsXT7sLUUY7gSu8v+PvzNLRwvjnp+Ly8vFx9LTLuVGFCi+mpysuRTaPpqZZJlzBJ3fST7xTGh67Pg==",
-            "dependencies": {
-                "@polkadot/x-global": "11.1.3",
-                "tslib": "^2.5.0"
-            },
-            "engines": {
-                "node": ">=14"
-            }
-        },
-        "node_modules/@polkadot/rpc-core/node_modules/@polkadot/x-global": {
-            "version": "11.1.3",
-            "resolved": "https://registry.npmjs.org/@polkadot/x-global/-/x-global-11.1.3.tgz",
-            "integrity": "sha512-R3aqtIjgzFHJ3TyX6wavhp+59oLbZiqczIHkaas/nJe21+SVARqFmIII6BwS7ty7+8Uu4fHliA9re+ZSUp+rwg==",
-            "dependencies": {
-                "tslib": "^2.5.0"
-            },
-            "engines": {
-                "node": ">=14"
+                "node": ">=16"
             }
         },
         "node_modules/@polkadot/rpc-core/node_modules/@polkadot/x-textdecoder": {
-            "version": "11.1.3",
-            "resolved": "https://registry.npmjs.org/@polkadot/x-textdecoder/-/x-textdecoder-11.1.3.tgz",
-            "integrity": "sha512-NhOjuXVfYRMw9l0VhCtZOtcWefZth58p5KpVOrFyJZd12fTsoMO5/746K7QoAjWRrLQTJ/LHCEKCtWww0LwVPw==",
+            "version": "12.1.2",
+            "resolved": "https://registry.npmjs.org/@polkadot/x-textdecoder/-/x-textdecoder-12.1.2.tgz",
+            "integrity": "sha512-O5ygxEHdPCIQVzH7T+xVALBfCwrT5tVms7Yjp6EMT697A9gpD3U2aPr4YinsQO6JFwYpQNzvm2wjW+7EEzYitw==",
             "dependencies": {
-                "@polkadot/x-global": "11.1.3",
+                "@polkadot/x-global": "12.1.2",
                 "tslib": "^2.5.0"
             },
             "engines": {
-                "node": ">=14"
+                "node": ">=16"
             }
         },
         "node_modules/@polkadot/rpc-core/node_modules/@polkadot/x-textencoder": {
-            "version": "11.1.3",
-            "resolved": "https://registry.npmjs.org/@polkadot/x-textencoder/-/x-textencoder-11.1.3.tgz",
-            "integrity": "sha512-7DmqjlPN8aQexLUKwoHeadihpUnW8hjpXEru+aEDxjgq9XIxPvb++NeBK+Mra9RzzZRuiT/K5z16HlwKN//ewg==",
+            "version": "12.1.2",
+            "resolved": "https://registry.npmjs.org/@polkadot/x-textencoder/-/x-textencoder-12.1.2.tgz",
+            "integrity": "sha512-N+9HIXT0eUQbfg/SfGrNRK8aLFpd2QngJzTxo8CljpjCvQ2ddqzBVFA8o/lKTaXVzX84EmPDzjIV+yJlOXnglA==",
             "dependencies": {
-                "@polkadot/x-global": "11.1.3",
+                "@polkadot/x-global": "12.1.2",
                 "tslib": "^2.5.0"
             },
             "engines": {
-                "node": ">=14"
+                "node": ">=16"
             }
         },
         "node_modules/@polkadot/rpc-provider": {
-            "version": "10.3.2",
-            "resolved": "https://registry.npmjs.org/@polkadot/rpc-provider/-/rpc-provider-10.3.2.tgz",
-            "integrity": "sha512-torI91dgZXPYIjUSU1/YzTK9mK3H/36JZhJFrdrw63PR3Lh5/cdQ8TFJ5gJ2naVXZB/GIOH7GAhm38ByL17wig==",
+            "version": "10.4.1",
+            "resolved": "https://registry.npmjs.org/@polkadot/rpc-provider/-/rpc-provider-10.4.1.tgz",
+            "integrity": "sha512-DwXs5dB1hp0P17I/Aqg+BnILQRMWlmMlABfSwwPprOh+16BBDw4P7bEuvaYw3gl/Zrxt4UhDcPl48jD+4j5OrQ==",
             "dependencies": {
-                "@polkadot/keyring": "^11.1.3",
-                "@polkadot/types": "10.3.2",
-                "@polkadot/types-support": "10.3.2",
-                "@polkadot/util": "^11.1.3",
-                "@polkadot/util-crypto": "^11.1.3",
-                "@polkadot/x-fetch": "^11.1.3",
-                "@polkadot/x-global": "^11.1.3",
-                "@polkadot/x-ws": "^11.1.3",
+                "@polkadot/keyring": "^12.0.1",
+                "@polkadot/types": "10.4.1",
+                "@polkadot/types-support": "10.4.1",
+                "@polkadot/util": "^12.0.1",
+                "@polkadot/util-crypto": "^12.0.1",
+                "@polkadot/x-fetch": "^12.0.1",
+                "@polkadot/x-global": "^12.0.1",
+                "@polkadot/x-ws": "^12.0.1",
                 "eventemitter3": "^5.0.0",
                 "mock-socket": "^9.2.1",
                 "nock": "^13.3.0",
                 "tslib": "^2.5.0"
             },
             "engines": {
-                "node": ">=14"
+                "node": ">=16"
             },
             "optionalDependencies": {
-                "@substrate/connect": "0.7.23"
+                "@substrate/connect": "0.7.24"
             }
         },
         "node_modules/@polkadot/rpc-provider/node_modules/@polkadot/util": {
-            "version": "11.1.3",
-            "resolved": "https://registry.npmjs.org/@polkadot/util/-/util-11.1.3.tgz",
-            "integrity": "sha512-Gsqzv1/fSoypS5tnJkM+NJQeT7O4iYlSniubUJnaZVOKsIbueTS1bMQ1y3/h8ISxbKBtICW5cZ6zCej6Q/jC3w==",
+            "version": "12.1.2",
+            "resolved": "https://registry.npmjs.org/@polkadot/util/-/util-12.1.2.tgz",
+            "integrity": "sha512-Da8q+0WVWSuMMS3hLAwnIid8FKRGLmwhD69jikye47zeEXCtvp4e/bjD0YbINNKHoeIRsApchJtqmbaEoxXjIQ==",
             "dependencies": {
-                "@polkadot/x-bigint": "11.1.3",
-                "@polkadot/x-global": "11.1.3",
-                "@polkadot/x-textdecoder": "11.1.3",
-                "@polkadot/x-textencoder": "11.1.3",
+                "@polkadot/x-bigint": "12.1.2",
+                "@polkadot/x-global": "12.1.2",
+                "@polkadot/x-textdecoder": "12.1.2",
+                "@polkadot/x-textencoder": "12.1.2",
                 "@types/bn.js": "^5.1.1",
                 "bn.js": "^5.2.1",
                 "tslib": "^2.5.0"
             },
             "engines": {
-                "node": ">=14"
-            }
-        },
-        "node_modules/@polkadot/rpc-provider/node_modules/@polkadot/x-bigint": {
-            "version": "11.1.3",
-            "resolved": "https://registry.npmjs.org/@polkadot/x-bigint/-/x-bigint-11.1.3.tgz",
-            "integrity": "sha512-fRUUHfW9VFsXT7sLUUY7gSu8v+PvzNLRwvjnp+Ly8vFx9LTLuVGFCi+mpysuRTaPpqZZJlzBJ3fST7xTGh67Pg==",
-            "dependencies": {
-                "@polkadot/x-global": "11.1.3",
-                "tslib": "^2.5.0"
-            },
-            "engines": {
-                "node": ">=14"
-            }
-        },
-        "node_modules/@polkadot/rpc-provider/node_modules/@polkadot/x-global": {
-            "version": "11.1.3",
-            "resolved": "https://registry.npmjs.org/@polkadot/x-global/-/x-global-11.1.3.tgz",
-            "integrity": "sha512-R3aqtIjgzFHJ3TyX6wavhp+59oLbZiqczIHkaas/nJe21+SVARqFmIII6BwS7ty7+8Uu4fHliA9re+ZSUp+rwg==",
-            "dependencies": {
-                "tslib": "^2.5.0"
-            },
-            "engines": {
-                "node": ">=14"
+                "node": ">=16"
             }
         },
         "node_modules/@polkadot/rpc-provider/node_modules/@polkadot/x-textdecoder": {
-            "version": "11.1.3",
-            "resolved": "https://registry.npmjs.org/@polkadot/x-textdecoder/-/x-textdecoder-11.1.3.tgz",
-            "integrity": "sha512-NhOjuXVfYRMw9l0VhCtZOtcWefZth58p5KpVOrFyJZd12fTsoMO5/746K7QoAjWRrLQTJ/LHCEKCtWww0LwVPw==",
+            "version": "12.1.2",
+            "resolved": "https://registry.npmjs.org/@polkadot/x-textdecoder/-/x-textdecoder-12.1.2.tgz",
+            "integrity": "sha512-O5ygxEHdPCIQVzH7T+xVALBfCwrT5tVms7Yjp6EMT697A9gpD3U2aPr4YinsQO6JFwYpQNzvm2wjW+7EEzYitw==",
             "dependencies": {
-                "@polkadot/x-global": "11.1.3",
+                "@polkadot/x-global": "12.1.2",
                 "tslib": "^2.5.0"
             },
             "engines": {
-                "node": ">=14"
+                "node": ">=16"
             }
         },
         "node_modules/@polkadot/rpc-provider/node_modules/@polkadot/x-textencoder": {
-            "version": "11.1.3",
-            "resolved": "https://registry.npmjs.org/@polkadot/x-textencoder/-/x-textencoder-11.1.3.tgz",
-            "integrity": "sha512-7DmqjlPN8aQexLUKwoHeadihpUnW8hjpXEru+aEDxjgq9XIxPvb++NeBK+Mra9RzzZRuiT/K5z16HlwKN//ewg==",
+            "version": "12.1.2",
+            "resolved": "https://registry.npmjs.org/@polkadot/x-textencoder/-/x-textencoder-12.1.2.tgz",
+            "integrity": "sha512-N+9HIXT0eUQbfg/SfGrNRK8aLFpd2QngJzTxo8CljpjCvQ2ddqzBVFA8o/lKTaXVzX84EmPDzjIV+yJlOXnglA==",
             "dependencies": {
-                "@polkadot/x-global": "11.1.3",
+                "@polkadot/x-global": "12.1.2",
                 "tslib": "^2.5.0"
             },
             "engines": {
-                "node": ">=14"
+                "node": ">=16"
             }
         },
         "node_modules/@polkadot/typegen": {
-            "version": "10.3.2",
-            "resolved": "https://registry.npmjs.org/@polkadot/typegen/-/typegen-10.3.2.tgz",
-            "integrity": "sha512-ho0oRXRTQfu85nOOHAZ/N1LMPzkn6gaT82PwUi2Rvt7hXCZVK5sYe6s9NSRK6eqlrp9gRXS55rmo+H7WQ7OIVw==",
+            "version": "10.4.1",
+            "resolved": "https://registry.npmjs.org/@polkadot/typegen/-/typegen-10.4.1.tgz",
+            "integrity": "sha512-M2DwurCqX4n7IAXWRK/T9yLERC6y+rKzg3YpIiQ6RdOz5Hmr0vimU/1KVunW/0I8gOI+dCvHR6ybXftRrLhabg==",
             "dev": true,
             "dependencies": {
-                "@polkadot/api": "10.3.2",
-                "@polkadot/api-augment": "10.3.2",
-                "@polkadot/rpc-augment": "10.3.2",
-                "@polkadot/rpc-provider": "10.3.2",
-                "@polkadot/types": "10.3.2",
-                "@polkadot/types-augment": "10.3.2",
-                "@polkadot/types-codec": "10.3.2",
-                "@polkadot/types-create": "10.3.2",
-                "@polkadot/types-support": "10.3.2",
-                "@polkadot/util": "^11.1.3",
-                "@polkadot/util-crypto": "^11.1.3",
-                "@polkadot/x-ws": "^11.1.3",
+                "@polkadot/api": "10.4.1",
+                "@polkadot/api-augment": "10.4.1",
+                "@polkadot/rpc-augment": "10.4.1",
+                "@polkadot/rpc-provider": "10.4.1",
+                "@polkadot/types": "10.4.1",
+                "@polkadot/types-augment": "10.4.1",
+                "@polkadot/types-codec": "10.4.1",
+                "@polkadot/types-create": "10.4.1",
+                "@polkadot/types-support": "10.4.1",
+                "@polkadot/util": "^12.0.1",
+                "@polkadot/util-crypto": "^12.0.1",
+                "@polkadot/x-ws": "^12.0.1",
                 "handlebars": "^4.7.7",
                 "tslib": "^2.5.0",
                 "yargs": "^17.7.1"
@@ -3280,558 +3087,395 @@
                 "polkadot-types-internal-metadata": "scripts/polkadot-types-internal-metadata.mjs"
             },
             "engines": {
-                "node": ">=14"
+                "node": ">=16"
             }
         },
         "node_modules/@polkadot/typegen/node_modules/@polkadot/util": {
-            "version": "11.1.3",
-            "resolved": "https://registry.npmjs.org/@polkadot/util/-/util-11.1.3.tgz",
-            "integrity": "sha512-Gsqzv1/fSoypS5tnJkM+NJQeT7O4iYlSniubUJnaZVOKsIbueTS1bMQ1y3/h8ISxbKBtICW5cZ6zCej6Q/jC3w==",
+            "version": "12.1.2",
+            "resolved": "https://registry.npmjs.org/@polkadot/util/-/util-12.1.2.tgz",
+            "integrity": "sha512-Da8q+0WVWSuMMS3hLAwnIid8FKRGLmwhD69jikye47zeEXCtvp4e/bjD0YbINNKHoeIRsApchJtqmbaEoxXjIQ==",
             "dev": true,
             "dependencies": {
-                "@polkadot/x-bigint": "11.1.3",
-                "@polkadot/x-global": "11.1.3",
-                "@polkadot/x-textdecoder": "11.1.3",
-                "@polkadot/x-textencoder": "11.1.3",
+                "@polkadot/x-bigint": "12.1.2",
+                "@polkadot/x-global": "12.1.2",
+                "@polkadot/x-textdecoder": "12.1.2",
+                "@polkadot/x-textencoder": "12.1.2",
                 "@types/bn.js": "^5.1.1",
                 "bn.js": "^5.2.1",
                 "tslib": "^2.5.0"
             },
             "engines": {
-                "node": ">=14"
-            }
-        },
-        "node_modules/@polkadot/typegen/node_modules/@polkadot/x-bigint": {
-            "version": "11.1.3",
-            "resolved": "https://registry.npmjs.org/@polkadot/x-bigint/-/x-bigint-11.1.3.tgz",
-            "integrity": "sha512-fRUUHfW9VFsXT7sLUUY7gSu8v+PvzNLRwvjnp+Ly8vFx9LTLuVGFCi+mpysuRTaPpqZZJlzBJ3fST7xTGh67Pg==",
-            "dev": true,
-            "dependencies": {
-                "@polkadot/x-global": "11.1.3",
-                "tslib": "^2.5.0"
-            },
-            "engines": {
-                "node": ">=14"
-            }
-        },
-        "node_modules/@polkadot/typegen/node_modules/@polkadot/x-global": {
-            "version": "11.1.3",
-            "resolved": "https://registry.npmjs.org/@polkadot/x-global/-/x-global-11.1.3.tgz",
-            "integrity": "sha512-R3aqtIjgzFHJ3TyX6wavhp+59oLbZiqczIHkaas/nJe21+SVARqFmIII6BwS7ty7+8Uu4fHliA9re+ZSUp+rwg==",
-            "dev": true,
-            "dependencies": {
-                "tslib": "^2.5.0"
-            },
-            "engines": {
-                "node": ">=14"
+                "node": ">=16"
             }
         },
         "node_modules/@polkadot/typegen/node_modules/@polkadot/x-textdecoder": {
-            "version": "11.1.3",
-            "resolved": "https://registry.npmjs.org/@polkadot/x-textdecoder/-/x-textdecoder-11.1.3.tgz",
-            "integrity": "sha512-NhOjuXVfYRMw9l0VhCtZOtcWefZth58p5KpVOrFyJZd12fTsoMO5/746K7QoAjWRrLQTJ/LHCEKCtWww0LwVPw==",
+            "version": "12.1.2",
+            "resolved": "https://registry.npmjs.org/@polkadot/x-textdecoder/-/x-textdecoder-12.1.2.tgz",
+            "integrity": "sha512-O5ygxEHdPCIQVzH7T+xVALBfCwrT5tVms7Yjp6EMT697A9gpD3U2aPr4YinsQO6JFwYpQNzvm2wjW+7EEzYitw==",
             "dev": true,
             "dependencies": {
-                "@polkadot/x-global": "11.1.3",
+                "@polkadot/x-global": "12.1.2",
                 "tslib": "^2.5.0"
             },
             "engines": {
-                "node": ">=14"
+                "node": ">=16"
             }
         },
         "node_modules/@polkadot/typegen/node_modules/@polkadot/x-textencoder": {
-            "version": "11.1.3",
-            "resolved": "https://registry.npmjs.org/@polkadot/x-textencoder/-/x-textencoder-11.1.3.tgz",
-            "integrity": "sha512-7DmqjlPN8aQexLUKwoHeadihpUnW8hjpXEru+aEDxjgq9XIxPvb++NeBK+Mra9RzzZRuiT/K5z16HlwKN//ewg==",
+            "version": "12.1.2",
+            "resolved": "https://registry.npmjs.org/@polkadot/x-textencoder/-/x-textencoder-12.1.2.tgz",
+            "integrity": "sha512-N+9HIXT0eUQbfg/SfGrNRK8aLFpd2QngJzTxo8CljpjCvQ2ddqzBVFA8o/lKTaXVzX84EmPDzjIV+yJlOXnglA==",
             "dev": true,
             "dependencies": {
-                "@polkadot/x-global": "11.1.3",
+                "@polkadot/x-global": "12.1.2",
                 "tslib": "^2.5.0"
             },
             "engines": {
-                "node": ">=14"
+                "node": ">=16"
             }
         },
         "node_modules/@polkadot/types": {
-            "version": "10.3.2",
-            "resolved": "https://registry.npmjs.org/@polkadot/types/-/types-10.3.2.tgz",
-            "integrity": "sha512-dwCB2S8yGS2gdvAMlqTiKB+ysGoiZgqhyD+hxpE2JsDtjDHb5q6BCAyeKGnG7BcUHdnspYAt9g0EcjRDkTt5Tw==",
+            "version": "10.4.1",
+            "resolved": "https://registry.npmjs.org/@polkadot/types/-/types-10.4.1.tgz",
+            "integrity": "sha512-w4spUa4CMLoPuIHOANR8X5F/Hfs4b4OnxsofA9SOl2aaQNRgu77Qu0y60rReu8HxBKD/FUBJJmRpZeY/2WQAAQ==",
             "dependencies": {
-                "@polkadot/keyring": "^11.1.3",
-                "@polkadot/types-augment": "10.3.2",
-                "@polkadot/types-codec": "10.3.2",
-                "@polkadot/types-create": "10.3.2",
-                "@polkadot/util": "^11.1.3",
-                "@polkadot/util-crypto": "^11.1.3",
+                "@polkadot/keyring": "^12.0.1",
+                "@polkadot/types-augment": "10.4.1",
+                "@polkadot/types-codec": "10.4.1",
+                "@polkadot/types-create": "10.4.1",
+                "@polkadot/util": "^12.0.1",
+                "@polkadot/util-crypto": "^12.0.1",
                 "rxjs": "^7.8.0",
                 "tslib": "^2.5.0"
             },
             "engines": {
-                "node": ">=14"
+                "node": ">=16"
             }
         },
         "node_modules/@polkadot/types-augment": {
-            "version": "10.3.2",
-            "resolved": "https://registry.npmjs.org/@polkadot/types-augment/-/types-augment-10.3.2.tgz",
-            "integrity": "sha512-ECtf8zYak+lJ6eMrQKigUB0FlqoQXPm1bJ5EKCw1Lkgf45sSgAkaY8rHgon4fzbxwVc3JQR7KUiumvRBd1dvnQ==",
+            "version": "10.4.1",
+            "resolved": "https://registry.npmjs.org/@polkadot/types-augment/-/types-augment-10.4.1.tgz",
+            "integrity": "sha512-4QWfxf6nA+sBf2X88S454N5Wpc4yTL+9uwdCP5PiqyDuCv96l+G0jQWurolywADJcKMKcnu8zHdQdv4rcgUyxQ==",
             "dependencies": {
-                "@polkadot/types": "10.3.2",
-                "@polkadot/types-codec": "10.3.2",
-                "@polkadot/util": "^11.1.3",
+                "@polkadot/types": "10.4.1",
+                "@polkadot/types-codec": "10.4.1",
+                "@polkadot/util": "^12.0.1",
                 "tslib": "^2.5.0"
             },
             "engines": {
-                "node": ">=14"
+                "node": ">=16"
             }
         },
         "node_modules/@polkadot/types-augment/node_modules/@polkadot/util": {
-            "version": "11.1.3",
-            "resolved": "https://registry.npmjs.org/@polkadot/util/-/util-11.1.3.tgz",
-            "integrity": "sha512-Gsqzv1/fSoypS5tnJkM+NJQeT7O4iYlSniubUJnaZVOKsIbueTS1bMQ1y3/h8ISxbKBtICW5cZ6zCej6Q/jC3w==",
+            "version": "12.1.2",
+            "resolved": "https://registry.npmjs.org/@polkadot/util/-/util-12.1.2.tgz",
+            "integrity": "sha512-Da8q+0WVWSuMMS3hLAwnIid8FKRGLmwhD69jikye47zeEXCtvp4e/bjD0YbINNKHoeIRsApchJtqmbaEoxXjIQ==",
             "dependencies": {
-                "@polkadot/x-bigint": "11.1.3",
-                "@polkadot/x-global": "11.1.3",
-                "@polkadot/x-textdecoder": "11.1.3",
-                "@polkadot/x-textencoder": "11.1.3",
+                "@polkadot/x-bigint": "12.1.2",
+                "@polkadot/x-global": "12.1.2",
+                "@polkadot/x-textdecoder": "12.1.2",
+                "@polkadot/x-textencoder": "12.1.2",
                 "@types/bn.js": "^5.1.1",
                 "bn.js": "^5.2.1",
                 "tslib": "^2.5.0"
             },
             "engines": {
-                "node": ">=14"
-            }
-        },
-        "node_modules/@polkadot/types-augment/node_modules/@polkadot/x-bigint": {
-            "version": "11.1.3",
-            "resolved": "https://registry.npmjs.org/@polkadot/x-bigint/-/x-bigint-11.1.3.tgz",
-            "integrity": "sha512-fRUUHfW9VFsXT7sLUUY7gSu8v+PvzNLRwvjnp+Ly8vFx9LTLuVGFCi+mpysuRTaPpqZZJlzBJ3fST7xTGh67Pg==",
-            "dependencies": {
-                "@polkadot/x-global": "11.1.3",
-                "tslib": "^2.5.0"
-            },
-            "engines": {
-                "node": ">=14"
-            }
-        },
-        "node_modules/@polkadot/types-augment/node_modules/@polkadot/x-global": {
-            "version": "11.1.3",
-            "resolved": "https://registry.npmjs.org/@polkadot/x-global/-/x-global-11.1.3.tgz",
-            "integrity": "sha512-R3aqtIjgzFHJ3TyX6wavhp+59oLbZiqczIHkaas/nJe21+SVARqFmIII6BwS7ty7+8Uu4fHliA9re+ZSUp+rwg==",
-            "dependencies": {
-                "tslib": "^2.5.0"
-            },
-            "engines": {
-                "node": ">=14"
+                "node": ">=16"
             }
         },
         "node_modules/@polkadot/types-augment/node_modules/@polkadot/x-textdecoder": {
-            "version": "11.1.3",
-            "resolved": "https://registry.npmjs.org/@polkadot/x-textdecoder/-/x-textdecoder-11.1.3.tgz",
-            "integrity": "sha512-NhOjuXVfYRMw9l0VhCtZOtcWefZth58p5KpVOrFyJZd12fTsoMO5/746K7QoAjWRrLQTJ/LHCEKCtWww0LwVPw==",
+            "version": "12.1.2",
+            "resolved": "https://registry.npmjs.org/@polkadot/x-textdecoder/-/x-textdecoder-12.1.2.tgz",
+            "integrity": "sha512-O5ygxEHdPCIQVzH7T+xVALBfCwrT5tVms7Yjp6EMT697A9gpD3U2aPr4YinsQO6JFwYpQNzvm2wjW+7EEzYitw==",
             "dependencies": {
-                "@polkadot/x-global": "11.1.3",
+                "@polkadot/x-global": "12.1.2",
                 "tslib": "^2.5.0"
             },
             "engines": {
-                "node": ">=14"
+                "node": ">=16"
             }
         },
         "node_modules/@polkadot/types-augment/node_modules/@polkadot/x-textencoder": {
-            "version": "11.1.3",
-            "resolved": "https://registry.npmjs.org/@polkadot/x-textencoder/-/x-textencoder-11.1.3.tgz",
-            "integrity": "sha512-7DmqjlPN8aQexLUKwoHeadihpUnW8hjpXEru+aEDxjgq9XIxPvb++NeBK+Mra9RzzZRuiT/K5z16HlwKN//ewg==",
+            "version": "12.1.2",
+            "resolved": "https://registry.npmjs.org/@polkadot/x-textencoder/-/x-textencoder-12.1.2.tgz",
+            "integrity": "sha512-N+9HIXT0eUQbfg/SfGrNRK8aLFpd2QngJzTxo8CljpjCvQ2ddqzBVFA8o/lKTaXVzX84EmPDzjIV+yJlOXnglA==",
             "dependencies": {
-                "@polkadot/x-global": "11.1.3",
+                "@polkadot/x-global": "12.1.2",
                 "tslib": "^2.5.0"
             },
             "engines": {
-                "node": ">=14"
+                "node": ">=16"
             }
         },
         "node_modules/@polkadot/types-codec": {
-            "version": "10.3.2",
-            "resolved": "https://registry.npmjs.org/@polkadot/types-codec/-/types-codec-10.3.2.tgz",
-            "integrity": "sha512-gsTyg11bcoAhCym8SlNcZ5bPrLUUq86HnWa3Yqq0+Sso+Skc0LO3FwBwbg+HS4EospMqoLnJEt+5CFBStr2M0A==",
+            "version": "10.4.1",
+            "resolved": "https://registry.npmjs.org/@polkadot/types-codec/-/types-codec-10.4.1.tgz",
+            "integrity": "sha512-h6OCSF6i0b/Q4uCOEEiibMkGefhb7daaDGwoxjTEOeSqDE9gMIkhkyXVjqcOGbsHsFaYqYhuJakRQe/LICykTw==",
             "dependencies": {
-                "@polkadot/util": "^11.1.3",
-                "@polkadot/x-bigint": "^11.1.3",
+                "@polkadot/util": "^12.0.1",
+                "@polkadot/x-bigint": "^12.0.1",
                 "tslib": "^2.5.0"
             },
             "engines": {
-                "node": ">=14"
+                "node": ">=16"
             }
         },
         "node_modules/@polkadot/types-codec/node_modules/@polkadot/util": {
-            "version": "11.1.3",
-            "resolved": "https://registry.npmjs.org/@polkadot/util/-/util-11.1.3.tgz",
-            "integrity": "sha512-Gsqzv1/fSoypS5tnJkM+NJQeT7O4iYlSniubUJnaZVOKsIbueTS1bMQ1y3/h8ISxbKBtICW5cZ6zCej6Q/jC3w==",
+            "version": "12.1.2",
+            "resolved": "https://registry.npmjs.org/@polkadot/util/-/util-12.1.2.tgz",
+            "integrity": "sha512-Da8q+0WVWSuMMS3hLAwnIid8FKRGLmwhD69jikye47zeEXCtvp4e/bjD0YbINNKHoeIRsApchJtqmbaEoxXjIQ==",
             "dependencies": {
-                "@polkadot/x-bigint": "11.1.3",
-                "@polkadot/x-global": "11.1.3",
-                "@polkadot/x-textdecoder": "11.1.3",
-                "@polkadot/x-textencoder": "11.1.3",
+                "@polkadot/x-bigint": "12.1.2",
+                "@polkadot/x-global": "12.1.2",
+                "@polkadot/x-textdecoder": "12.1.2",
+                "@polkadot/x-textencoder": "12.1.2",
                 "@types/bn.js": "^5.1.1",
                 "bn.js": "^5.2.1",
                 "tslib": "^2.5.0"
             },
             "engines": {
-                "node": ">=14"
-            }
-        },
-        "node_modules/@polkadot/types-codec/node_modules/@polkadot/x-bigint": {
-            "version": "11.1.3",
-            "resolved": "https://registry.npmjs.org/@polkadot/x-bigint/-/x-bigint-11.1.3.tgz",
-            "integrity": "sha512-fRUUHfW9VFsXT7sLUUY7gSu8v+PvzNLRwvjnp+Ly8vFx9LTLuVGFCi+mpysuRTaPpqZZJlzBJ3fST7xTGh67Pg==",
-            "dependencies": {
-                "@polkadot/x-global": "11.1.3",
-                "tslib": "^2.5.0"
-            },
-            "engines": {
-                "node": ">=14"
-            }
-        },
-        "node_modules/@polkadot/types-codec/node_modules/@polkadot/x-global": {
-            "version": "11.1.3",
-            "resolved": "https://registry.npmjs.org/@polkadot/x-global/-/x-global-11.1.3.tgz",
-            "integrity": "sha512-R3aqtIjgzFHJ3TyX6wavhp+59oLbZiqczIHkaas/nJe21+SVARqFmIII6BwS7ty7+8Uu4fHliA9re+ZSUp+rwg==",
-            "dependencies": {
-                "tslib": "^2.5.0"
-            },
-            "engines": {
-                "node": ">=14"
+                "node": ">=16"
             }
         },
         "node_modules/@polkadot/types-codec/node_modules/@polkadot/x-textdecoder": {
-            "version": "11.1.3",
-            "resolved": "https://registry.npmjs.org/@polkadot/x-textdecoder/-/x-textdecoder-11.1.3.tgz",
-            "integrity": "sha512-NhOjuXVfYRMw9l0VhCtZOtcWefZth58p5KpVOrFyJZd12fTsoMO5/746K7QoAjWRrLQTJ/LHCEKCtWww0LwVPw==",
+            "version": "12.1.2",
+            "resolved": "https://registry.npmjs.org/@polkadot/x-textdecoder/-/x-textdecoder-12.1.2.tgz",
+            "integrity": "sha512-O5ygxEHdPCIQVzH7T+xVALBfCwrT5tVms7Yjp6EMT697A9gpD3U2aPr4YinsQO6JFwYpQNzvm2wjW+7EEzYitw==",
             "dependencies": {
-                "@polkadot/x-global": "11.1.3",
+                "@polkadot/x-global": "12.1.2",
                 "tslib": "^2.5.0"
             },
             "engines": {
-                "node": ">=14"
+                "node": ">=16"
             }
         },
         "node_modules/@polkadot/types-codec/node_modules/@polkadot/x-textencoder": {
-            "version": "11.1.3",
-            "resolved": "https://registry.npmjs.org/@polkadot/x-textencoder/-/x-textencoder-11.1.3.tgz",
-            "integrity": "sha512-7DmqjlPN8aQexLUKwoHeadihpUnW8hjpXEru+aEDxjgq9XIxPvb++NeBK+Mra9RzzZRuiT/K5z16HlwKN//ewg==",
+            "version": "12.1.2",
+            "resolved": "https://registry.npmjs.org/@polkadot/x-textencoder/-/x-textencoder-12.1.2.tgz",
+            "integrity": "sha512-N+9HIXT0eUQbfg/SfGrNRK8aLFpd2QngJzTxo8CljpjCvQ2ddqzBVFA8o/lKTaXVzX84EmPDzjIV+yJlOXnglA==",
             "dependencies": {
-                "@polkadot/x-global": "11.1.3",
+                "@polkadot/x-global": "12.1.2",
                 "tslib": "^2.5.0"
             },
             "engines": {
-                "node": ">=14"
+                "node": ">=16"
             }
         },
         "node_modules/@polkadot/types-create": {
-            "version": "10.3.2",
-            "resolved": "https://registry.npmjs.org/@polkadot/types-create/-/types-create-10.3.2.tgz",
-            "integrity": "sha512-y0kdN75iFtjZ8VJ8+bq2csVIb03FWHQzUohoH0VFrDOs1dAqMTWKBiBTpkEN+Dd9ZyBjsQphgJlMbIEd6Prx+w==",
+            "version": "10.4.1",
+            "resolved": "https://registry.npmjs.org/@polkadot/types-create/-/types-create-10.4.1.tgz",
+            "integrity": "sha512-E15P4ZQSAIq90Gnc+ZVK7XmEWRIF9qbCAQvJQ6nxikb6u5A9AzePAZ4XwxjJ3JXC5/t0Wxnij+pddtfxOkUi2w==",
             "dependencies": {
-                "@polkadot/types-codec": "10.3.2",
-                "@polkadot/util": "^11.1.3",
+                "@polkadot/types-codec": "10.4.1",
+                "@polkadot/util": "^12.0.1",
                 "tslib": "^2.5.0"
             },
             "engines": {
-                "node": ">=14"
+                "node": ">=16"
             }
         },
         "node_modules/@polkadot/types-create/node_modules/@polkadot/util": {
-            "version": "11.1.3",
-            "resolved": "https://registry.npmjs.org/@polkadot/util/-/util-11.1.3.tgz",
-            "integrity": "sha512-Gsqzv1/fSoypS5tnJkM+NJQeT7O4iYlSniubUJnaZVOKsIbueTS1bMQ1y3/h8ISxbKBtICW5cZ6zCej6Q/jC3w==",
+            "version": "12.1.2",
+            "resolved": "https://registry.npmjs.org/@polkadot/util/-/util-12.1.2.tgz",
+            "integrity": "sha512-Da8q+0WVWSuMMS3hLAwnIid8FKRGLmwhD69jikye47zeEXCtvp4e/bjD0YbINNKHoeIRsApchJtqmbaEoxXjIQ==",
             "dependencies": {
-                "@polkadot/x-bigint": "11.1.3",
-                "@polkadot/x-global": "11.1.3",
-                "@polkadot/x-textdecoder": "11.1.3",
-                "@polkadot/x-textencoder": "11.1.3",
+                "@polkadot/x-bigint": "12.1.2",
+                "@polkadot/x-global": "12.1.2",
+                "@polkadot/x-textdecoder": "12.1.2",
+                "@polkadot/x-textencoder": "12.1.2",
                 "@types/bn.js": "^5.1.1",
                 "bn.js": "^5.2.1",
                 "tslib": "^2.5.0"
             },
             "engines": {
-                "node": ">=14"
-            }
-        },
-        "node_modules/@polkadot/types-create/node_modules/@polkadot/x-bigint": {
-            "version": "11.1.3",
-            "resolved": "https://registry.npmjs.org/@polkadot/x-bigint/-/x-bigint-11.1.3.tgz",
-            "integrity": "sha512-fRUUHfW9VFsXT7sLUUY7gSu8v+PvzNLRwvjnp+Ly8vFx9LTLuVGFCi+mpysuRTaPpqZZJlzBJ3fST7xTGh67Pg==",
-            "dependencies": {
-                "@polkadot/x-global": "11.1.3",
-                "tslib": "^2.5.0"
-            },
-            "engines": {
-                "node": ">=14"
-            }
-        },
-        "node_modules/@polkadot/types-create/node_modules/@polkadot/x-global": {
-            "version": "11.1.3",
-            "resolved": "https://registry.npmjs.org/@polkadot/x-global/-/x-global-11.1.3.tgz",
-            "integrity": "sha512-R3aqtIjgzFHJ3TyX6wavhp+59oLbZiqczIHkaas/nJe21+SVARqFmIII6BwS7ty7+8Uu4fHliA9re+ZSUp+rwg==",
-            "dependencies": {
-                "tslib": "^2.5.0"
-            },
-            "engines": {
-                "node": ">=14"
+                "node": ">=16"
             }
         },
         "node_modules/@polkadot/types-create/node_modules/@polkadot/x-textdecoder": {
-            "version": "11.1.3",
-            "resolved": "https://registry.npmjs.org/@polkadot/x-textdecoder/-/x-textdecoder-11.1.3.tgz",
-            "integrity": "sha512-NhOjuXVfYRMw9l0VhCtZOtcWefZth58p5KpVOrFyJZd12fTsoMO5/746K7QoAjWRrLQTJ/LHCEKCtWww0LwVPw==",
+            "version": "12.1.2",
+            "resolved": "https://registry.npmjs.org/@polkadot/x-textdecoder/-/x-textdecoder-12.1.2.tgz",
+            "integrity": "sha512-O5ygxEHdPCIQVzH7T+xVALBfCwrT5tVms7Yjp6EMT697A9gpD3U2aPr4YinsQO6JFwYpQNzvm2wjW+7EEzYitw==",
             "dependencies": {
-                "@polkadot/x-global": "11.1.3",
+                "@polkadot/x-global": "12.1.2",
                 "tslib": "^2.5.0"
             },
             "engines": {
-                "node": ">=14"
+                "node": ">=16"
             }
         },
         "node_modules/@polkadot/types-create/node_modules/@polkadot/x-textencoder": {
-            "version": "11.1.3",
-            "resolved": "https://registry.npmjs.org/@polkadot/x-textencoder/-/x-textencoder-11.1.3.tgz",
-            "integrity": "sha512-7DmqjlPN8aQexLUKwoHeadihpUnW8hjpXEru+aEDxjgq9XIxPvb++NeBK+Mra9RzzZRuiT/K5z16HlwKN//ewg==",
+            "version": "12.1.2",
+            "resolved": "https://registry.npmjs.org/@polkadot/x-textencoder/-/x-textencoder-12.1.2.tgz",
+            "integrity": "sha512-N+9HIXT0eUQbfg/SfGrNRK8aLFpd2QngJzTxo8CljpjCvQ2ddqzBVFA8o/lKTaXVzX84EmPDzjIV+yJlOXnglA==",
             "dependencies": {
-                "@polkadot/x-global": "11.1.3",
+                "@polkadot/x-global": "12.1.2",
                 "tslib": "^2.5.0"
             },
             "engines": {
-                "node": ">=14"
+                "node": ">=16"
             }
         },
         "node_modules/@polkadot/types-known": {
-            "version": "10.3.2",
-            "resolved": "https://registry.npmjs.org/@polkadot/types-known/-/types-known-10.3.2.tgz",
-            "integrity": "sha512-eNiYCLbGYzjPt4maJuNubhxjebiFoyoAFxzADOXSqQS5dg93GdEa2ZvSNlffp9XYoTi0fqkV2vuDfdvb6tD3Iw==",
+            "version": "10.4.1",
+            "resolved": "https://registry.npmjs.org/@polkadot/types-known/-/types-known-10.4.1.tgz",
+            "integrity": "sha512-vgxsJeZTdbNJ55CCICRcSeOJD6Qy4D2NaMhR2j24xxHRY1lL8uBfCE/ReIEY2Bxa8cCIjCtw5fXJiCWPjnQQoQ==",
             "dependencies": {
-                "@polkadot/networks": "^11.1.3",
-                "@polkadot/types": "10.3.2",
-                "@polkadot/types-codec": "10.3.2",
-                "@polkadot/types-create": "10.3.2",
-                "@polkadot/util": "^11.1.3",
+                "@polkadot/networks": "^12.0.1",
+                "@polkadot/types": "10.4.1",
+                "@polkadot/types-codec": "10.4.1",
+                "@polkadot/types-create": "10.4.1",
+                "@polkadot/util": "^12.0.1",
                 "tslib": "^2.5.0"
             },
             "engines": {
-                "node": ">=14"
+                "node": ">=16"
             }
         },
         "node_modules/@polkadot/types-known/node_modules/@polkadot/util": {
-            "version": "11.1.3",
-            "resolved": "https://registry.npmjs.org/@polkadot/util/-/util-11.1.3.tgz",
-            "integrity": "sha512-Gsqzv1/fSoypS5tnJkM+NJQeT7O4iYlSniubUJnaZVOKsIbueTS1bMQ1y3/h8ISxbKBtICW5cZ6zCej6Q/jC3w==",
+            "version": "12.1.2",
+            "resolved": "https://registry.npmjs.org/@polkadot/util/-/util-12.1.2.tgz",
+            "integrity": "sha512-Da8q+0WVWSuMMS3hLAwnIid8FKRGLmwhD69jikye47zeEXCtvp4e/bjD0YbINNKHoeIRsApchJtqmbaEoxXjIQ==",
             "dependencies": {
-                "@polkadot/x-bigint": "11.1.3",
-                "@polkadot/x-global": "11.1.3",
-                "@polkadot/x-textdecoder": "11.1.3",
-                "@polkadot/x-textencoder": "11.1.3",
+                "@polkadot/x-bigint": "12.1.2",
+                "@polkadot/x-global": "12.1.2",
+                "@polkadot/x-textdecoder": "12.1.2",
+                "@polkadot/x-textencoder": "12.1.2",
                 "@types/bn.js": "^5.1.1",
                 "bn.js": "^5.2.1",
                 "tslib": "^2.5.0"
             },
             "engines": {
-                "node": ">=14"
-            }
-        },
-        "node_modules/@polkadot/types-known/node_modules/@polkadot/x-bigint": {
-            "version": "11.1.3",
-            "resolved": "https://registry.npmjs.org/@polkadot/x-bigint/-/x-bigint-11.1.3.tgz",
-            "integrity": "sha512-fRUUHfW9VFsXT7sLUUY7gSu8v+PvzNLRwvjnp+Ly8vFx9LTLuVGFCi+mpysuRTaPpqZZJlzBJ3fST7xTGh67Pg==",
-            "dependencies": {
-                "@polkadot/x-global": "11.1.3",
-                "tslib": "^2.5.0"
-            },
-            "engines": {
-                "node": ">=14"
-            }
-        },
-        "node_modules/@polkadot/types-known/node_modules/@polkadot/x-global": {
-            "version": "11.1.3",
-            "resolved": "https://registry.npmjs.org/@polkadot/x-global/-/x-global-11.1.3.tgz",
-            "integrity": "sha512-R3aqtIjgzFHJ3TyX6wavhp+59oLbZiqczIHkaas/nJe21+SVARqFmIII6BwS7ty7+8Uu4fHliA9re+ZSUp+rwg==",
-            "dependencies": {
-                "tslib": "^2.5.0"
-            },
-            "engines": {
-                "node": ">=14"
+                "node": ">=16"
             }
         },
         "node_modules/@polkadot/types-known/node_modules/@polkadot/x-textdecoder": {
-            "version": "11.1.3",
-            "resolved": "https://registry.npmjs.org/@polkadot/x-textdecoder/-/x-textdecoder-11.1.3.tgz",
-            "integrity": "sha512-NhOjuXVfYRMw9l0VhCtZOtcWefZth58p5KpVOrFyJZd12fTsoMO5/746K7QoAjWRrLQTJ/LHCEKCtWww0LwVPw==",
+            "version": "12.1.2",
+            "resolved": "https://registry.npmjs.org/@polkadot/x-textdecoder/-/x-textdecoder-12.1.2.tgz",
+            "integrity": "sha512-O5ygxEHdPCIQVzH7T+xVALBfCwrT5tVms7Yjp6EMT697A9gpD3U2aPr4YinsQO6JFwYpQNzvm2wjW+7EEzYitw==",
             "dependencies": {
-                "@polkadot/x-global": "11.1.3",
+                "@polkadot/x-global": "12.1.2",
                 "tslib": "^2.5.0"
             },
             "engines": {
-                "node": ">=14"
+                "node": ">=16"
             }
         },
         "node_modules/@polkadot/types-known/node_modules/@polkadot/x-textencoder": {
-            "version": "11.1.3",
-            "resolved": "https://registry.npmjs.org/@polkadot/x-textencoder/-/x-textencoder-11.1.3.tgz",
-            "integrity": "sha512-7DmqjlPN8aQexLUKwoHeadihpUnW8hjpXEru+aEDxjgq9XIxPvb++NeBK+Mra9RzzZRuiT/K5z16HlwKN//ewg==",
+            "version": "12.1.2",
+            "resolved": "https://registry.npmjs.org/@polkadot/x-textencoder/-/x-textencoder-12.1.2.tgz",
+            "integrity": "sha512-N+9HIXT0eUQbfg/SfGrNRK8aLFpd2QngJzTxo8CljpjCvQ2ddqzBVFA8o/lKTaXVzX84EmPDzjIV+yJlOXnglA==",
             "dependencies": {
-                "@polkadot/x-global": "11.1.3",
+                "@polkadot/x-global": "12.1.2",
                 "tslib": "^2.5.0"
             },
             "engines": {
-                "node": ">=14"
+                "node": ">=16"
             }
         },
         "node_modules/@polkadot/types-support": {
-            "version": "10.3.2",
-            "resolved": "https://registry.npmjs.org/@polkadot/types-support/-/types-support-10.3.2.tgz",
-            "integrity": "sha512-gqYzfj5BfmFWU/f5TaK6MovF9vb4oiOecNKDMsFlH+i3cCUpIYeUDFhYRoPRnfVf4sjLNvgS2NYbl5t5+ymQIQ==",
+            "version": "10.4.1",
+            "resolved": "https://registry.npmjs.org/@polkadot/types-support/-/types-support-10.4.1.tgz",
+            "integrity": "sha512-kt/TGVAGaGD76eM/kye8qdYxQDZtpc6GS58xYvgnsk59KkCvaOzOE+hHFDXx0UDy4pPgXKquk1EHxwiFTKSb4g==",
             "dependencies": {
-                "@polkadot/util": "^11.1.3",
+                "@polkadot/util": "^12.0.1",
                 "tslib": "^2.5.0"
             },
             "engines": {
-                "node": ">=14"
+                "node": ">=16"
             }
         },
         "node_modules/@polkadot/types-support/node_modules/@polkadot/util": {
-            "version": "11.1.3",
-            "resolved": "https://registry.npmjs.org/@polkadot/util/-/util-11.1.3.tgz",
-            "integrity": "sha512-Gsqzv1/fSoypS5tnJkM+NJQeT7O4iYlSniubUJnaZVOKsIbueTS1bMQ1y3/h8ISxbKBtICW5cZ6zCej6Q/jC3w==",
+            "version": "12.1.2",
+            "resolved": "https://registry.npmjs.org/@polkadot/util/-/util-12.1.2.tgz",
+            "integrity": "sha512-Da8q+0WVWSuMMS3hLAwnIid8FKRGLmwhD69jikye47zeEXCtvp4e/bjD0YbINNKHoeIRsApchJtqmbaEoxXjIQ==",
             "dependencies": {
-                "@polkadot/x-bigint": "11.1.3",
-                "@polkadot/x-global": "11.1.3",
-                "@polkadot/x-textdecoder": "11.1.3",
-                "@polkadot/x-textencoder": "11.1.3",
+                "@polkadot/x-bigint": "12.1.2",
+                "@polkadot/x-global": "12.1.2",
+                "@polkadot/x-textdecoder": "12.1.2",
+                "@polkadot/x-textencoder": "12.1.2",
                 "@types/bn.js": "^5.1.1",
                 "bn.js": "^5.2.1",
                 "tslib": "^2.5.0"
             },
             "engines": {
-                "node": ">=14"
-            }
-        },
-        "node_modules/@polkadot/types-support/node_modules/@polkadot/x-bigint": {
-            "version": "11.1.3",
-            "resolved": "https://registry.npmjs.org/@polkadot/x-bigint/-/x-bigint-11.1.3.tgz",
-            "integrity": "sha512-fRUUHfW9VFsXT7sLUUY7gSu8v+PvzNLRwvjnp+Ly8vFx9LTLuVGFCi+mpysuRTaPpqZZJlzBJ3fST7xTGh67Pg==",
-            "dependencies": {
-                "@polkadot/x-global": "11.1.3",
-                "tslib": "^2.5.0"
-            },
-            "engines": {
-                "node": ">=14"
-            }
-        },
-        "node_modules/@polkadot/types-support/node_modules/@polkadot/x-global": {
-            "version": "11.1.3",
-            "resolved": "https://registry.npmjs.org/@polkadot/x-global/-/x-global-11.1.3.tgz",
-            "integrity": "sha512-R3aqtIjgzFHJ3TyX6wavhp+59oLbZiqczIHkaas/nJe21+SVARqFmIII6BwS7ty7+8Uu4fHliA9re+ZSUp+rwg==",
-            "dependencies": {
-                "tslib": "^2.5.0"
-            },
-            "engines": {
-                "node": ">=14"
+                "node": ">=16"
             }
         },
         "node_modules/@polkadot/types-support/node_modules/@polkadot/x-textdecoder": {
-            "version": "11.1.3",
-            "resolved": "https://registry.npmjs.org/@polkadot/x-textdecoder/-/x-textdecoder-11.1.3.tgz",
-            "integrity": "sha512-NhOjuXVfYRMw9l0VhCtZOtcWefZth58p5KpVOrFyJZd12fTsoMO5/746K7QoAjWRrLQTJ/LHCEKCtWww0LwVPw==",
+            "version": "12.1.2",
+            "resolved": "https://registry.npmjs.org/@polkadot/x-textdecoder/-/x-textdecoder-12.1.2.tgz",
+            "integrity": "sha512-O5ygxEHdPCIQVzH7T+xVALBfCwrT5tVms7Yjp6EMT697A9gpD3U2aPr4YinsQO6JFwYpQNzvm2wjW+7EEzYitw==",
             "dependencies": {
-                "@polkadot/x-global": "11.1.3",
+                "@polkadot/x-global": "12.1.2",
                 "tslib": "^2.5.0"
             },
             "engines": {
-                "node": ">=14"
+                "node": ">=16"
             }
         },
         "node_modules/@polkadot/types-support/node_modules/@polkadot/x-textencoder": {
-            "version": "11.1.3",
-            "resolved": "https://registry.npmjs.org/@polkadot/x-textencoder/-/x-textencoder-11.1.3.tgz",
-            "integrity": "sha512-7DmqjlPN8aQexLUKwoHeadihpUnW8hjpXEru+aEDxjgq9XIxPvb++NeBK+Mra9RzzZRuiT/K5z16HlwKN//ewg==",
+            "version": "12.1.2",
+            "resolved": "https://registry.npmjs.org/@polkadot/x-textencoder/-/x-textencoder-12.1.2.tgz",
+            "integrity": "sha512-N+9HIXT0eUQbfg/SfGrNRK8aLFpd2QngJzTxo8CljpjCvQ2ddqzBVFA8o/lKTaXVzX84EmPDzjIV+yJlOXnglA==",
             "dependencies": {
-                "@polkadot/x-global": "11.1.3",
+                "@polkadot/x-global": "12.1.2",
                 "tslib": "^2.5.0"
             },
             "engines": {
-                "node": ">=14"
+                "node": ">=16"
             }
         },
         "node_modules/@polkadot/types/node_modules/@polkadot/util": {
-            "version": "11.1.3",
-            "resolved": "https://registry.npmjs.org/@polkadot/util/-/util-11.1.3.tgz",
-            "integrity": "sha512-Gsqzv1/fSoypS5tnJkM+NJQeT7O4iYlSniubUJnaZVOKsIbueTS1bMQ1y3/h8ISxbKBtICW5cZ6zCej6Q/jC3w==",
+            "version": "12.1.2",
+            "resolved": "https://registry.npmjs.org/@polkadot/util/-/util-12.1.2.tgz",
+            "integrity": "sha512-Da8q+0WVWSuMMS3hLAwnIid8FKRGLmwhD69jikye47zeEXCtvp4e/bjD0YbINNKHoeIRsApchJtqmbaEoxXjIQ==",
             "dependencies": {
-                "@polkadot/x-bigint": "11.1.3",
-                "@polkadot/x-global": "11.1.3",
-                "@polkadot/x-textdecoder": "11.1.3",
-                "@polkadot/x-textencoder": "11.1.3",
+                "@polkadot/x-bigint": "12.1.2",
+                "@polkadot/x-global": "12.1.2",
+                "@polkadot/x-textdecoder": "12.1.2",
+                "@polkadot/x-textencoder": "12.1.2",
                 "@types/bn.js": "^5.1.1",
                 "bn.js": "^5.2.1",
                 "tslib": "^2.5.0"
             },
             "engines": {
-                "node": ">=14"
-            }
-        },
-        "node_modules/@polkadot/types/node_modules/@polkadot/x-bigint": {
-            "version": "11.1.3",
-            "resolved": "https://registry.npmjs.org/@polkadot/x-bigint/-/x-bigint-11.1.3.tgz",
-            "integrity": "sha512-fRUUHfW9VFsXT7sLUUY7gSu8v+PvzNLRwvjnp+Ly8vFx9LTLuVGFCi+mpysuRTaPpqZZJlzBJ3fST7xTGh67Pg==",
-            "dependencies": {
-                "@polkadot/x-global": "11.1.3",
-                "tslib": "^2.5.0"
-            },
-            "engines": {
-                "node": ">=14"
-            }
-        },
-        "node_modules/@polkadot/types/node_modules/@polkadot/x-global": {
-            "version": "11.1.3",
-            "resolved": "https://registry.npmjs.org/@polkadot/x-global/-/x-global-11.1.3.tgz",
-            "integrity": "sha512-R3aqtIjgzFHJ3TyX6wavhp+59oLbZiqczIHkaas/nJe21+SVARqFmIII6BwS7ty7+8Uu4fHliA9re+ZSUp+rwg==",
-            "dependencies": {
-                "tslib": "^2.5.0"
-            },
-            "engines": {
-                "node": ">=14"
+                "node": ">=16"
             }
         },
         "node_modules/@polkadot/types/node_modules/@polkadot/x-textdecoder": {
-            "version": "11.1.3",
-            "resolved": "https://registry.npmjs.org/@polkadot/x-textdecoder/-/x-textdecoder-11.1.3.tgz",
-            "integrity": "sha512-NhOjuXVfYRMw9l0VhCtZOtcWefZth58p5KpVOrFyJZd12fTsoMO5/746K7QoAjWRrLQTJ/LHCEKCtWww0LwVPw==",
+            "version": "12.1.2",
+            "resolved": "https://registry.npmjs.org/@polkadot/x-textdecoder/-/x-textdecoder-12.1.2.tgz",
+            "integrity": "sha512-O5ygxEHdPCIQVzH7T+xVALBfCwrT5tVms7Yjp6EMT697A9gpD3U2aPr4YinsQO6JFwYpQNzvm2wjW+7EEzYitw==",
             "dependencies": {
-                "@polkadot/x-global": "11.1.3",
+                "@polkadot/x-global": "12.1.2",
                 "tslib": "^2.5.0"
             },
             "engines": {
-                "node": ">=14"
+                "node": ">=16"
             }
         },
         "node_modules/@polkadot/types/node_modules/@polkadot/x-textencoder": {
-            "version": "11.1.3",
-            "resolved": "https://registry.npmjs.org/@polkadot/x-textencoder/-/x-textencoder-11.1.3.tgz",
-            "integrity": "sha512-7DmqjlPN8aQexLUKwoHeadihpUnW8hjpXEru+aEDxjgq9XIxPvb++NeBK+Mra9RzzZRuiT/K5z16HlwKN//ewg==",
+            "version": "12.1.2",
+            "resolved": "https://registry.npmjs.org/@polkadot/x-textencoder/-/x-textencoder-12.1.2.tgz",
+            "integrity": "sha512-N+9HIXT0eUQbfg/SfGrNRK8aLFpd2QngJzTxo8CljpjCvQ2ddqzBVFA8o/lKTaXVzX84EmPDzjIV+yJlOXnglA==",
             "dependencies": {
-                "@polkadot/x-global": "11.1.3",
+                "@polkadot/x-global": "12.1.2",
                 "tslib": "^2.5.0"
             },
             "engines": {
-                "node": ">=14"
+                "node": ">=16"
             }
         },
         "node_modules/@polkadot/util": {
-            "version": "10.4.2",
-            "resolved": "https://registry.npmjs.org/@polkadot/util/-/util-10.4.2.tgz",
-            "integrity": "sha512-0r5MGICYiaCdWnx+7Axlpvzisy/bi1wZGXgCSw5+ZTyPTOqvsYRqM2X879yxvMsGfibxzWqNzaiVjToz1jvUaA==",
+            "version": "10.4.1",
+            "resolved": "https://registry.npmjs.org/@polkadot/util/-/util-10.4.1.tgz",
+            "integrity": "sha512-dOlmue4nhbk8msbs/YgoBqVtUzDx5iqhiDnC62GWC8b+JmIlIM4Ddgg1rhBf1KJ6TfEQrzQA0FwLaqCCH5vYmA==",
             "dependencies": {
                 "@babel/runtime": "^7.20.13",
-                "@polkadot/x-bigint": "10.4.2",
-                "@polkadot/x-global": "10.4.2",
-                "@polkadot/x-textdecoder": "10.4.2",
-                "@polkadot/x-textencoder": "10.4.2",
+                "@polkadot/x-bigint": "10.4.1",
+                "@polkadot/x-global": "10.4.1",
+                "@polkadot/x-textdecoder": "10.4.1",
+                "@polkadot/x-textencoder": "10.4.1",
                 "@types/bn.js": "^5.1.1",
                 "bn.js": "^5.2.1"
             },
@@ -3840,228 +3484,156 @@
             }
         },
         "node_modules/@polkadot/util-crypto": {
-            "version": "11.1.3",
-            "resolved": "https://registry.npmjs.org/@polkadot/util-crypto/-/util-crypto-11.1.3.tgz",
-            "integrity": "sha512-hjH1y6jXQuceJ2NWx7+ei0sR4A7t844XwlNquPxZX3kQbQS+1t6tO4Eo3/95JhPsEaJOXduus02cYEF6gteEYQ==",
+            "version": "12.1.2",
+            "resolved": "https://registry.npmjs.org/@polkadot/util-crypto/-/util-crypto-12.1.2.tgz",
+            "integrity": "sha512-xV5P7auvs2Qck+HGGk2uaJWyujbJSFc+VDlM/giqM2xKgfmkRUTgGtcBuLLLZq5R1A9tGW5DUQg0VgVHYJaNvw==",
             "dependencies": {
+                "@noble/curves": "1.0.0",
                 "@noble/hashes": "1.3.0",
-                "@noble/secp256k1": "1.7.1",
-                "@polkadot/networks": "11.1.3",
-                "@polkadot/util": "11.1.3",
-                "@polkadot/wasm-crypto": "^7.0.3",
-                "@polkadot/x-bigint": "11.1.3",
-                "@polkadot/x-randomvalues": "11.1.3",
+                "@polkadot/networks": "12.1.2",
+                "@polkadot/util": "12.1.2",
+                "@polkadot/wasm-crypto": "^7.1.2",
+                "@polkadot/wasm-util": "^7.1.2",
+                "@polkadot/x-bigint": "12.1.2",
+                "@polkadot/x-randomvalues": "12.1.2",
                 "@scure/base": "1.1.1",
-                "tslib": "^2.5.0",
-                "tweetnacl": "^1.0.3"
+                "tslib": "^2.5.0"
             },
             "engines": {
-                "node": ">=14"
+                "node": ">=16"
             },
             "peerDependencies": {
-                "@polkadot/util": "11.1.3"
+                "@polkadot/util": "12.1.2"
             }
         },
         "node_modules/@polkadot/util-crypto/node_modules/@polkadot/util": {
-            "version": "11.1.3",
-            "resolved": "https://registry.npmjs.org/@polkadot/util/-/util-11.1.3.tgz",
-            "integrity": "sha512-Gsqzv1/fSoypS5tnJkM+NJQeT7O4iYlSniubUJnaZVOKsIbueTS1bMQ1y3/h8ISxbKBtICW5cZ6zCej6Q/jC3w==",
+            "version": "12.1.2",
+            "resolved": "https://registry.npmjs.org/@polkadot/util/-/util-12.1.2.tgz",
+            "integrity": "sha512-Da8q+0WVWSuMMS3hLAwnIid8FKRGLmwhD69jikye47zeEXCtvp4e/bjD0YbINNKHoeIRsApchJtqmbaEoxXjIQ==",
             "dependencies": {
-                "@polkadot/x-bigint": "11.1.3",
-                "@polkadot/x-global": "11.1.3",
-                "@polkadot/x-textdecoder": "11.1.3",
-                "@polkadot/x-textencoder": "11.1.3",
+                "@polkadot/x-bigint": "12.1.2",
+                "@polkadot/x-global": "12.1.2",
+                "@polkadot/x-textdecoder": "12.1.2",
+                "@polkadot/x-textencoder": "12.1.2",
                 "@types/bn.js": "^5.1.1",
                 "bn.js": "^5.2.1",
                 "tslib": "^2.5.0"
             },
             "engines": {
-                "node": ">=14"
+                "node": ">=16"
             }
         },
-        "node_modules/@polkadot/util-crypto/node_modules/@polkadot/x-bigint": {
-            "version": "11.1.3",
-            "resolved": "https://registry.npmjs.org/@polkadot/x-bigint/-/x-bigint-11.1.3.tgz",
-            "integrity": "sha512-fRUUHfW9VFsXT7sLUUY7gSu8v+PvzNLRwvjnp+Ly8vFx9LTLuVGFCi+mpysuRTaPpqZZJlzBJ3fST7xTGh67Pg==",
+        "node_modules/@polkadot/util-crypto/node_modules/@polkadot/wasm-bridge": {
+            "version": "7.1.2",
+            "resolved": "https://registry.npmjs.org/@polkadot/wasm-bridge/-/wasm-bridge-7.1.2.tgz",
+            "integrity": "sha512-6t8b1el/03b30ZFKVFYU5pQEx9OeDZ3GBndgZ5b6fMNFRoowFWTwx74HLqhXlQb+hOTjGJA70jHdxkplh1sO3A==",
             "dependencies": {
-                "@polkadot/x-global": "11.1.3",
+                "@polkadot/wasm-util": "7.1.2",
                 "tslib": "^2.5.0"
             },
             "engines": {
-                "node": ">=14"
+                "node": ">=16"
+            },
+            "peerDependencies": {
+                "@polkadot/util": "*",
+                "@polkadot/x-randomvalues": "*"
             }
         },
-        "node_modules/@polkadot/util-crypto/node_modules/@polkadot/x-global": {
-            "version": "11.1.3",
-            "resolved": "https://registry.npmjs.org/@polkadot/x-global/-/x-global-11.1.3.tgz",
-            "integrity": "sha512-R3aqtIjgzFHJ3TyX6wavhp+59oLbZiqczIHkaas/nJe21+SVARqFmIII6BwS7ty7+8Uu4fHliA9re+ZSUp+rwg==",
+        "node_modules/@polkadot/util-crypto/node_modules/@polkadot/wasm-crypto": {
+            "version": "7.1.2",
+            "resolved": "https://registry.npmjs.org/@polkadot/wasm-crypto/-/wasm-crypto-7.1.2.tgz",
+            "integrity": "sha512-DO5Xf5nA2mSVdWnRM+PLAVE/wcg9vZAQkSHHSE+/qDmDVCQYygksHOA8ecRvn8nGfMNZQ0rmlIlsgyvAEtX1pw==",
             "dependencies": {
+                "@polkadot/wasm-bridge": "7.1.2",
+                "@polkadot/wasm-crypto-asmjs": "7.1.2",
+                "@polkadot/wasm-crypto-init": "7.1.2",
+                "@polkadot/wasm-crypto-wasm": "7.1.2",
+                "@polkadot/wasm-util": "7.1.2",
                 "tslib": "^2.5.0"
             },
             "engines": {
-                "node": ">=14"
+                "node": ">=16"
+            },
+            "peerDependencies": {
+                "@polkadot/util": "*",
+                "@polkadot/x-randomvalues": "*"
+            }
+        },
+        "node_modules/@polkadot/util-crypto/node_modules/@polkadot/wasm-crypto-init": {
+            "version": "7.1.2",
+            "resolved": "https://registry.npmjs.org/@polkadot/wasm-crypto-init/-/wasm-crypto-init-7.1.2.tgz",
+            "integrity": "sha512-jqeK04MYofvCU7kFMJDoKUM9SjfDEBDizIxgurxAZZvF4jMOhgStZTLTr9QkKTOMTrMUE9PWRMzrnDM/Od3kzA==",
+            "dependencies": {
+                "@polkadot/wasm-bridge": "7.1.2",
+                "@polkadot/wasm-crypto-asmjs": "7.1.2",
+                "@polkadot/wasm-crypto-wasm": "7.1.2",
+                "@polkadot/wasm-util": "7.1.2",
+                "tslib": "^2.5.0"
+            },
+            "engines": {
+                "node": ">=16"
+            },
+            "peerDependencies": {
+                "@polkadot/util": "*",
+                "@polkadot/x-randomvalues": "*"
+            }
+        },
+        "node_modules/@polkadot/util-crypto/node_modules/@polkadot/x-randomvalues": {
+            "version": "12.1.2",
+            "resolved": "https://registry.npmjs.org/@polkadot/x-randomvalues/-/x-randomvalues-12.1.2.tgz",
+            "integrity": "sha512-Jqwftgl+t8egG5miwI3f+MUNp3GIJUxZ0mcYbGDc3dY8LueY3yhKs94MQF/S6h8XPpRFI5/8mUZnmMgmNXsX6Q==",
+            "dependencies": {
+                "@polkadot/x-global": "12.1.2",
+                "tslib": "^2.5.0"
+            },
+            "engines": {
+                "node": ">=16"
+            },
+            "peerDependencies": {
+                "@polkadot/util": "12.1.2",
+                "@polkadot/wasm-util": "*"
             }
         },
         "node_modules/@polkadot/util-crypto/node_modules/@polkadot/x-textdecoder": {
-            "version": "11.1.3",
-            "resolved": "https://registry.npmjs.org/@polkadot/x-textdecoder/-/x-textdecoder-11.1.3.tgz",
-            "integrity": "sha512-NhOjuXVfYRMw9l0VhCtZOtcWefZth58p5KpVOrFyJZd12fTsoMO5/746K7QoAjWRrLQTJ/LHCEKCtWww0LwVPw==",
+            "version": "12.1.2",
+            "resolved": "https://registry.npmjs.org/@polkadot/x-textdecoder/-/x-textdecoder-12.1.2.tgz",
+            "integrity": "sha512-O5ygxEHdPCIQVzH7T+xVALBfCwrT5tVms7Yjp6EMT697A9gpD3U2aPr4YinsQO6JFwYpQNzvm2wjW+7EEzYitw==",
             "dependencies": {
-                "@polkadot/x-global": "11.1.3",
+                "@polkadot/x-global": "12.1.2",
                 "tslib": "^2.5.0"
             },
             "engines": {
-                "node": ">=14"
+                "node": ">=16"
             }
         },
         "node_modules/@polkadot/util-crypto/node_modules/@polkadot/x-textencoder": {
-            "version": "11.1.3",
-            "resolved": "https://registry.npmjs.org/@polkadot/x-textencoder/-/x-textencoder-11.1.3.tgz",
-            "integrity": "sha512-7DmqjlPN8aQexLUKwoHeadihpUnW8hjpXEru+aEDxjgq9XIxPvb++NeBK+Mra9RzzZRuiT/K5z16HlwKN//ewg==",
+            "version": "12.1.2",
+            "resolved": "https://registry.npmjs.org/@polkadot/x-textencoder/-/x-textencoder-12.1.2.tgz",
+            "integrity": "sha512-N+9HIXT0eUQbfg/SfGrNRK8aLFpd2QngJzTxo8CljpjCvQ2ddqzBVFA8o/lKTaXVzX84EmPDzjIV+yJlOXnglA==",
             "dependencies": {
-                "@polkadot/x-global": "11.1.3",
+                "@polkadot/x-global": "12.1.2",
                 "tslib": "^2.5.0"
             },
             "engines": {
-                "node": ">=14"
+                "node": ">=16"
             }
         },
-        "node_modules/@polkadot/wasm-bridge": {
-            "version": "7.0.3",
-            "resolved": "https://registry.npmjs.org/@polkadot/wasm-bridge/-/wasm-bridge-7.0.3.tgz",
-            "integrity": "sha512-q5qyhkGE9lHQmThNg6G5zCM4gYip2KtmR+De/URX7yWAO6snsinFqt066RFVuHvX1hZijrYSe/BGQABAUtH4pw==",
-            "dependencies": {
-                "tslib": "^2.5.0"
-            },
-            "engines": {
-                "node": ">=14.0.0"
-            },
-            "peerDependencies": {
-                "@polkadot/util": "*",
-                "@polkadot/x-randomvalues": "*"
-            }
-        },
-        "node_modules/@polkadot/wasm-crypto": {
-            "version": "7.0.3",
-            "resolved": "https://registry.npmjs.org/@polkadot/wasm-crypto/-/wasm-crypto-7.0.3.tgz",
-            "integrity": "sha512-mOCLCaL9cyrU72PCc9nMNAj3zdvOzau5mOGJjLahIz+mqlHAoAmEXCAJvJ2qCo7OFl8QiDToAEGhdDWQfiHUyg==",
-            "dependencies": {
-                "@polkadot/wasm-bridge": "7.0.3",
-                "@polkadot/wasm-crypto-asmjs": "7.0.3",
-                "@polkadot/wasm-crypto-init": "7.0.3",
-                "@polkadot/wasm-crypto-wasm": "7.0.3",
-                "@polkadot/wasm-util": "7.0.3",
-                "tslib": "^2.5.0"
-            },
-            "engines": {
-                "node": ">=14.0.0"
-            },
-            "peerDependencies": {
-                "@polkadot/util": "*",
-                "@polkadot/x-randomvalues": "*"
-            }
-        },
-        "node_modules/@polkadot/wasm-crypto-asmjs": {
-            "version": "7.0.3",
-            "resolved": "https://registry.npmjs.org/@polkadot/wasm-crypto-asmjs/-/wasm-crypto-asmjs-7.0.3.tgz",
-            "integrity": "sha512-ldMZjowYywn0Uj7jSr8a21rrlFFq/jWhCXVl21/KDcYGdFEfIajqbcrO5cHoT6w95sQgAwMWJwwDClXOaBjc/Q==",
-            "dependencies": {
-                "tslib": "^2.5.0"
-            },
-            "engines": {
-                "node": ">=14.0.0"
-            },
-            "peerDependencies": {
-                "@polkadot/util": "*"
-            }
-        },
-        "node_modules/@polkadot/wasm-crypto-init": {
-            "version": "7.0.3",
-            "resolved": "https://registry.npmjs.org/@polkadot/wasm-crypto-init/-/wasm-crypto-init-7.0.3.tgz",
-            "integrity": "sha512-W4ClfPrzOTqiX0x4h6rXjCt8UsVsbg3zU7LJFFjeLgrguPoKTLGw4h5O1rR2H7EuMFbuqdztzJn3qTjBcR03Cg==",
-            "dependencies": {
-                "@polkadot/wasm-bridge": "7.0.3",
-                "@polkadot/wasm-crypto-asmjs": "7.0.3",
-                "@polkadot/wasm-crypto-wasm": "7.0.3",
-                "tslib": "^2.5.0"
-            },
-            "engines": {
-                "node": ">=14.0.0"
-            },
-            "peerDependencies": {
-                "@polkadot/util": "*",
-                "@polkadot/x-randomvalues": "*"
-            }
-        },
-        "node_modules/@polkadot/wasm-crypto-wasm": {
-            "version": "7.0.3",
-            "resolved": "https://registry.npmjs.org/@polkadot/wasm-crypto-wasm/-/wasm-crypto-wasm-7.0.3.tgz",
-            "integrity": "sha512-FRjUADiA3wMkjJqQLgB0v9rbSADcb2PY/6dJi06iza9m41HebTN3x7f5D3gWTCfgJjzWLAPchY2Hwsa0WpTQkw==",
-            "dependencies": {
-                "@polkadot/wasm-util": "7.0.3",
-                "tslib": "^2.5.0"
-            },
-            "engines": {
-                "node": ">=14.0.0"
-            },
-            "peerDependencies": {
-                "@polkadot/util": "*"
-            }
-        },
-        "node_modules/@polkadot/wasm-util": {
-            "version": "7.0.3",
-            "resolved": "https://registry.npmjs.org/@polkadot/wasm-util/-/wasm-util-7.0.3.tgz",
-            "integrity": "sha512-L9U5nSbzr5xa2YSpveP/zZxhOB6i8ibssK+ihuG+7SICYtTC0B9wJp/UnjP/c6bEDlMV3yWiNXJPBTJMGmkmIQ==",
-            "dependencies": {
-                "tslib": "^2.5.0"
-            },
-            "engines": {
-                "node": ">=14.0.0"
-            },
-            "peerDependencies": {
-                "@polkadot/util": "*"
-            }
-        },
-        "node_modules/@polkadot/x-bigint": {
-            "version": "10.4.2",
-            "resolved": "https://registry.npmjs.org/@polkadot/x-bigint/-/x-bigint-10.4.2.tgz",
-            "integrity": "sha512-awRiox+/XSReLzimAU94fPldowiwnnMUkQJe8AebYhNocAj6SJU00GNoj6j6tAho6yleOwrTJXZaWFBaQVJQNg==",
+        "node_modules/@polkadot/util/node_modules/@polkadot/x-bigint": {
+            "version": "10.4.1",
+            "resolved": "https://registry.npmjs.org/@polkadot/x-bigint/-/x-bigint-10.4.1.tgz",
+            "integrity": "sha512-CpTGPwNUDrJcrnfDU/94mfZ16TZoTwWAwTLH0oMUJtrM2mHo+LtWZBlCTG+thhkcGcSRy/rrpzx4ffNsj5Sy1w==",
             "dependencies": {
                 "@babel/runtime": "^7.20.13",
-                "@polkadot/x-global": "10.4.2"
+                "@polkadot/x-global": "10.4.1"
             },
             "engines": {
                 "node": ">=14.0.0"
             }
         },
-        "node_modules/@polkadot/x-fetch": {
-            "version": "11.1.3",
-            "resolved": "https://registry.npmjs.org/@polkadot/x-fetch/-/x-fetch-11.1.3.tgz",
-            "integrity": "sha512-+Z0RxxsN7+l2ZmmDdHqOo0kgqvjXJ1bw8CwTVnq3t9nPgZKn2pC3Fq3xdj/sRWiLuf/UhgCxKfYfMmt5ek4kIg==",
-            "dependencies": {
-                "@polkadot/x-global": "11.1.3",
-                "node-fetch": "^3.3.1",
-                "tslib": "^2.5.0"
-            },
-            "engines": {
-                "node": ">=14"
-            }
-        },
-        "node_modules/@polkadot/x-fetch/node_modules/@polkadot/x-global": {
-            "version": "11.1.3",
-            "resolved": "https://registry.npmjs.org/@polkadot/x-global/-/x-global-11.1.3.tgz",
-            "integrity": "sha512-R3aqtIjgzFHJ3TyX6wavhp+59oLbZiqczIHkaas/nJe21+SVARqFmIII6BwS7ty7+8Uu4fHliA9re+ZSUp+rwg==",
-            "dependencies": {
-                "tslib": "^2.5.0"
-            },
-            "engines": {
-                "node": ">=14"
-            }
-        },
-        "node_modules/@polkadot/x-global": {
-            "version": "10.4.2",
-            "resolved": "https://registry.npmjs.org/@polkadot/x-global/-/x-global-10.4.2.tgz",
-            "integrity": "sha512-g6GXHD/ykZvHap3M6wh19dO70Zm43l4jEhlxf5LtTo5/0/UporFCXr2YJYZqfbn9JbQwl1AU+NroYio+vtJdiA==",
+        "node_modules/@polkadot/util/node_modules/@polkadot/x-global": {
+            "version": "10.4.1",
+            "resolved": "https://registry.npmjs.org/@polkadot/x-global/-/x-global-10.4.1.tgz",
+            "integrity": "sha512-Kdh2Fzl1fpEwU6vL1HMaXJy+fadX79eSy4VAnIx/uyCF3H5Z4WaxzoiNVmHdDZSVaamqtbuKepi1nkE3q1nvlA==",
             "dependencies": {
                 "@babel/runtime": "^7.20.13"
             },
@@ -4069,75 +3641,142 @@
                 "node": ">=14.0.0"
             }
         },
-        "node_modules/@polkadot/x-randomvalues": {
-            "version": "11.1.3",
-            "resolved": "https://registry.npmjs.org/@polkadot/x-randomvalues/-/x-randomvalues-11.1.3.tgz",
-            "integrity": "sha512-kZjbRgxokMR9UTodZQKs6s3C/Q2YgeizcxpDCghM/VdvQUE8OVBGNzduF7SvBvQyg2Qbg8jMcSxXOY7UgcOWSg==",
+        "node_modules/@polkadot/wasm-crypto-asmjs": {
+            "version": "7.1.2",
+            "resolved": "https://registry.npmjs.org/@polkadot/wasm-crypto-asmjs/-/wasm-crypto-asmjs-7.1.2.tgz",
+            "integrity": "sha512-Gdb824MoeWjESv7fu57Dqpvmx7FR2zhM2Os34/H8s1LcZ8m5qUxvm22kjtq+6DRJlGo7KxpS0OA4xCbSDDe0rA==",
             "dependencies": {
-                "@polkadot/x-global": "11.1.3",
                 "tslib": "^2.5.0"
             },
             "engines": {
-                "node": ">=14"
+                "node": ">=16"
+            },
+            "peerDependencies": {
+                "@polkadot/util": "*"
             }
         },
-        "node_modules/@polkadot/x-randomvalues/node_modules/@polkadot/x-global": {
-            "version": "11.1.3",
-            "resolved": "https://registry.npmjs.org/@polkadot/x-global/-/x-global-11.1.3.tgz",
-            "integrity": "sha512-R3aqtIjgzFHJ3TyX6wavhp+59oLbZiqczIHkaas/nJe21+SVARqFmIII6BwS7ty7+8Uu4fHliA9re+ZSUp+rwg==",
+        "node_modules/@polkadot/wasm-crypto-wasm": {
+            "version": "7.1.2",
+            "resolved": "https://registry.npmjs.org/@polkadot/wasm-crypto-wasm/-/wasm-crypto-wasm-7.1.2.tgz",
+            "integrity": "sha512-p2RBfXc43r6rXkFo811LboSfRQFpCgOC6+ByqMs/geTA/+/I4l2ajz95aL6cQ20AA3W5x/ZwHxhwvmJ0HBjJ6A==",
+            "dependencies": {
+                "@polkadot/wasm-util": "7.1.2",
+                "tslib": "^2.5.0"
+            },
+            "engines": {
+                "node": ">=16"
+            },
+            "peerDependencies": {
+                "@polkadot/util": "*"
+            }
+        },
+        "node_modules/@polkadot/wasm-util": {
+            "version": "7.1.2",
+            "resolved": "https://registry.npmjs.org/@polkadot/wasm-util/-/wasm-util-7.1.2.tgz",
+            "integrity": "sha512-lHQJFG0iotgmUovXYcw/HM3QhGxtze6ozAgRMd0/maTQjYwbV/7z1NzEle9fBwxX6GijTnpWc1vzW+YU0O1lLw==",
             "dependencies": {
                 "tslib": "^2.5.0"
             },
             "engines": {
-                "node": ">=14"
+                "node": ">=16"
+            },
+            "peerDependencies": {
+                "@polkadot/util": "*"
+            }
+        },
+        "node_modules/@polkadot/x-bigint": {
+            "version": "12.1.2",
+            "resolved": "https://registry.npmjs.org/@polkadot/x-bigint/-/x-bigint-12.1.2.tgz",
+            "integrity": "sha512-KU7C8HlJ2kO6Igg2Jq2Q/eAdll3HuVoylYcyVQxevcrC2fXhC2PDIEa+iWHBPz40p2TvI9sBZKrCsDDGz9K6sw==",
+            "dependencies": {
+                "@polkadot/x-global": "12.1.2",
+                "tslib": "^2.5.0"
+            },
+            "engines": {
+                "node": ">=16"
+            }
+        },
+        "node_modules/@polkadot/x-fetch": {
+            "version": "12.1.2",
+            "resolved": "https://registry.npmjs.org/@polkadot/x-fetch/-/x-fetch-12.1.2.tgz",
+            "integrity": "sha512-X+MY1UT25Xcvp6iUQOdmukOle1KsKaAblEhl+CrDfXGwM90wDLc5U3TZzddrKnQRcIgcNDyn9gRlHGQkZEbL9Q==",
+            "dependencies": {
+                "@polkadot/x-global": "12.1.2",
+                "node-fetch": "^3.3.1",
+                "tslib": "^2.5.0"
+            },
+            "engines": {
+                "node": ">=16"
+            }
+        },
+        "node_modules/@polkadot/x-global": {
+            "version": "12.1.2",
+            "resolved": "https://registry.npmjs.org/@polkadot/x-global/-/x-global-12.1.2.tgz",
+            "integrity": "sha512-WGwPQN27hpwhVOQGUizJfmNJRxkijMwECMPUAYtSSgJhkV5MwWeFuVebfUjgHceakEvDRQWzEX6JjV6TttnPZw==",
+            "dependencies": {
+                "tslib": "^2.5.0"
+            },
+            "engines": {
+                "node": ">=16"
             }
         },
         "node_modules/@polkadot/x-textdecoder": {
-            "version": "10.4.2",
-            "resolved": "https://registry.npmjs.org/@polkadot/x-textdecoder/-/x-textdecoder-10.4.2.tgz",
-            "integrity": "sha512-d3ADduOKUTU+cliz839+KCFmi23pxTlabH7qh7Vs1GZQvXOELWdqFOqakdiAjtMn68n1KVF4O14Y+OUm7gp/zA==",
+            "version": "10.4.1",
+            "resolved": "https://registry.npmjs.org/@polkadot/x-textdecoder/-/x-textdecoder-10.4.1.tgz",
+            "integrity": "sha512-OcAL0napRM4hukgvH6kYGdiczqvbkFYoLBgQFalZChktjL1tDNiF6tzzt4Nn8WQXYYFlfyxp5LoZRtNrcFJq4w==",
             "dependencies": {
                 "@babel/runtime": "^7.20.13",
-                "@polkadot/x-global": "10.4.2"
+                "@polkadot/x-global": "10.4.1"
+            },
+            "engines": {
+                "node": ">=14.0.0"
+            }
+        },
+        "node_modules/@polkadot/x-textdecoder/node_modules/@polkadot/x-global": {
+            "version": "10.4.1",
+            "resolved": "https://registry.npmjs.org/@polkadot/x-global/-/x-global-10.4.1.tgz",
+            "integrity": "sha512-Kdh2Fzl1fpEwU6vL1HMaXJy+fadX79eSy4VAnIx/uyCF3H5Z4WaxzoiNVmHdDZSVaamqtbuKepi1nkE3q1nvlA==",
+            "dependencies": {
+                "@babel/runtime": "^7.20.13"
             },
             "engines": {
                 "node": ">=14.0.0"
             }
         },
         "node_modules/@polkadot/x-textencoder": {
-            "version": "10.4.2",
-            "resolved": "https://registry.npmjs.org/@polkadot/x-textencoder/-/x-textencoder-10.4.2.tgz",
-            "integrity": "sha512-mxcQuA1exnyv74Kasl5vxBq01QwckG088lYjc3KwmND6+pPrW2OWagbxFX5VFoDLDAE+UJtnUHsjdWyOTDhpQA==",
+            "version": "10.4.1",
+            "resolved": "https://registry.npmjs.org/@polkadot/x-textencoder/-/x-textencoder-10.4.1.tgz",
+            "integrity": "sha512-YBS04HV/QgRppt0XC5n48c89ueH3ErivrcmqFTlkKMcXNzvtpMCTZGCTzG5vU8ozP0tl/4Is5N8agmYHLMu1Cg==",
             "dependencies": {
                 "@babel/runtime": "^7.20.13",
-                "@polkadot/x-global": "10.4.2"
+                "@polkadot/x-global": "10.4.1"
+            },
+            "engines": {
+                "node": ">=14.0.0"
+            }
+        },
+        "node_modules/@polkadot/x-textencoder/node_modules/@polkadot/x-global": {
+            "version": "10.4.1",
+            "resolved": "https://registry.npmjs.org/@polkadot/x-global/-/x-global-10.4.1.tgz",
+            "integrity": "sha512-Kdh2Fzl1fpEwU6vL1HMaXJy+fadX79eSy4VAnIx/uyCF3H5Z4WaxzoiNVmHdDZSVaamqtbuKepi1nkE3q1nvlA==",
+            "dependencies": {
+                "@babel/runtime": "^7.20.13"
             },
             "engines": {
                 "node": ">=14.0.0"
             }
         },
         "node_modules/@polkadot/x-ws": {
-            "version": "11.1.3",
-            "resolved": "https://registry.npmjs.org/@polkadot/x-ws/-/x-ws-11.1.3.tgz",
-            "integrity": "sha512-omNU2mIVX997HiHm2YxEdJdyCFnv+oTyKWZd0+FdS47rdfhVwD+H9/bS+rtQ9lIqfhODdGmw3fG//gq1KpYJcw==",
+            "version": "12.1.2",
+            "resolved": "https://registry.npmjs.org/@polkadot/x-ws/-/x-ws-12.1.2.tgz",
+            "integrity": "sha512-xmwBtn0WIstrviNuLNladsVHXUWeh4/HHAuCCeTp5Rld+8pJ6D1snhl+qvicmm4t1Si9mpb6y4yfnWFm5fLHVA==",
             "dependencies": {
-                "@polkadot/x-global": "11.1.3",
+                "@polkadot/x-global": "12.1.2",
                 "tslib": "^2.5.0",
                 "ws": "^8.13.0"
             },
             "engines": {
-                "node": ">=14"
-            }
-        },
-        "node_modules/@polkadot/x-ws/node_modules/@polkadot/x-global": {
-            "version": "11.1.3",
-            "resolved": "https://registry.npmjs.org/@polkadot/x-global/-/x-global-11.1.3.tgz",
-            "integrity": "sha512-R3aqtIjgzFHJ3TyX6wavhp+59oLbZiqczIHkaas/nJe21+SVARqFmIII6BwS7ty7+8Uu4fHliA9re+ZSUp+rwg==",
-            "dependencies": {
-                "tslib": "^2.5.0"
-            },
-            "engines": {
-                "node": ">=14"
+                "node": ">=16"
             }
         },
         "node_modules/@protobufjs/aspromise": {
@@ -4410,14 +4049,14 @@
             }
         },
         "node_modules/@substrate/connect": {
-            "version": "0.7.23",
-            "resolved": "https://registry.npmjs.org/@substrate/connect/-/connect-0.7.23.tgz",
-            "integrity": "sha512-zlfI76HdUJszQWG7Dpwd0g7jjQv6LNZtE6Kd7OWv4OdpHJa1VpL2jGjg7YdLhwtx7qxqOuRiak1H+5KrsavzRQ==",
+            "version": "0.7.24",
+            "resolved": "https://registry.npmjs.org/@substrate/connect/-/connect-0.7.24.tgz",
+            "integrity": "sha512-vF82taiM0yME+ibiJgEv0xn/NZd9TQ4atXk1AQCe2z82SEKzw0Lwx9ZLFEOvlgnh+Nc2EtQi7y4cXJ+48rOqxw==",
             "optional": true,
             "dependencies": {
                 "@substrate/connect-extension-protocol": "^1.0.1",
                 "eventemitter3": "^4.0.7",
-                "smoldot": "1.0.1"
+                "smoldot": "1.0.2"
             }
         },
         "node_modules/@substrate/connect-extension-protocol": {
@@ -4433,9 +4072,9 @@
             "optional": true
         },
         "node_modules/@substrate/ss58-registry": {
-            "version": "1.39.0",
-            "resolved": "https://registry.npmjs.org/@substrate/ss58-registry/-/ss58-registry-1.39.0.tgz",
-            "integrity": "sha512-qZYpuE6n+mwew+X71dOur/CbMXj6rNW27o63JeJwdQH/GvcSKm3JLNhd+bGzwUKg0D/zD30Qc6p4JykArzM+tA=="
+            "version": "1.40.0",
+            "resolved": "https://registry.npmjs.org/@substrate/ss58-registry/-/ss58-registry-1.40.0.tgz",
+            "integrity": "sha512-QuU2nBql3J4KCnOWtWDw4n1K4JU0T79j54ZZvm/9nhsX6AIar13FyhsaBfs6QkJ2ixTQAnd7TocJIoJRWbqMZA=="
         },
         "node_modules/@szmarczak/http-timer": {
             "version": "5.0.1",
@@ -10797,9 +10436,9 @@
             }
         },
         "node_modules/nock": {
-            "version": "13.3.0",
-            "resolved": "https://registry.npmjs.org/nock/-/nock-13.3.0.tgz",
-            "integrity": "sha512-HHqYQ6mBeiMc+N038w8LkMpDCRquCHWeNmN3v6645P3NhN2+qXOBqvPqo7Rt1VyCMzKhJ733wZqw5B7cQVFNPg==",
+            "version": "13.3.1",
+            "resolved": "https://registry.npmjs.org/nock/-/nock-13.3.1.tgz",
+            "integrity": "sha512-vHnopocZuI93p2ccivFyGuUfzjq2fxNyNurp7816mlT5V5HF4SzXu8lvLrVzBbNqzs+ODooZ6OksuSUNM7Njkw==",
             "dependencies": {
                 "debug": "^4.1.0",
                 "json-stringify-safe": "^5.0.1",
@@ -12405,9 +12044,9 @@
             }
         },
         "node_modules/smoldot": {
-            "version": "1.0.1",
-            "resolved": "https://registry.npmjs.org/smoldot/-/smoldot-1.0.1.tgz",
-            "integrity": "sha512-48M9tLU+5q0XHFUCuGULraghfqQU/yARkdcYZzulFB38f2aw4ujTHzlbE+bhiJ8+h63uoXdAQO0WeCsWDTXGkA==",
+            "version": "1.0.2",
+            "resolved": "https://registry.npmjs.org/smoldot/-/smoldot-1.0.2.tgz",
+            "integrity": "sha512-IHhMzvXwyl6I5GA4JvfzM2OOp9wBO06AmjqT4nCoNms5PiLe74f/A+jIZIJKyY6eBhMpmECizyfeTneHO2wMFQ==",
             "optional": true,
             "dependencies": {
                 "pako": "^2.0.4",
@@ -12933,11 +12572,6 @@
             "engines": {
                 "node": "*"
             }
-        },
-        "node_modules/tweetnacl": {
-            "version": "1.0.3",
-            "resolved": "https://registry.npmjs.org/tweetnacl/-/tweetnacl-1.0.3.tgz",
-            "integrity": "sha512-6rt+RN7aOi1nGMyC4Xa5DdYiukl2UWCbcJft7YhxReBGQD7OAM8Pbxw6YMo4r2diNEA8FEmu32YOn9rhaiE5yw=="
         },
         "node_modules/type-check": {
             "version": "0.4.0",

--- a/integration-tests/package.json
+++ b/integration-tests/package.json
@@ -16,15 +16,15 @@
     "license": "Apache-2.0",
     "dependencies": {
         "@frequency-chain/api-augment": "file:../js/api-augment/dist/frequency-chain-api-augment-0.0.0.tgz",
-        "@polkadot/api": "10.3.2",
-        "@polkadot/types": "10.3.2",
-        "@polkadot/util": "10.4.2",
+        "@polkadot/api": "10.4.1",
+        "@polkadot/types": "10.4.1",
+        "@polkadot/util": "10.4.1",
         "ipfs": "^0.66.0",
         "multiformats": "^11.0.1",
         "rxjs": "^7.8.0"
     },
     "devDependencies": {
-        "@polkadot/typegen": "10.3.2",
+        "@polkadot/typegen": "10.4.1",
         "@types/mocha": "^10.0.0",
         "@typescript-eslint/eslint-plugin": "^5.48.1",
         "@typescript-eslint/parser": "^5.48.1",

--- a/js/api-augment/package-lock.json
+++ b/js/api-augment/package-lock.json
@@ -9,12 +9,12 @@
       "version": "0.0.0",
       "license": "Apache-2.0",
       "dependencies": {
-        "@polkadot/api": "^10.4.1",
-        "@polkadot/rpc-provider": "^10.4.1",
-        "@polkadot/types": "^10.4.1"
+        "@polkadot/api": "10.4.1",
+        "@polkadot/rpc-provider": "10.4.1",
+        "@polkadot/types": "10.4.1"
       },
       "devDependencies": {
-        "@polkadot/typegen": "^10.4.1",
+        "@polkadot/typegen": "10.4.1",
         "@types/mocha": "^10.0.1",
         "@typescript-eslint/eslint-plugin": "^5.59.1",
         "@typescript-eslint/parser": "^5.59.1",

--- a/js/api-augment/package.json
+++ b/js/api-augment/package.json
@@ -33,12 +33,12 @@
   "author": "LibertyDSNP",
   "license": "Apache-2.0",
   "dependencies": {
-    "@polkadot/api": "^10.4.1",
-    "@polkadot/rpc-provider": "^10.4.1",
-    "@polkadot/types": "^10.4.1"
+    "@polkadot/api": "10.4.1",
+    "@polkadot/rpc-provider": "10.4.1",
+    "@polkadot/types": "10.4.1"
   },
   "devDependencies": {
-    "@polkadot/typegen": "^10.4.1",
+    "@polkadot/typegen": "10.4.1",
     "@types/mocha": "^10.0.1",
     "@typescript-eslint/eslint-plugin": "^5.59.1",
     "@typescript-eslint/parser": "^5.59.1",


### PR DESCRIPTION
# Goal
The goal of this PR is to pin the version of polkadot js as latest builds break and needs a careful update.

Pining to last stable version 10.4.1 https://github.com/polkadot-js/api/releases/tag/v10.4.1

Creates #1461 

# Checklist
- [ ] Chain spec updated
- [ ] Custom RPC OR Runtime API added/changed? Updated js/api-augment.
- [ ] Design doc(s) updated
- [ ] Tests added
- [ ] Benchmarks added
- [ ] Weights updated
