### PR TITLE
TESTING: Lock srtool-cli to 0.10.0

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -319,7 +319,7 @@ jobs:
       - name: Install srtool-cli
         if: steps.cache-wasm.outputs.cache-hit != 'true'
         run: |
-          cargo install --git https://github.com/chevdor/srtool-cli
+          cargo install --locked --git https://github.com/chevdor/srtool-cli --tag v0.10.0
           srtool --version
       - name: Build Deterministic WASM
         if: steps.cache-wasm.outputs.cache-hit != 'true'


### PR DESCRIPTION
# Goal
The goal of this PR is to lock the version of srtool-cli until issue https://github.com/chevdor/srtool-cli/issues/25 can be resolved.

Part of #1485 