### PR TITLE
Build new binary and use it for integration tests

### DIFF
--- a/.github/workflows/verify-pr-commit.yml
+++ b/.github/workflows/verify-pr-commit.yml
@@ -20,6 +20,11 @@ jobs:
       cargo-lock: ${{steps.filter.outputs.cargo-lock}}
       run-integration-tests: ${{steps.filter.outputs.run-integration-tests}}
     steps:
+      - name: Install Required Packages
+        run: |
+          apt-get update
+          apt-get install -y git
+          git config --global --add safe.directory /__w/frequency/frequency
       - name: Check Out Repo
         uses: actions/checkout@v3
       - name: Check for Changed Files
@@ -66,6 +71,10 @@ jobs:
             spec: frequency-rococo-local
             branch_alias: pr
             network: local
+          - git_branch: ${{github.head_ref}}
+            spec: frequency-no-relay
+            branch_alias: pr
+            network: local
           - git_branch: main
             spec: frequency-rococo-local
             branch_alias: main
@@ -90,6 +99,10 @@ jobs:
         include:
           - git_branch: ${{github.head_ref}}
             spec: frequency-rococo-local
+            branch_alias: pr
+            network: local
+          - git_branch: ${{github.head_ref}}
+            spec: frequency-no-relay
             branch_alias: pr
             network: local
           - git_branch: main
@@ -118,7 +131,7 @@ jobs:
       - name: Set Env Vars
         run: |
           export BUILT_BIN_FILENAME=frequency; echo "BUILT_BIN_FILENAME=$BUILT_BIN_FILENAME" >> $GITHUB_ENV
-          echo "FINAL_BIN_FILENAME=$BUILT_BIN_FILENAME.${{matrix.network}}-${{matrix.branch_alias}}" >> $GITHUB_ENV
+          echo "FINAL_BIN_FILENAME=$BUILT_BIN_FILENAME.${{matrix.network}}.${{matrix.spec}}.${{matrix.branch_alias}}" >> $GITHUB_ENV
       # # XXX Keep this step as it lets us skip full binary builds during development/testing
       # - name: Cache Binary for Testing
       #   id: cache-binary
@@ -406,7 +419,7 @@ jobs:
         uses: actions/checkout@v3
       - name: Set Env Vars
         run: |
-          echo "BIN_FILENAME=frequency.local-pr" >> $GITHUB_ENV
+          echo "BIN_FILENAME=frequency.local.frequency-rococo-local.pr" >> $GITHUB_ENV
       - name: Set up NodeJs
         uses: actions/setup-node@v3
         with:
@@ -465,7 +478,7 @@ jobs:
         uses: actions/checkout@v3
       - name: Set Env Vars
         run: |
-          echo "BUILT_BIN_FILENAME=frequency.mainnet-pr" >> $GITHUB_ENV
+          echo "BUILT_BIN_FILENAME=frequency.mainnet.frequency.pr" >> $GITHUB_ENV
           echo "DOCKER_BIN_FILENAME=frequency" >> $GITHUB_ENV
       - name: Download Binaries
         uses: actions/download-artifact@v3
@@ -516,12 +529,7 @@ jobs:
         uses: actions/checkout@v3
       - name: Set Env Vars
         run: |
-          echo "TEST_BIN_FILENAME=frequency.mainnet-pr" >> $GITHUB_ENV
-      # # XXX Do I need to install toolchain?
-      # - name: Install Rust Toolchain
-      #   uses: dtolnay/rust-toolchain@e12eda571dc9a5ee5d58eecf4738ec291c66f295
-      #   with:
-      #     toolchain: stable
+          echo "TEST_BIN_FILENAME=frequency.mainnet.frequency.pr" >> $GITHUB_ENV
       - name: Download Binaries
         uses: actions/download-artifact@v3
         with:
@@ -554,8 +562,8 @@ jobs:
           fetch-depth: 0
       - name: Set Env Vars
         run: |
-          echo "TEST_BIN_FILENAME=frequency.local-pr" >> $GITHUB_ENV
-          echo "REF_BIN_FILENAME=frequency.local-main" >> $GITHUB_ENV
+          echo "TEST_BIN_FILENAME=frequency.local.frequency-rococo-local.pr" >> $GITHUB_ENV
+          echo "REF_BIN_FILENAME=frequency.local.frequency-rococo-local.main" >> $GITHUB_ENV
       - name: Download Binaries
         uses: actions/download-artifact@v3
         with:
@@ -613,7 +621,7 @@ jobs:
           fetch-depth: 0
       - name: Set Env Vars
         run: |
-          echo "BIN_FILENAME=frequency.local-pr" >> $GITHUB_ENV
+          echo "BIN_FILENAME=frequency.local.frequency-no-relay.pr" >> $GITHUB_ENV
           echo "FREQUENCY_PROCESS_NAME=frequency" >> $GITHUB_ENV
       - name: Download Binaries
         uses: actions/download-artifact@v3
@@ -634,7 +642,7 @@ jobs:
         run: |
           ./${{env.BIN_FILENAME}} \
             -lruntime=debug \
-            --chain=frequency-rococo-local \
+            --dev \
             --instant-sealing \
             --wasm-execution=compiled \
             --execution=wasm \
@@ -679,8 +687,8 @@ jobs:
         run: |
           echo "EXPECTED_GENESIS_STATE_ROCOCO=0x000000000000000000000000000000000000000000000000000000000000000000e3495742b019f5ad49dff7de4040bc965b75eaf46769c24db1027d4ff86fc92703170a2e7597b7b7e3d84c05391d139a62b157e78786d8c082f29dcf4c11131400" >> $GITHUB_ENV
           echo "EXPECTED_GENESIS_STATE_MAINNET=0x000000000000000000000000000000000000000000000000000000000000000000393a2a0f7778716d006206c5a4787cbf2ea3b26a67379b7a38ee54519d7fd4be03170a2e7597b7b7e3d84c05391d139a62b157e78786d8c082f29dcf4c11131400" >> $GITHUB_ENV
-          echo "BIN_FILENAME_ROCOCO=frequency.rococo-pr" >> $GITHUB_ENV
-          echo "BIN_FILENAME_MAINNET=frequency.mainnet-pr" >> $GITHUB_ENV
+          echo "BIN_FILENAME_ROCOCO=frequency.rococo.frequency-rococo-testnet.pr" >> $GITHUB_ENV
+          echo "BIN_FILENAME_MAINNET=frequency.mainnet.frequency.pr" >> $GITHUB_ENV
       - name: Download Binaries
         uses: actions/download-artifact@v3
         with:


### PR DESCRIPTION
# Goal
The goal of this PR is build a new local binary from PR branch with `frequency-no-relay` spec name and use that binary for running integration tests.

Closes #1474