### PR TITLE
Integration tests on Rococo

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -239,6 +239,9 @@ integration-test-load:
 integration-test-load-only:
 	./scripts/run_integration_tests.sh -s load
 
+integration-test-rococo:
+	./scripts/run_integration_tests.sh -r
+
 .PHONY: try-runtime
 try-runtime:
 	cargo run --release --features frequency-lint-check,try-runtime try-runtime --help

--- a/Makefile
+++ b/Makefile
@@ -240,10 +240,10 @@ integration-test-load-only:
 	./scripts/run_integration_tests.sh -s load
 
 integration-test-rococo:
-	./scripts/run_integration_tests.sh -r
+	./scripts/run_integration_tests.sh -c frequency_rococo
 
 integration-test-local-relay:
-	./scripts/run_integration_tests.sh -l
+	./scripts/run_integration_tests.sh -c local_relay
 
 .PHONY: try-runtime
 try-runtime:

--- a/Makefile
+++ b/Makefile
@@ -242,6 +242,9 @@ integration-test-load-only:
 integration-test-rococo:
 	./scripts/run_integration_tests.sh -r
 
+integration-test-local-relay:
+	./scripts/run_integration_tests.sh -l
+
 .PHONY: try-runtime
 try-runtime:
 	cargo run --release --features frequency-lint-check,try-runtime try-runtime --help

--- a/integration-tests/.mocharc.json
+++ b/integration-tests/.mocharc.json
@@ -4,6 +4,6 @@
     "parallel": false,
     "require": ["scaffolding/rootHooks.ts", "scaffolding/extrinsicHelpers.ts"],
     "loader": "ts-node/esm",
-    "spec": ["./{,!(node_modules|load-tests)/**}/*.test.ts"],
+    "spec": ["./{,!(node_modules|load-tests)/**}/createMsa.test.ts"],
     "timeout": 2000
 }

--- a/integration-tests/.mocharc.json
+++ b/integration-tests/.mocharc.json
@@ -4,6 +4,6 @@
     "parallel": false,
     "require": ["scaffolding/rootHooks.ts", "scaffolding/extrinsicHelpers.ts"],
     "loader": "ts-node/esm",
-    "spec": ["./{,!(node_modules|load-tests)/**}/createMsa.test.ts"],
+    "spec": ["./{,!(node_modules|load-tests)/**}/*.test.ts"],
     "timeout": 2000
 }

--- a/integration-tests/.relay-chain.mocharc.json
+++ b/integration-tests/.relay-chain.mocharc.json
@@ -1,0 +1,16 @@
+{
+    "exit": true,
+    "extension": [
+        "ts"
+    ],
+    "parallel": false,
+    "require": [
+        "scaffolding/rootHooks.ts",
+        "scaffolding/extrinsicHelpers.ts"
+    ],
+    "loader": "ts-node/esm",
+    "spec": [
+        "./{,!(node_modules|load-tests)/**}/createMsa.test.ts"
+    ],
+    "timeout": 200000
+}

--- a/integration-tests/package.json
+++ b/integration-tests/package.json
@@ -7,6 +7,7 @@
         "build": "tsc -p ./tsconfig.json",
         "test": "mocha",
         "test:load": "mocha --config .load-test.mocharc.js",
+        "test:relay": "mocha --config .relay-chain.mocharc.json",
         "format": "tsc --noEmit --pretty",
         "lint": "tsc --noEmit --pretty",
         "preinstall": "echo \"NOTICE: Integration tests REQUIRE ../js/api-augment to have been built and packaged\""

--- a/integration-tests/scaffolding/extrinsicHelpers.ts
+++ b/integration-tests/scaffolding/extrinsicHelpers.ts
@@ -5,7 +5,7 @@ import { Compact, u128, u16, u32, u64, Vec, Option, Bytes } from "@polkadot/type
 import { FrameSystemAccountInfo, SpRuntimeDispatchError } from "@polkadot/types/lookup";
 import { AnyNumber, AnyTuple, Codec, IEvent, ISubmittableResult } from "@polkadot/types/types";
 import {firstValueFrom, filter, map, pipe, tap} from "rxjs";
-import {devAccounts, getBlockNumber, log, Sr25519Signature} from "./helpers";
+import {devAccounts, getBlockNumber, log, rococoAccounts, Sr25519Signature} from "./helpers";
 import { connect, connectPromise } from "./apiConnection";
 import { CreatedBlock, DispatchError, Event, SignedBlock } from "@polkadot/types/interfaces";
 import { IsEvent } from "@polkadot/types/metadata/decorate/types";
@@ -139,8 +139,15 @@ export class Extrinsic<T extends ISubmittableResult = ISubmittableResult, C exte
     }
 
     public async fundOperation(source?: KeyringPair, nonce?: number): Promise<void> {
+        let default_source;
+        if (process.env.CHAIN_ENVIRONMENT == "rococo") {
+            default_source = rococoAccounts[0];
+        } else {
+            default_source = devAccounts[0];
+        }
+
         const amount = await this.getEstimatedTxFee();
-        await ExtrinsicHelper.transferFunds(source || devAccounts[0].keys, this.keys, amount).signAndSend(nonce);
+        await ExtrinsicHelper.transferFunds(source || default_source.keys, this.keys, amount).signAndSend(nonce);
     }
 
     public async fundAndSend(source?: KeyringPair, nonce?: number): Promise<ParsedEventResult> {

--- a/integration-tests/scaffolding/extrinsicHelpers.ts
+++ b/integration-tests/scaffolding/extrinsicHelpers.ts
@@ -5,7 +5,7 @@ import { Compact, u128, u16, u32, u64, Vec, Option, Bytes } from "@polkadot/type
 import { FrameSystemAccountInfo, SpRuntimeDispatchError } from "@polkadot/types/lookup";
 import { AnyNumber, AnyTuple, Codec, IEvent, ISubmittableResult } from "@polkadot/types/types";
 import {firstValueFrom, filter, map, pipe, tap} from "rxjs";
-import {devAccounts, getBlockNumber, log, rococoAccounts, Sr25519Signature} from "./helpers";
+import { devAccounts, getBlockNumber, log, getDefaultFundingSource, Sr25519Signature} from "./helpers";
 import { connect, connectPromise } from "./apiConnection";
 import { CreatedBlock, DispatchError, Event, SignedBlock } from "@polkadot/types/interfaces";
 import { IsEvent } from "@polkadot/types/metadata/decorate/types";
@@ -139,15 +139,10 @@ export class Extrinsic<T extends ISubmittableResult = ISubmittableResult, C exte
     }
 
     public async fundOperation(source?: KeyringPair, nonce?: number): Promise<void> {
-        let default_source;
-        if (process.env.CHAIN_ENVIRONMENT == "rococo") {
-            default_source = rococoAccounts[0];
-        } else {
-            default_source = devAccounts[0];
-        }
+        let default_funding_source = getDefaultFundingSource();
 
         const amount = await this.getEstimatedTxFee();
-        await ExtrinsicHelper.transferFunds(source || default_source.keys, this.keys, amount).signAndSend(nonce);
+        await ExtrinsicHelper.transferFunds(source || default_funding_source.keys, this.keys, amount).signAndSend(nonce);
     }
 
     public async fundAndSend(source?: KeyringPair, nonce?: number): Promise<ParsedEventResult> {

--- a/integration-tests/scaffolding/helpers.ts
+++ b/integration-tests/scaffolding/helpers.ts
@@ -53,7 +53,7 @@ export async function getBlockNumber(): Promise<number> {
   return (await ExtrinsicHelper.getLastBlock()).block.header.number.toNumber()
 }
 
-export async function generateAddKeyPayload(payloadInputs: AddKeyData, expirationOffset: number = 5, blockNumber?: number): Promise<AddKeyData> {
+export async function generateAddKeyPayload(payloadInputs: AddKeyData, expirationOffset: number = 100, blockNumber?: number): Promise<AddKeyData> {
   let { expiration, ...payload } = payloadInputs;
   if (!expiration) {
     expiration = (blockNumber || (await getBlockNumber())) + expirationOffset;

--- a/integration-tests/scaffolding/helpers.ts
+++ b/integration-tests/scaffolding/helpers.ts
@@ -111,21 +111,20 @@ export function createKeys(name: string = 'first pair'): KeyringPair {
   return keypair;
 }
 
+export function getDefaultFundingSource() {
+  return process.env.CHAIN_ENVIRONMENT === "rococo" ? rococoAccounts[0] : devAccounts[0];
+}
+
 export async function fundKeypair(source: KeyringPair, dest: KeyringPair, amount: bigint, nonce?: number): Promise<void> {
   await ExtrinsicHelper.transferFunds(source, dest, amount).signAndSend(nonce);
 }
 
 export async function createAndFundKeypair(amount = EXISTENTIAL_DEPOSIT, keyName?: string, source?: KeyringPair, nonce?: number): Promise<KeyringPair> {
-  let default_source;
-  if (process.env.CHAIN_ENVIRONMENT == "rococo") {
-    default_source = rococoAccounts[0];
-  } else {
-    default_source = devAccounts[0];
-  }
+  const default_funding_source = getDefaultFundingSource();
   const keypair = createKeys(keyName);
 
   // Transfer funds from source (usually pre-funded dev account) to new account
-  await fundKeypair((source || default_source.keys), keypair, amount, nonce);
+  await fundKeypair((source || default_funding_source.keys), keypair, amount, nonce);
 
   return keypair;
 }

--- a/integration-tests/scaffolding/helpers.ts
+++ b/integration-tests/scaffolding/helpers.ts
@@ -18,12 +18,13 @@ import assert from "assert";
 import { firstValueFrom } from "rxjs";
 import { AVRO_GRAPH_CHANGE } from "../schemas/fixtures/avroGraphChangeSchemaType";
 
-export interface DevAccount {
+export interface Account {
   uri: string,
   keys: KeyringPair,
 }
 
-export let devAccounts: DevAccount[] = [];
+export let devAccounts: Account[] = [];
+export let rococoAccounts: Account[] = [];
 
 export type Sr25519Signature = { Sr25519: `0x${string}` }
 
@@ -114,11 +115,17 @@ export async function fundKeypair(source: KeyringPair, dest: KeyringPair, amount
   await ExtrinsicHelper.transferFunds(source, dest, amount).signAndSend(nonce);
 }
 
-export async function createAndFundKeypair(amount = EXISTENTIAL_DEPOSIT, keyName?: string, devAccount?: KeyringPair, nonce?: number): Promise<KeyringPair> {
+export async function createAndFundKeypair(amount = EXISTENTIAL_DEPOSIT, keyName?: string, source?: KeyringPair, nonce?: number): Promise<KeyringPair> {
+  let default_source;
+  if (process.env.CHAIN_ENVIRONMENT == "rococo") {
+    default_source = rococoAccounts[0];
+  } else {
+    default_source = devAccounts[0];
+  }
   const keypair = createKeys(keyName);
 
   // Transfer funds from source (usually pre-funded dev account) to new account
-  await fundKeypair((devAccount || devAccounts[0].keys), keypair, amount, nonce);
+  await fundKeypair((source || default_source.keys), keypair, amount, nonce);
 
   return keypair;
 }

--- a/integration-tests/scaffolding/rootHooks.ts
+++ b/integration-tests/scaffolding/rootHooks.ts
@@ -1,18 +1,28 @@
 import { ExtrinsicHelper } from "./extrinsicHelpers";
 import { createKeys } from "./apiConnection";
-import { devAccounts } from "./helpers";
+import { devAccounts, rococoAccounts } from "./helpers";
 
 export let EXISTENTIAL_DEPOSIT: bigint;
 
 exports.mochaHooks = {
     async beforeAll() {
         await ExtrinsicHelper.initialize();
-        for (const uri of ["//Alice", "//Bob", "//Charlie", "//Dave", "//Eve", "//Ferdie"]) {
-            devAccounts.push({
-                uri,
-                keys: createKeys(uri),
-            });
+        let default_source;
+        if (process.env.CHAIN_ENVIRONMENT == "rococo") {
+            const seed_phrase = "Place holder for seed phrase";
+            rococoAccounts.push({
+                uri: "RococoTestRunnerAccount",
+                keys: createKeys(seed_phrase),
+        });
+        } else {
+            for (const uri of ["//Alice", "//Bob", "//Charlie", "//Dave", "//Eve", "//Ferdie"]) {
+                devAccounts.push({
+                    uri,
+                    keys: createKeys(uri),
+                });
+            }
         }
+
 
         EXISTENTIAL_DEPOSIT = ExtrinsicHelper.api.consts.balances.existentialDeposit.toBigInt();
     },

--- a/integration-tests/scaffolding/rootHooks.ts
+++ b/integration-tests/scaffolding/rootHooks.ts
@@ -7,7 +7,7 @@ export let EXISTENTIAL_DEPOSIT: bigint;
 exports.mochaHooks = {
     async beforeAll() {
         await ExtrinsicHelper.initialize();
-        let default_source;
+
         if (process.env.CHAIN_ENVIRONMENT == "rococo") {
             const seed_phrase = "Place holder for seed phrase";
             rococoAccounts.push({

--- a/scripts/run_integration_tests.sh
+++ b/scripts/run_integration_tests.sh
@@ -30,49 +30,50 @@ function cleanup () {
 
 RUNDIR=$(dirname ${0})
 SKIP_JS_BUILD=
-TEST_AGAINST_FREQUENCY_ROCOCO=0
-TEST_AGAINST_LOCAL_RELAY=0
+CHAIN="local_instant_sealing"
 
 trap 'cleanup EXIT' EXIT
 trap 'cleanup TERM' TERM
 trap 'cleanup INT' INT
 
-while getopts "srl" OPTNAME
+while getopts "sc:" OPTNAME
 do
     case "${OPTNAME}" in
         "s")
             SKIP_JS_BUILD=1
         ;;
-        "r")
-            TEST_AGAINST_FREQUENCY_ROCOCO=1
-        ;;
-        "l")
-            TEST_AGAINST_LOCAL_RELAY=1
+        "c")
+            CHAIN=$OPTARG
         ;;
     esac
 done
 shift $((OPTIND-1))
 
-NPM_RUN_COMMAND="test"
-BLOCK_SEALING="instant"
+case "${CHAIN}" in
+    "local_instant_sealing")
+        PROVIDER_URL="ws://127.0.0.1:9944"
+        CHAIN_ENVIRONMENT="local"
+        BLOCK_SEALING="instant"
+        NPM_RUN_COMMAND="test"
 
-if [ $TEST_AGAINST_FREQUENCY_ROCOCO == 1 ]; then
-    PROVIDER_URL="wss://rpc.rococo.frequency.xyz"
-    NPM_RUN_COMMAND="test:relay"
-    CHAIN_ENVIRONMENT="rococo"
-elif [ $TEST_AGAINST_LOCAL_RELAY == 1 ]; then
-    PROVIDER_URL="ws://127.0.0.1:9944"
-    NPM_RUN_COMMAND="test:relay"
-    CHAIN_ENVIRONMENT="local"
-else
-    PROVIDER_URL="ws://127.0.0.1:9944"
-    CHAIN_ENVIRONMENT="local"
-
-    if [[ "$1" == "load" ]]; then
-        NPM_RUN_COMMAND="test:load"
-        BLOCK_SEALING="manual"
-    fi
-fi
+        if [[ "$1" == "load" ]]; then
+            NPM_RUN_COMMAND="test:load"
+            BLOCK_SEALING="manual"
+        fi
+    ;;
+    "local_relay")
+        PROVIDER_URL="ws://127.0.0.1:9944"
+        NPM_RUN_COMMAND="test:relay"
+        CHAIN_ENVIRONMENT="local"
+        BLOCK_SEALING="instant"
+    ;;
+    "frequency_rococo")
+        PROVIDER_URL="wss://rpc.rococo.frequency.xyz"
+        NPM_RUN_COMMAND="test:relay"
+        CHAIN_ENVIRONMENT="rococo"
+        BLOCK_SEALING="instant"
+    ;;
+esac
 
 echo "The integration test output will be logged on this console"
 

--- a/scripts/run_integration_tests.sh
+++ b/scripts/run_integration_tests.sh
@@ -31,12 +31,13 @@ function cleanup () {
 RUNDIR=$(dirname ${0})
 SKIP_JS_BUILD=
 TEST_AGAINST_FREQUENCY_ROCOCO=0
+TEST_AGAINST_LOCAL_RELAY=0
 
 trap 'cleanup EXIT' EXIT
 trap 'cleanup TERM' TERM
 trap 'cleanup INT' INT
 
-while getopts "sr" OPTNAME
+while getopts "srl" OPTNAME
 do
     case "${OPTNAME}" in
         "s")
@@ -44,6 +45,9 @@ do
         ;;
         "r")
             TEST_AGAINST_FREQUENCY_ROCOCO=1
+        ;;
+        "l")
+            TEST_AGAINST_LOCAL_RELAY=1
         ;;
     esac
 done
@@ -56,6 +60,10 @@ if [ $TEST_AGAINST_FREQUENCY_ROCOCO == 1 ]; then
     PROVIDER_URL="wss://rpc.rococo.frequency.xyz"
     NPM_RUN_COMMAND="test:relay"
     CHAIN_ENVIRONMENT="rococo"
+elif [ $TEST_AGAINST_LOCAL_RELAY == 1 ]; then
+    PROVIDER_URL="ws://127.0.0.1:9944"
+    NPM_RUN_COMMAND="test:relay"
+    CHAIN_ENVIRONMENT="local"
 else
     PROVIDER_URL="ws://127.0.0.1:9944"
     CHAIN_ENVIRONMENT="local"
@@ -135,4 +143,5 @@ npm install
 echo "---------------------------------------------"
 echo "Starting Tests..."
 echo "---------------------------------------------"
+set -x
 CHAIN_ENVIRONMENT=$CHAIN_ENVIRONMENT WS_PROVIDER_URL="$PROVIDER_URL" npm run $NPM_RUN_COMMAND


### PR DESCRIPTION
# Goal
The goal of this PR is to add the ability for MSA creation integration tests to run against Frequency on Rococo

Related to #1458 

Adds `integration-test-rococo` target to the `Makefile`

# Discussion
This was first tested against a local Frequency build connected to a local relay.
The `createMsa` suite of mocha tests runs successful against the local relay, however there are a few failing against Frequency on Rococo. More testing is needed to determine if this is an environmental difference or related to something else.
