### PR TITLE
test(e2e-tests): Capacity staking from multiple msa to one provider; …

### DIFF
--- a/integration-tests/capacity/replenishment.test.ts
+++ b/integration-tests/capacity/replenishment.test.ts
@@ -16,16 +16,13 @@ import {
   CENTS,
   DOLLARS,
   TokenPerCapacity,
+  assertEvent,
+  getRemainingCapacity
 } from "../scaffolding/helpers";
-import { firstValueFrom } from "rxjs";
 
 describe("Capacity Replenishment Testing: ", function () {
   let schemaId: u16;
 
-  async function getRemainingCapacity(providerId: u64): Promise<u128> {
-    const capacityStaked = (await firstValueFrom(ExtrinsicHelper.api.query.capacity.capacityLedger(providerId))).unwrap();
-    return capacityStaked.remainingCapacity;
-  }
 
   async function createAndStakeProvider(name: string, stakingAmount: bigint): Promise<[KeyringPair, u64]> {
     const stakeKeys = createKeys(name);
@@ -35,9 +32,6 @@ describe("Capacity Replenishment Testing: ", function () {
     return [stakeKeys, stakeProviderId];
   }
 
-  function assertEvent(events: EventMap, eventName: string) {
-    assert(events.hasOwnProperty(eventName));
-  }
 
   before(async function () {
     await setEpochLength(devAccounts[0].keys, TEST_EPOCH_LENGTH);

--- a/integration-tests/capacity/staking.test.ts
+++ b/integration-tests/capacity/staking.test.ts
@@ -6,20 +6,18 @@ import { ExtrinsicHelper } from "../scaffolding/extrinsicHelpers";
 import {
     devAccounts, createKeys, createMsaAndProvider,
     stakeToProvider, fundKeypair,
-    getNextEpochBlock, TEST_EPOCH_LENGTH, setEpochLength
+    getNextEpochBlock, TEST_EPOCH_LENGTH, setEpochLength,
+    CENTS, DOLLARS, createAndFundKeypair
 }
     from "../scaffolding/helpers";
 import { firstValueFrom } from "rxjs";
 
 describe("Capacity Staking Tests", function () {
-    const CENTS = 1000000n;
-    const DOLLARS = 100n * CENTS;
     const accountBalance: bigint = 200n * DOLLARS;
     const tokenMinStake: bigint = 1n * CENTS;
     let capacityMin: bigint = tokenMinStake / 50n;
 
     before(async function () {
-        // this isn't working now?
         await setEpochLength(devAccounts[0].keys, TEST_EPOCH_LENGTH);
     });
 
@@ -145,6 +143,44 @@ describe("Capacity Staking Tests", function () {
                         assert.equal(capacityStaked.totalTokensStaked, 1n * CENTS, "should return a capacityLedger with 1M total tokens staked");
                         assert.equal(capacityStaked.totalCapacityIssued, expectedCapacity, "should return a capacityLedger with 1/50M capacity issued");
                     });
+
+                    it("successfully increases the amount that was targeted to provider from different accounts", async function () {
+                        // Create a new account
+                        const additionalKeys = await createAndFundKeypair(accountBalance);
+
+                        // get the current account info
+                        let currentAcctInfo = await ExtrinsicHelper.getAccountInfo(additionalKeys.address);
+                        const currentStaked = (await firstValueFrom(ExtrinsicHelper.api.query.capacity.capacityLedger(stakeProviderId))).unwrap();
+
+                        await assert.doesNotReject(stakeToProvider(additionalKeys, stakeProviderId, 1n*CENTS));
+
+                        const capacityStaked = (await firstValueFrom(ExtrinsicHelper.api.query.capacity.capacityLedger(stakeProviderId))).unwrap();
+                        assert.equal(
+                            capacityStaked.remainingCapacity,
+                            currentStaked.remainingCapacity.toBigInt() + capacityMin,
+                             `should return a capacityLedger with ${capacityMin} remaining, got ${capacityStaked.remainingCapacity}`
+                        );
+                        assert.equal(
+                            capacityStaked.totalTokensStaked,
+                            currentStaked.totalTokensStaked.toBigInt() +  tokenMinStake,
+                            `should return a capacityLedger with ${tokenMinStake} total staked, got: ${capacityStaked.totalTokensStaked}`
+                        );
+                        assert.equal(
+                            capacityStaked.totalCapacityIssued,
+                            currentStaked.totalCapacityIssued.toBigInt() + capacityMin, 
+                            `should return a capacityLedger with ${capacityMin} total issued, got ${capacityStaked.totalCapacityIssued}`
+                        );
+
+                        // Confirm that the tokens were not staked in the stakeKeys account using the query API
+                        const stakedAcctInfo = await ExtrinsicHelper.getAccountInfo(additionalKeys.address);
+
+                        let increasedMiscFrozen: bigint = stakedAcctInfo.data.miscFrozen.toBigInt() - currentAcctInfo.data.miscFrozen.toBigInt();
+                        let increasedFeeFrozen: bigint = stakedAcctInfo.data.feeFrozen.toBigInt() - currentAcctInfo.data.feeFrozen.toBigInt();
+
+                        assert.equal(increasedMiscFrozen, tokenMinStake, `expected miscFrozen=${tokenMinStake}, got ${increasedMiscFrozen}`);
+                        assert.equal(increasedFeeFrozen, tokenMinStake, `expected feeFrozen=${tokenMinStake}, got ${increasedFeeFrozen}`);
+                    });
+
                 });
             });
         });
@@ -152,11 +188,13 @@ describe("Capacity Staking Tests", function () {
 
     describe("when staking and targeting an InvalidTarget", async function () {
         it("fails to stake", async function () {
+            const maxMsaId = (await ExtrinsicHelper.getCurrentMsaIdentifierMaximum()).toNumber();
+
             let stakeKeys = createKeys("StakeKeys");
             let stakeAmount = 100n * DOLLARS;
             await fundKeypair(devAccounts[0].keys, stakeKeys, stakeAmount)
 
-            const failStakeObj = ExtrinsicHelper.stake(stakeKeys, 99, stakeAmount);
+            const failStakeObj = ExtrinsicHelper.stake(stakeKeys, maxMsaId + 1, stakeAmount);
             await assert.rejects(failStakeObj.fundAndSend(), { name: "InvalidTarget" });
         });
     });

--- a/integration-tests/capacity/staking.test.ts
+++ b/integration-tests/capacity/staking.test.ts
@@ -96,12 +96,15 @@ describe("Capacity Staking Tests", function () {
                   // get the current account info
                    let oldStakedAcctInfo = await ExtrinsicHelper.getAccountInfo(stakeKeys.address);
 
-                    await assert.doesNotReject(stakeToProvider(stakeKeys, stakeProviderId, 1n*CENTS));
+                    await assert.doesNotReject(stakeToProvider(stakeKeys, stakeProviderId, tokenMinStake));
 
                     const capacityStaked = (await firstValueFrom(ExtrinsicHelper.api.query.capacity.capacityLedger(stakeProviderId))).unwrap();
-                    assert.equal(capacityStaked.remainingCapacity, capacityMin, "should return a capacityLedger with  remainingCapacity");
-                    assert.equal(capacityStaked.totalTokensStaked, tokenMinStake, "should return a capacityLedger with 50M total staked");
-                    assert.equal(capacityStaked.totalCapacityIssued, capacityMin, "should return a capacityLedger with 1M capacity issued");
+                    assert.equal(capacityStaked.remainingCapacity, capacityMin,
+                        `expected capacityStaked.remainingCapacity = ${capacityMin}, got ${capacityStaked.remainingCapacity}`);
+                    assert.equal(capacityStaked.totalTokensStaked, tokenMinStake,
+                        `expected capacityStaked.totalTokensStaked = ${tokenMinStake}, got ${capacityStaked.totalTokensStaked}`);
+                    assert.equal(capacityStaked.totalCapacityIssued, capacityMin,
+                        `expected capacityStaked.totalCapacityIssued = ${capacityMin}, got ${capacityStaked.totalCapacityIssued}`);
 
                     // Confirm that the tokens were staked in the stakeKeys account using the query API
                     const stakedAcctInfo = await ExtrinsicHelper.getAccountInfo(stakeKeys.address);
@@ -152,7 +155,7 @@ describe("Capacity Staking Tests", function () {
                         let currentAcctInfo = await ExtrinsicHelper.getAccountInfo(additionalKeys.address);
                         const currentStaked = (await firstValueFrom(ExtrinsicHelper.api.query.capacity.capacityLedger(stakeProviderId))).unwrap();
 
-                        await assert.doesNotReject(stakeToProvider(additionalKeys, stakeProviderId, 1n*CENTS));
+                        await assert.doesNotReject(stakeToProvider(additionalKeys, stakeProviderId, tokenMinStake));
 
                         const capacityStaked = (await firstValueFrom(ExtrinsicHelper.api.query.capacity.capacityLedger(stakeProviderId))).unwrap();
                         assert.equal(
@@ -252,7 +255,7 @@ describe("Capacity Staking Tests", function () {
 
         describe("when account has not staked", async function () {
             it("errors with StakingAccountNotFound", async function () {
-                const failUnstakeObj = ExtrinsicHelper.unstake(unstakeKeys, providerId, 1000000);
+                const failUnstakeObj = ExtrinsicHelper.unstake(unstakeKeys, providerId, tokenMinStake);
                 await assert.rejects(failUnstakeObj.fundAndSend(), { name: "StakingAccountNotFound" });
             });
         });

--- a/integration-tests/capacity/transactions.test.ts
+++ b/integration-tests/capacity/transactions.test.ts
@@ -1,32 +1,24 @@
 import "@frequency-chain/api-augment";
 import { KeyringPair } from "@polkadot/keyring/types";
-import { Bytes, u32, u64, u16, u128, Vec } from "@polkadot/types";
+import { Bytes, u64, u16, u128 } from "@polkadot/types";
 import { Codec } from "@polkadot/types/types";
 import { u8aToHex } from "@polkadot/util/u8a/toHex";
 import { u8aWrapBytes } from "@polkadot/util";
 import assert from "assert";
-import { AddKeyData, AddProviderPayload, EventMap, ExtrinsicHelper } from "../scaffolding/extrinsicHelpers";
-import {
-  devAccounts, createKeys, createAndFundKeypair, createMsaAndProvider,
-  generateDelegationPayload, getBlockNumber, signPayloadSr25519, stakeToProvider, fundKeypair,
-  TEST_EPOCH_LENGTH,
-  setEpochLength,
-  generateAddKeyPayload,
-  CENTS,
-  DOLLARS,
-  createGraphChangeSchema,
-  TokenPerCapacity,
-  Sr25519Signature,
-  assertEvent,
-  getCurrentItemizedHash,
-  getCurrentPaginatedHash,
-  getRemainingCapacity,
-} from "../scaffolding/helpers";
+import { AddKeyData, AddProviderPayload, ExtrinsicHelper } from "../scaffolding/extrinsicHelpers";
 import { loadIpfs, getBases } from "../messages/loadIPFS";
 import { PARQUET_BROADCAST } from "../schemas/fixtures/parquetBroadcastSchemaType";
-import { async, firstValueFrom } from "rxjs";
+import { firstValueFrom } from "rxjs";
 import { SchemaId } from "@frequency-chain/api-augment/interfaces";
 import { AVRO_CHAT_MESSAGE } from "../stateful-pallet-storage/fixtures/itemizedSchemaType";
+import {
+    devAccounts, createKeys, createAndFundKeypair, createMsaAndProvider,
+    generateDelegationPayload, getBlockNumber, signPayloadSr25519, stakeToProvider, fundKeypair,
+    TEST_EPOCH_LENGTH, setEpochLength, generateAddKeyPayload, CENTS, DOLLARS, createGraphChangeSchema,
+    TokenPerCapacity, Sr25519Signature, assertEvent, getCurrentItemizedHash, getCurrentPaginatedHash,
+    generateItemizedSignaturePayload, createDelegator, generatePaginatedUpsertSignaturePayload,
+    generatePaginatedDeleteSignaturePayload
+} from "../scaffolding/helpers";
 
 describe("Capacity Transactions", function () {
     const FUNDS_AMOUNT: bigint = 200n * DOLLARS;
@@ -49,234 +41,334 @@ describe("Capacity Transactions", function () {
                 // Create schemas for testing with Grant Delegation to test pay_with_capacity
                 schemaId = await createGraphChangeSchema();
                 assert.notEqual(schemaId, undefined, "setup should populate schemaId");
-
             });
 
-            it("successfully pays with Capacity for eligible transaction - addPublicKeytoMSA", async function () {
-                let authorizedKeys: KeyringPair[] = [];
-                let defaultPayload: AddKeyData = {};
-                let payload: AddKeyData;
-                let ownerSig: Sr25519Signature;
-                let newSig: Sr25519Signature;
-                let addKeyData: Codec;
-
-                await assert.doesNotReject(stakeToProvider(capacityKeys, capacityProvider, amountStaked));
-
-                authorizedKeys.push(await createAndFundKeypair());
-                defaultPayload.msaId = capacityProvider
-                defaultPayload.newPublicKey = authorizedKeys[0].publicKey;
-
-                payload = await generateAddKeyPayload(defaultPayload);
-                addKeyData = ExtrinsicHelper.api.registry.createType("PalletMsaAddKeyData", payload);
-                ownerSig = signPayloadSr25519(capacityKeys, addKeyData);
-                newSig = signPayloadSr25519(authorizedKeys[0], addKeyData);
-                const addPublicKeyOp = ExtrinsicHelper.addPublicKeyToMsa(capacityKeys, ownerSig, newSig, payload);
-
-                const [_, chainEvents] = await addPublicKeyOp.payWithCapacity();
-
-                assertEvent(chainEvents, "msa.PublicKeyAdded");
-                assertEvent(chainEvents, "capacity.CapacityWithdrawn");
-            });
-
-            // REVIEW: No existing e2e test for createSponsoredAccountWithDelegation
-            it("should test pays with Capacity for eligible transaction - createSponsoredAccountWithDelegation");
-
-            it("successfully pays with Capacity for eligible transaction - grantDelegation", async function () {
-                await assert.doesNotReject(stakeToProvider(capacityKeys, capacityProvider, amountStaked));
-
+            describe("when capacity eligible transaction is from the msa pallet", async function () {
                 let delegatorKeys = createKeys("delegatorKeys");
-                await fundKeypair(devAccounts[0].keys, delegatorKeys, 100n * DOLLARS);
+                let payload: any = {};
 
-                let [_, MsaCreatedEvent] = await ExtrinsicHelper.createMsa(delegatorKeys).signAndSend();
-                assertEvent(MsaCreatedEvent, "msa.MsaCreated");
-                // assert.notEqual(MsaCreatedEvent, undefined, "should have returned MsaCreated event");
-
-                const payload = await generateDelegationPayload({
-                    authorizedMsaId: capacityProvider,
-                    schemaIds: [schemaId],
+                beforeEach(async function () {
+                    await assert.doesNotReject(stakeToProvider(capacityKeys, capacityProvider, amountStaked));
+                    payload = await generateDelegationPayload({
+                        authorizedMsaId: capacityProvider,
+                        schemaIds: [schemaId],
+                    });
                 });
-                const addProviderData = ExtrinsicHelper.api.registry.createType("PalletMsaAddProvider", payload);
-                const grantDelegationOp = ExtrinsicHelper.grantDelegation(delegatorKeys, capacityKeys,
-                    signPayloadSr25519(delegatorKeys, addProviderData), payload);
 
-                const [grantDelegationEvent, chainEvents] = await grantDelegationOp.payWithCapacity();
-                if (grantDelegationEvent &&
-                    !(ExtrinsicHelper.api.events.msa.DelegationGranted.is(grantDelegationEvent))) {
-                    assert.fail("should return a DelegationGranted event");
-                }
+                it("successfully pays with Capacity for eligible transaction - addPublicKeytoMSA", async function () {
+                    let authorizedKeys: KeyringPair[] = [];
+                    let defaultPayload: AddKeyData = {};
+                    let payload: AddKeyData;
+                    let ownerSig: Sr25519Signature;
+                    let newSig: Sr25519Signature;
+                    let addKeyData: Codec;
 
-                let fee: u128;
-                if (chainEvents["capacity.CapacityWithdrawn"] &&
-                    ExtrinsicHelper.api.events.capacity.CapacityWithdrawn.is(chainEvents["capacity.CapacityWithdrawn"]))
-                {
-                    fee = chainEvents["capacity.CapacityWithdrawn"].data.amount;
-                }
-                else {
-                    assert.fail("should return a CapacityWithdrawn event");
-                }
-                const expectedRemainingCapacity = amountStaked/TokenPerCapacity - fee.toBigInt();
+                    authorizedKeys.push(await createAndFundKeypair());
+                    defaultPayload.msaId = capacityProvider
+                    defaultPayload.newPublicKey = authorizedKeys[0].publicKey;
 
-                // Check for remaining capacity to be reduced by correct amount
-                const capacityStaked = (await firstValueFrom(ExtrinsicHelper.api.query.capacity.capacityLedger(capacityProvider))).unwrap();
+                    payload = await generateAddKeyPayload(defaultPayload);
+                    addKeyData = ExtrinsicHelper.api.registry.createType("PalletMsaAddKeyData", payload);
+                    ownerSig = signPayloadSr25519(capacityKeys, addKeyData);
+                    newSig = signPayloadSr25519(authorizedKeys[0], addKeyData);
+                    const addPublicKeyOp = ExtrinsicHelper.addPublicKeyToMsa(capacityKeys, ownerSig, newSig, payload);
 
-                let remaining = capacityStaked.remainingCapacity.toBigInt();
-                assert.equal(remaining, expectedRemainingCapacity);
-                assert.equal(capacityStaked.totalTokensStaked, amountStaked);
-                assert.equal(capacityStaked.totalCapacityIssued, amountStaked/TokenPerCapacity);
+                    const [_, chainEvents] = await addPublicKeyOp.payWithCapacity();
+                    assertEvent(chainEvents, "system.ExtrinsicSuccess");
+                    assertEvent(chainEvents, "capacity.CapacityWithdrawn");
+                    assertEvent(chainEvents, "msa.PublicKeyAdded");
+                });
+
+                it("successfully pays with Capacity for eligible transaction - createSponsoredAccountWithDelegation", async function () {
+                    const addProviderData = ExtrinsicHelper.api.registry.createType("PalletMsaAddProvider", payload);
+                    const call = ExtrinsicHelper.createSponsoredAccountWithDelegation(
+                        delegatorKeys, capacityKeys,
+                        signPayloadSr25519(delegatorKeys, addProviderData),
+                        payload
+                    );
+                    const [_, chainEvents] = await call.payWithCapacity();
+                    assertEvent(chainEvents, "system.ExtrinsicSuccess");
+                    assertEvent(chainEvents, "capacity.CapacityWithdrawn");
+                    assertEvent(chainEvents, "msa.DelegationGranted");
+                });
+
+                it("successfully pays with Capacity for eligible transaction - grantDelegation", async function () {
+                    await fundKeypair(devAccounts[0].keys, delegatorKeys, 100n * DOLLARS);
+
+                    let [_, MsaCreatedEvent] = await ExtrinsicHelper.createMsa(delegatorKeys).signAndSend();
+                    assertEvent(MsaCreatedEvent, "msa.MsaCreated");
+
+                    const addProviderData = ExtrinsicHelper.api.registry.createType("PalletMsaAddProvider", payload);
+                    const grantDelegationOp = ExtrinsicHelper.grantDelegation(delegatorKeys, capacityKeys,
+                        signPayloadSr25519(delegatorKeys, addProviderData), payload);
+
+                    const [grantDelegationEvent, chainEvents] = await grantDelegationOp.payWithCapacity();
+                    assertEvent(chainEvents, "system.ExtrinsicSuccess");
+                    assertEvent(chainEvents, "capacity.CapacityWithdrawn");
+                    assertEvent(chainEvents, "msa.DelegationGranted");
+
+                    let fee: u128 = {} as u128;
+                    if (chainEvents["capacity.CapacityWithdrawn"] &&
+                        ExtrinsicHelper.api.events.capacity.CapacityWithdrawn.is(chainEvents["capacity.CapacityWithdrawn"]))
+                    {
+                        fee = chainEvents["capacity.CapacityWithdrawn"].data.amount;
+                    }
+                    const expectedRemainingCapacity = amountStaked/TokenPerCapacity - fee.toBigInt();
+
+                    // Check for remaining capacity to be reduced by correct amount
+                    const capacityStaked = (await firstValueFrom(ExtrinsicHelper.api.query.capacity.capacityLedger(capacityProvider))).unwrap();
+
+                    let remaining = capacityStaked.remainingCapacity.toBigInt();
+                    assert.equal(remaining, expectedRemainingCapacity);
+                    assert.equal(capacityStaked.totalTokensStaked, amountStaked);
+                    assert.equal(capacityStaked.totalCapacityIssued, amountStaked/TokenPerCapacity);
+                });
             });
 
-            it("successfully pays with Capacity for eligible transaction - addIPFSMessage", async function () {
-                // REVIEW: need more staking?
-                await assert.doesNotReject(stakeToProvider(capacityKeys, capacityProvider, amountStaked));
-                // Create a schema for IPFS
-                const createSchema = ExtrinsicHelper.createSchema(capacityKeys, PARQUET_BROADCAST, "Parquet", "IPFS");
-                let [event] = await createSchema.fundAndSend();
-                if (event && createSchema.api.events.schemas.SchemaCreated.is(event)) {
-                    [, schemaId] = event.data;
-                }
-                const ipfs_payload_data = "This is a test of Frequency.";
-                const ipfs_payload_len = ipfs_payload_data.length + 1;
-                let ipfs_node: any;
-                let ipfs_cid_64: string;
-                ipfs_node = await loadIpfs();
-                const { base64, base32 } = await getBases();
-                const file = await ipfs_node.add({ path: 'integration_test.txt', content: ipfs_payload_data }, { cidVersion: 1, onlyHash: true });
-                ipfs_cid_64 = file.cid.toString(base64);
-                const call = ExtrinsicHelper.addIPFSMessage(capacityKeys, schemaId, ipfs_cid_64, ipfs_payload_len);
+            describe("when capacity eligible transaction is from the messages pallet", async function () {
+                beforeEach(async function () {
+                    await assert.doesNotReject(stakeToProvider(capacityKeys, capacityProvider, amountStaked));
+                });
 
-                const [_, chainEvents] = await call.payWithCapacity();
-                assertEvent(chainEvents, "capacity.CapacityWithdrawn");
-                assertEvent(chainEvents, "messages.MessagesStored");
+                it("successfully pays with Capacity for eligible transaction - addIPFSMessage", async function () {
+                    // Create a schema for IPFS
+                    const createSchema = ExtrinsicHelper.createSchema(capacityKeys, PARQUET_BROADCAST, "Parquet", "IPFS");
+                    let [event] = await createSchema.fundAndSend();
+                    if (event && createSchema.api.events.schemas.SchemaCreated.is(event)) {
+                        [, schemaId] = event.data;
+                    }
+                    const ipfs_payload_data = "This is a test of Frequency.";
+                    const ipfs_payload_len = ipfs_payload_data.length + 1;
+                    let ipfs_node: any;
+                    let ipfs_cid_64: string;
+                    ipfs_node = await loadIpfs();
+                    const { base64, base32 } = await getBases();
+                    const file = await ipfs_node.add({ path: 'integration_test.txt', content: ipfs_payload_data }, { cidVersion: 1, onlyHash: true });
+                    ipfs_cid_64 = file.cid.toString(base64);
+                    const call = ExtrinsicHelper.addIPFSMessage(capacityKeys, schemaId, ipfs_cid_64, ipfs_payload_len);
+
+                    const [_, chainEvents] = await call.payWithCapacity();
+                    assertEvent(chainEvents, "capacity.CapacityWithdrawn");
+                    assertEvent(chainEvents, "messages.MessagesStored");
+                    await ipfs_node.stop();
+                });
+
+                it("successfully pays with Capacity for eligible transaction - addOnchainMessage", async function () {
+                    // Create a dummy on-chain schema
+                    let dummySchemaId: u16;
+                    const createDummySchema = ExtrinsicHelper.createSchema(
+                        capacityKeys, 
+                        { type: "record", name: "Dummy on-chain schema", fields: [] }, 
+                        "AvroBinary", 
+                        "OnChain"
+                    );
+                    const [dummySchemaEvent] = await createDummySchema.fundAndSend();
+                    if (dummySchemaEvent && createDummySchema.api.events.schemas.SchemaCreated.is(dummySchemaEvent)) {
+                        [, dummySchemaId] = dummySchemaEvent.data;
+                    }
+                    else {
+                        assert.fail("should have returned a SchemaCreated event");
+                    }
+                    const call = ExtrinsicHelper.addOnChainMessage(capacityKeys, dummySchemaId, "0xdeadbeef");
+                    const [_, chainEvents] = await call.payWithCapacity();
+                    assertEvent(chainEvents, "capacity.CapacityWithdrawn");
+                    assertEvent(chainEvents, "messages.MessagesStored");
+                });
             });
 
-            it("successfully pays with Capacity for eligible transaction - addOnchainMessage", async function () {
-                // REVIEW: need more staking?
-                await assert.doesNotReject(stakeToProvider(capacityKeys, capacityProvider, amountStaked));
-                // Create a dummy on-chain schema
-                let dummySchemaId: u16;
-                const createDummySchema = ExtrinsicHelper.createSchema(
-                    capacityKeys, 
-                    { type: "record", name: "Dummy on-chain schema", fields: [] }, 
-                    "AvroBinary", 
-                    "OnChain"
-                );
-                const [dummySchemaEvent] = await createDummySchema.fundAndSend();
-                if (dummySchemaEvent && createDummySchema.api.events.schemas.SchemaCreated.is(dummySchemaEvent)) {
-                    [, dummySchemaId] = dummySchemaEvent.data;
-                }
-                else {
-                    assert.fail("should have returned a SchemaCreated event");
-                }
-                const call = ExtrinsicHelper.addOnChainMessage(capacityKeys, dummySchemaId, "0xdeadbeef");
-                const [_, chainEvents] = await call.payWithCapacity();
-                assertEvent(chainEvents, "capacity.CapacityWithdrawn");
-                assertEvent(chainEvents, "messages.MessagesStored");
-            });
+            describe("when capacity eligible transaction is from the StatefulStorage pallet", async function () {
+                let delegatorKeys: KeyringPair;
+                beforeEach(async function () {
+                    await assert.doesNotReject(stakeToProvider(capacityKeys, capacityProvider, amountStaked));
+                });
 
-            it("successfully pays with Capacity for eligible transaction - applyItemActions", async function () {
-                // REVIEW: need more staking?
-                await assert.doesNotReject(stakeToProvider(capacityKeys, capacityProvider, amountStaked));
-                // Create a schema to allow delete actions
-                let schemaId_deletable: SchemaId;
-                const createSchemaDeletable = ExtrinsicHelper.createSchema(capacityKeys, AVRO_CHAT_MESSAGE, "AvroBinary", "Itemized");
-                const [eventDeletable] = await createSchemaDeletable.fundAndSend();
-                if (eventDeletable && createSchemaDeletable.api.events.schemas.SchemaCreated.is(eventDeletable)) {
-                    schemaId_deletable = eventDeletable.data.schemaId;
-                }
-                else {
-                    assert.fail("setup should populate schemaId");
-                }
+                it("successfully pays with Capacity for eligible transaction - applyItemActions", async function () {
+                    // Create a schema to allow delete actions
+                    let schemaId_deletable: SchemaId;
+                    const createSchemaDeletable = ExtrinsicHelper.createSchema(capacityKeys, AVRO_CHAT_MESSAGE, "AvroBinary", "Itemized");
+                    const [eventDeletable] = await createSchemaDeletable.fundAndSend();
+                    if (eventDeletable && createSchemaDeletable.api.events.schemas.SchemaCreated.is(eventDeletable)) {
+                        schemaId_deletable = eventDeletable.data.schemaId;
+                    }
+                    else {
+                        assert.fail("setup should populate schemaId");
+                    }
 
-                // Add and update actions
-                let payload_1 = new Bytes(ExtrinsicHelper.api.registry, "Hello World From Frequency");
+                    // Add and update actions
+                    let payload_1 = new Bytes(ExtrinsicHelper.api.registry, "Hello World From Frequency");
+                    const add_action = {
+                        "Add": payload_1
+                    }
 
-                const add_action = {
+                    let payload_2 = new Bytes(ExtrinsicHelper.api.registry, "Hello World Again From Frequency");
+                    const update_action = {
+                        "Add": payload_2
+                    }
+
+                    const target_hash = await getCurrentItemizedHash(capacityProvider, schemaId_deletable);
+
+                    let add_actions = [add_action, update_action];
+                    const call = ExtrinsicHelper.applyItemActions(capacityKeys, schemaId_deletable, capacityProvider, add_actions, target_hash);
+                    const [_pageUpdateEvent, chainEvents] = await call.payWithCapacity();
+                    assertEvent(chainEvents, "system.ExtrinsicSuccess");
+                    assertEvent(chainEvents, "capacity.CapacityWithdrawn");
+                    assertEvent(chainEvents, "statefulStorage.ItemizedPageUpdated");
+                });
+
+                it("successfully pays with Capacity for eligible transaction - upsertPage; deletePage", async function () {
+                    // Create a schema for Paginated PayloadLocation
+                    const createSchema = ExtrinsicHelper.createSchema(capacityKeys, AVRO_CHAT_MESSAGE, "AvroBinary", "Paginated");
+                    const [event] = await createSchema.fundAndSend();
+                    if (event && createSchema.api.events.schemas.SchemaCreated.is(event)) {
+                        schemaId = event.data.schemaId;
+                    }
+                    assert.notEqual(schemaId, undefined, "setup should populate schemaId");
+
+                    let page_id = 0;
+                    let target_hash = await getCurrentPaginatedHash(capacityProvider, schemaId, page_id)
+
+                    // Add and update actions
+                    const payload_1 = new Bytes(ExtrinsicHelper.api.registry, "Hello World From Frequency");
+                    let call = ExtrinsicHelper.upsertPage(capacityKeys, schemaId, capacityProvider, page_id, payload_1, target_hash);
+                    let [_pageUpdateEvent1, chainEvents] = await call.payWithCapacity();
+                    assertEvent(chainEvents, "system.ExtrinsicSuccess");
+                    assertEvent(chainEvents, "capacity.CapacityWithdrawn");
+                    assertEvent(chainEvents, "statefulStorage.PaginatedPageUpdated")
+
+                    // Remove the page
+                    target_hash = await getCurrentPaginatedHash(capacityProvider, schemaId, page_id)
+                    call = ExtrinsicHelper.removePage(capacityKeys, schemaId, capacityProvider, page_id, target_hash);
+                    let [_pageRemove, chainEvents2] = await call.payWithCapacity();
+                    assertEvent(chainEvents2, "system.ExtrinsicSuccess");
+                    assertEvent(chainEvents2, "capacity.CapacityWithdrawn");
+                    assertEvent(chainEvents2, "statefulStorage.PaginatedPageDeleted");
+                });
+
+                it("successfully pays with Capacity for eligible transaction - applyItemActionsWithSignature", async function () {
+                    // Create a schema for Itemized PayloadLocation
+                    let itemizedSchemaId: SchemaId;
+
+                    const createSchema = ExtrinsicHelper.createSchema(capacityKeys, AVRO_CHAT_MESSAGE, "AvroBinary", "Itemized");
+                    const [event] = await createSchema.fundAndSend();
+                    if (event && createSchema.api.events.schemas.SchemaCreated.is(event)) {
+                        itemizedSchemaId = event.data.schemaId;
+                    }
+                    else {
+                        assert.fail("setup should populate schemaId");
+                    }
+
+                    // Create a MSA for the delegator
+                    [delegatorKeys, capacityProvider] = await createDelegator();
+                    assert.notEqual(delegatorKeys, undefined, "setup should populate delegator_key");
+                    assert.notEqual(capacityProvider, undefined, "setup should populate msa_id");
+
+                    // Add and update actions
+                    let payload_1 = new Bytes(ExtrinsicHelper.api.registry, "Hello World From Frequency");
+                    const add_action = {
                     "Add": payload_1
-                }
+                    }
 
-                let payload_2 = new Bytes(ExtrinsicHelper.api.registry, "Hello World Again From Frequency");
-
-                const update_action = {
+                    let payload_2 = new Bytes(ExtrinsicHelper.api.registry, "Hello World Again From Frequency");
+                    const update_action = {
                     "Add": payload_2
-                }
+                    }
 
-                const target_hash = await getCurrentItemizedHash(capacityProvider, schemaId_deletable);
+                    const target_hash = await getCurrentItemizedHash(capacityProvider, itemizedSchemaId);
 
-                let add_actions = [add_action, update_action];
-                const call = ExtrinsicHelper.applyItemActions(capacityKeys, schemaId_deletable, capacityProvider, add_actions, target_hash);
-                const [pageUpdateEvent, chainEvents] = await call.payWithCapacity();
-                assertEvent(chainEvents, "system.ExtrinsicSuccess");
-                assertEvent(chainEvents, "capacity.CapacityWithdrawn");
-                // REVIEW: Is this event correct?
-                assert.notEqual(pageUpdateEvent, undefined, "should have returned a PalletStatefulStorageItemizedActionApplied event");
- 
+                    let add_actions = [add_action, update_action];
+                    const payload = await generateItemizedSignaturePayload({
+                        msaId: capacityProvider,
+                        targetHash: target_hash,
+                        schemaId: itemizedSchemaId,
+                        actions: add_actions,
+                    });
+                    const itemizedPayloadData = ExtrinsicHelper.api.registry.createType("PalletStatefulStorageItemizedSignaturePayload", payload);
+                    let itemized_add_result_1 = ExtrinsicHelper.applyItemActionsWithSignature(delegatorKeys, capacityKeys, signPayloadSr25519(delegatorKeys, itemizedPayloadData), payload);
+                    const [pageUpdateEvent1, chainEvents] = await itemized_add_result_1.payWithCapacity();
+                    assertEvent(chainEvents, "system.ExtrinsicSuccess");
+                    assertEvent(chainEvents, "capacity.CapacityWithdrawn");
+                    assert.notEqual(pageUpdateEvent1, undefined, "should have returned a PalletStatefulStorageItemizedActionApplied event");
+                });
+
+                it("successfully pays with Capacity for eligible transaction - upsertPageWithSignature; deletePageWithSignature", async function () {
+                    let paginatedSchemaId: SchemaId;
+
+                    // Create a schema for Paginated PayloadLocation
+                    const createSchema2 = ExtrinsicHelper.createSchema(capacityKeys, AVRO_CHAT_MESSAGE, "AvroBinary", "Paginated");
+                    const [event2] = await createSchema2.fundAndSend();
+                    assert.notEqual(event2, undefined, "setup should return a SchemaCreated event");
+                    if (event2 && createSchema2.api.events.schemas.SchemaCreated.is(event2)) {
+                        paginatedSchemaId = event2.data.schemaId;
+                        assert.notEqual(paginatedSchemaId, undefined, "setup should populate schemaId");
+                    }
+                    else {
+                        assert.fail("setup should populate schemaId");
+                    }
+
+                    // Create a MSA for the delegator
+                    [delegatorKeys, capacityProvider] = await createDelegator();
+                    assert.notEqual(delegatorKeys, undefined, "setup should populate delegator_key");
+                    assert.notEqual(capacityProvider, undefined, "setup should populate msa_id");
+
+                    let page_id = new u16(ExtrinsicHelper.api.registry, 1);
+
+                    // Add and update actions
+                    let target_hash = await getCurrentPaginatedHash(capacityProvider, paginatedSchemaId, page_id.toNumber());
+                    const upsertPayload = await generatePaginatedUpsertSignaturePayload({
+                        msaId: capacityProvider,
+                        targetHash: target_hash,
+                        schemaId: paginatedSchemaId,
+                        pageId: page_id,
+                        payload: new Bytes(ExtrinsicHelper.api.registry, "Hello World From Frequency"),
+                    });
+                    const upsertPayloadData = ExtrinsicHelper.api.registry.createType("PalletStatefulStoragePaginatedUpsertSignaturePayload", upsertPayload);
+                    let upsert_result = ExtrinsicHelper.upsertPageWithSignature(delegatorKeys, capacityKeys, signPayloadSr25519(delegatorKeys, upsertPayloadData), upsertPayload);
+                    const [pageUpdateEvent, chainEvents1] = await upsert_result.payWithCapacity();
+                    assertEvent(chainEvents1, "system.ExtrinsicSuccess");
+                    assertEvent(chainEvents1, "capacity.CapacityWithdrawn");
+                    assert.notEqual(pageUpdateEvent, undefined, "should have returned a PalletStatefulStoragePaginatedPageUpdate event");
+
+                    // Remove the page
+                    target_hash = await getCurrentPaginatedHash(capacityProvider, paginatedSchemaId, page_id.toNumber());
+                    const deletePayload = await generatePaginatedDeleteSignaturePayload({
+                        msaId: capacityProvider,
+                        targetHash: target_hash,
+                        schemaId: paginatedSchemaId,
+                        pageId: page_id,
+                    });
+                    const deletePayloadData = ExtrinsicHelper.api.registry.createType("PalletStatefulStoragePaginatedDeleteSignaturePayload", deletePayload);
+                    let remove_result = ExtrinsicHelper.removePageWithSignature(delegatorKeys, capacityKeys, signPayloadSr25519(delegatorKeys, deletePayloadData), deletePayload);
+                    const [pageRemove, chainEvents2] = await remove_result.payWithCapacity();
+                    assertEvent(chainEvents2, "system.ExtrinsicSuccess");
+                    assertEvent(chainEvents2, "capacity.CapacityWithdrawn");
+                    assert.notEqual(pageRemove, undefined, "should have returned a event");
+
+                    // no pages should exist
+                    const result = await ExtrinsicHelper.getPaginatedStorage(capacityProvider, paginatedSchemaId);
+                    assert.notEqual(result, undefined, "should have returned a valid response");
+                    assert.equal(result.length, 0, "should returned no paginated pages");
+                });
             });
 
-            // REVIEW: No existing e2e test for createSponsoredAccountWithDelegation
-            it("successfully pays with Capacity for eligible transaction - upsertPage; deletePage", async function () {
-                // REVIEW: need more staking?
-                await assert.doesNotReject(stakeToProvider(capacityKeys, capacityProvider, amountStaked));
+            describe("when capacity eligible transaction is from the handles pallet", async function () {
+                it("successfully pays with Capacity for eligible transaction - claimHandle", async function () {
+                    await assert.doesNotReject(stakeToProvider(capacityKeys, capacityProvider, amountStaked));
 
-                // Create a schema for Paginated PayloadLocation
-                const createSchema = ExtrinsicHelper.createSchema(capacityKeys, AVRO_CHAT_MESSAGE, "AvroBinary", "Paginated");
-                const [event] = await createSchema.fundAndSend();
-                if (event && createSchema.api.events.schemas.SchemaCreated.is(event)) {
-                    schemaId = event.data.schemaId;
-                }
-                assert.notEqual(schemaId, undefined, "setup should populate schemaId");
-
-                let page_id = 0;
-                let target_hash = await getCurrentPaginatedHash(capacityProvider, schemaId, page_id)
-
-                // Add and update actions
-                const payload_1 = new Bytes(ExtrinsicHelper.api.registry, "Hello World From Frequency");
-                let call = ExtrinsicHelper.upsertPage(capacityKeys, schemaId, capacityProvider, page_id, payload_1, target_hash);
-                let [pageUpdateEvent1, chainEvents] = await call.payWithCapacity();
-                assertEvent(chainEvents, "system.ExtrinsicSuccess");
-                assertEvent(chainEvents, "capacity.CapacityWithdrawn");
-                assert.notEqual(pageUpdateEvent1, undefined, "should have returned a PalletStatefulStoragepaginatedActionApplied event");
-
-                // Remove the page
-                target_hash = await getCurrentPaginatedHash(capacityProvider, schemaId, page_id)
-                call = ExtrinsicHelper.removePage(capacityKeys, schemaId, capacityProvider, page_id, target_hash);
-                let [pageRemove, chainEvents2] = await call.payWithCapacity();
-                assertEvent(chainEvents2, "system.ExtrinsicSuccess");
-                assertEvent(chainEvents2, "capacity.CapacityWithdrawn");
-                // assertEvent(chainEvents2, "PaginatedPageDeleted");
-                assert.notEqual(pageRemove, undefined, "should have returned an event");
+                    const handle = "test_handle";
+                    const expiration = (await getBlockNumber()) + 10;
+                    const handle_vec = new Bytes(ExtrinsicHelper.api.registry, handle);
+                    const handlePayload = {
+                        baseHandle: handle_vec,
+                        expiration: expiration,
+                    };
+                    const claimHandlePayload = ExtrinsicHelper.api.registry.createType("CommonPrimitivesHandlesClaimHandlePayload", handlePayload);
+                    const claimHandle = ExtrinsicHelper.claimHandle(capacityKeys, claimHandlePayload);
+                    const [_, eventMap] = await claimHandle.payWithCapacity();
+                    assertEvent(eventMap, "system.ExtrinsicSuccess");
+                    assertEvent(eventMap, "capacity.CapacityWithdrawn");
+                    assertEvent(eventMap, "handles.HandleClaimed");
+                });
             });
-
-
-            it("successfully pays with Capacity for eligible transaction - deletePage", async function () {
-                // REVIEW: need more staking?
-                // await assert.doesNotReject(stakeToProvider(capacityKeys, capacityProvider, amountStaked));
-
-                // // Create a schema for Paginated PayloadLocation
-                // const createSchema = ExtrinsicHelper.createSchema(capacityKeys, AVRO_CHAT_MESSAGE, "AvroBinary", "Paginated");
-                // const [event] = await createSchema.fundAndSend();
-                // if (event && createSchema.api.events.schemas.SchemaCreated.is(event)) {
-                //     schemaId = event.data.schemaId;
-                // }
-                // assert.notEqual(schemaId, undefined, "setup should populate schemaId");
-
-                // // Remove the page
-                // let page_id = 0;
-                // let target_hash = await getCurrentPaginatedHash(capacityProvider, schemaId, page_id)
-                // let call = ExtrinsicHelper.removePage(capacityKeys, schemaId, capacityProvider, page_id, target_hash);
-                // const [pageRemove, chainEvents] = await call.payWithCapacity();
-                // assertEvent(chainEvents, "system.ExtrinsicSuccess");
-                // assertEvent(chainEvents, "capacity.CapacityWithdrawn");
-                // assertEvent(chainEvents, "PaginatedPageDeleted");
-                // assert.notEqual(pageRemove, undefined, "should have returned an event");
-            });
-
-            it("successfully pays with Capacity for eligible transaction - applyItemActionsWithSignature");
-
-            it("successfully pays with Capacity for eligible transaction - upsertPageWithSignature");
-
-            it("successfully pays with Capacity for eligible transaction - deletePageWithSignature");
-
-            it("successfully pays with Capacity for eligible transaction - claimHandle");
 
             // When a user attempts to pay for a non-capacity transaction with Capacity,
             // it should error and drop the transaction from the transaction-pool.
@@ -411,6 +503,7 @@ describe("Capacity Transactions", function () {
             });
         });
     });
+
     describe("pay_with_capacity_batch_all", function () {
         describe("when caller has a Capacity account", async function () {
             let capacityProviderKeys: KeyringPair;

--- a/integration-tests/capacity/transactions.test.ts
+++ b/integration-tests/capacity/transactions.test.ts
@@ -126,6 +126,7 @@ describe("Capacity Transactions", function () {
             });
 
             describe("when capacity eligible transaction is from the messages pallet", async function () {
+                this.timeout(5000); // Override default timeout of 500ms to allow for IPFS node startup
                 beforeEach(async function () {
                     await assert.doesNotReject(stakeToProvider(capacityKeys, capacityProvider, amountStaked));
                 });

--- a/integration-tests/messages/addIPFSMessage.test.ts
+++ b/integration-tests/messages/addIPFSMessage.test.ts
@@ -107,6 +107,19 @@ describe("Add Offchain Message", function () {
         }
     });
 
+    it("should successfully add onchain message", async function () {
+        const f = ExtrinsicHelper.addOnChainMessage(keys, dummySchemaId, "0xdeadbeef");
+        const [event] = await f.fundAndSend();
+
+        assert.notEqual(event, undefined, "should have returned a MessagesStored event");
+        if (event && f.api.events.messages.MessagesStored.is(event)) {
+            messageBlockNumber = event.data.blockNumber;
+            assert.deepEqual(event.data.schemaId, dummySchemaId, 'schema ids should be equal');
+            assert.notEqual(event.data.blockNumber, undefined, 'should have a block number');
+            assert.equal(event.data.count.toNumber(), 1, "message count should be 1");
+        }
+    });
+
     it("should successfully retrieve added message and returned CID should have Base32 encoding", async function () {
         const f = await firstValueFrom(ExtrinsicHelper.api.rpc.messages.getBySchemaId(schemaId, { from_block: starting_block, from_index: 0, to_block: starting_block + 999, page_size: 999 }));
         const response: MessageResponse = f.content[f.content.length - 1];

--- a/integration-tests/messages/addIPFSMessage.test.ts
+++ b/integration-tests/messages/addIPFSMessage.test.ts
@@ -53,6 +53,10 @@ describe("Add Offchain Message", function () {
         }
     })
 
+    after(async function () {
+        await ipfs_node.stop();
+    });
+
     it('should fail if insufficient funds', async function () {
         await assert.rejects(ExtrinsicHelper.addIPFSMessage(keys, schemaId, ipfs_cid_64, ipfs_payload_len).signAndSend(), {
             message: /Inability to pay some fees/,
@@ -126,4 +130,5 @@ describe("Add Offchain Message", function () {
         const cid = Buffer.from(response.cid.unwrap()).toString();
         assert.equal(cid, ipfs_cid_32, 'returned CID should match base32-encoded CID');
     })
+
 });

--- a/integration-tests/messages/addIPFSMessage.test.ts
+++ b/integration-tests/messages/addIPFSMessage.test.ts
@@ -53,10 +53,6 @@ describe("Add Offchain Message", function () {
         }
     })
 
-    after(async function () {
-        await ipfs_node.stop();
-    });
-
     it('should fail if insufficient funds', async function () {
         await assert.rejects(ExtrinsicHelper.addIPFSMessage(keys, schemaId, ipfs_cid_64, ipfs_payload_len).signAndSend(), {
             message: /Inability to pay some fees/,

--- a/integration-tests/messages/addIPFSMessage.test.ts
+++ b/integration-tests/messages/addIPFSMessage.test.ts
@@ -107,19 +107,6 @@ describe("Add Offchain Message", function () {
         }
     });
 
-    it("should successfully add onchain message", async function () {
-        const f = ExtrinsicHelper.addOnChainMessage(keys, dummySchemaId, "0xdeadbeef");
-        const [event] = await f.fundAndSend();
-
-        assert.notEqual(event, undefined, "should have returned a MessagesStored event");
-        if (event && f.api.events.messages.MessagesStored.is(event)) {
-            messageBlockNumber = event.data.blockNumber;
-            assert.deepEqual(event.data.schemaId, dummySchemaId, 'schema ids should be equal');
-            assert.notEqual(event.data.blockNumber, undefined, 'should have a block number');
-            assert.equal(event.data.count.toNumber(), 1, "message count should be 1");
-        }
-    });
-
     it("should successfully retrieve added message and returned CID should have Base32 encoding", async function () {
         const f = await firstValueFrom(ExtrinsicHelper.api.rpc.messages.getBySchemaId(schemaId, { from_block: starting_block, from_index: 0, to_block: starting_block + 999, page_size: 999 }));
         const response: MessageResponse = f.content[f.content.length - 1];
@@ -127,4 +114,29 @@ describe("Add Offchain Message", function () {
         assert.equal(cid, ipfs_cid_32, 'returned CID should match base32-encoded CID');
     })
 
+    describe("Add OnChain Message and successfully retrieve it", function () {
+        it("should successfully add and retrieve an onchain message", async function () {
+            const f = ExtrinsicHelper.addOnChainMessage(keys, dummySchemaId, "0xdeadbeef");
+            const [event] = await f.fundAndSend();
+
+            assert.notEqual(event, undefined, "should have returned a MessagesStored event");
+            if (event && f.api.events.messages.MessagesStored.is(event)) {
+                messageBlockNumber = event.data.blockNumber;
+                assert.deepEqual(event.data.schemaId, dummySchemaId, 'schema ids should be equal');
+                assert.notEqual(event.data.blockNumber, undefined, 'should have a block number');
+                assert.equal(event.data.count.toNumber(), 1, "message count should be 1");
+            }
+
+            const get = await firstValueFrom(ExtrinsicHelper.api.rpc.messages.getBySchemaId(
+                    dummySchemaId,
+                    { from_block: starting_block,
+                    from_index: 0,
+                    to_block: starting_block + 999,
+                    page_size: 999
+                    }
+                ));
+            const response: MessageResponse = get.content[get.content.length - 1];
+            assert.equal(response.payload, "0xdeadbeef", "payload should be 0xdeadbeef");
+        });
+    });
 });

--- a/integration-tests/scaffolding/extrinsicHelpers.ts
+++ b/integration-tests/scaffolding/extrinsicHelpers.ts
@@ -218,6 +218,10 @@ export class ExtrinsicHelper {
         return ExtrinsicHelper.apiPromise.query.schemas.governanceSchemaModelMaxBytes();
     }
 
+    public static getCurrentMsaIdentifierMaximum() {
+        return ExtrinsicHelper.apiPromise.query.msa.currentMsaIdentifierMaximum();
+    }
+
     /** Balance Extrinsics */
     public static transferFunds(keys: KeyringPair, dest: KeyringPair, amount: Compact<u128> | AnyNumber): Extrinsic {
         return new Extrinsic(() => ExtrinsicHelper.api.tx.balances.transfer(dest.address, amount), keys, ExtrinsicHelper.api.events.balances.Transfer);

--- a/integration-tests/scaffolding/helpers.ts
+++ b/integration-tests/scaffolding/helpers.ts
@@ -283,7 +283,3 @@ export async function getRemainingCapacity(providerId: u64): Promise<u128> {
   const capacityStaked = (await firstValueFrom(ExtrinsicHelper.api.query.capacity.capacityLedger(providerId))).unwrap();
   return capacityStaked.remainingCapacity;
 }
-// export async function getCapacityFee(providerId: u64): Promise<u128> {
-//   const capacityFee = (await firstValueFrom(ExtrinsicHelper.api.query.capacity.capacityLedger(providerId))).unwrap();
-//   return capacityStaked.;
-// }

--- a/integration-tests/scaffolding/helpers.ts
+++ b/integration-tests/scaffolding/helpers.ts
@@ -1,6 +1,6 @@
 import { Keyring } from "@polkadot/api";
 import { KeyringPair } from "@polkadot/keyring/types";
-import { u16, u32, u64, Option} from "@polkadot/types";
+import { u16, u32, u64, Option, u128} from "@polkadot/types";
 import { Codec } from "@polkadot/types/types";
 import { u8aToHex, u8aWrapBytes } from "@polkadot/util";
 import { mnemonicGenerate } from '@polkadot/util-crypto';
@@ -8,6 +8,7 @@ import { env } from "./env";
 import {
   AddKeyData,
   AddProviderPayload,
+  EventMap,
   ExtrinsicHelper,
   ItemizedSignaturePayload, PaginatedDeleteSignaturePayload,
   PaginatedUpsertSignaturePayload
@@ -274,3 +275,15 @@ export async function createGraphChangeSchema(): Promise<u16> {
 }
 
 export const TokenPerCapacity = 50n;
+
+export function assertEvent(events: EventMap, eventName: string) {
+  assert(events.hasOwnProperty(eventName));
+}
+export async function getRemainingCapacity(providerId: u64): Promise<u128> {
+  const capacityStaked = (await firstValueFrom(ExtrinsicHelper.api.query.capacity.capacityLedger(providerId))).unwrap();
+  return capacityStaked.remainingCapacity;
+}
+// export async function getCapacityFee(providerId: u64): Promise<u128> {
+//   const capacityFee = (await firstValueFrom(ExtrinsicHelper.api.query.capacity.capacityLedger(providerId))).unwrap();
+//   return capacityStaked.;
+// }

--- a/scripts/run_integration_tests.sh
+++ b/scripts/run_integration_tests.sh
@@ -144,5 +144,4 @@ npm install
 echo "---------------------------------------------"
 echo "Starting Tests..."
 echo "---------------------------------------------"
-set -x
 CHAIN_ENVIRONMENT=$CHAIN_ENVIRONMENT WS_PROVIDER_URL="$PROVIDER_URL" npm run $NPM_RUN_COMMAND


### PR DESCRIPTION
# Goal
The goal of this PR is to implement additional end to end tests for capacity.
This PR will also add a test to add an on-chain message, as it was needed to test all pay_with_capacity eligible calls.

Closes #1226
Closes #1478

# Discussion
- Test staking from different msa targeting the same provider.
- Implement helper `getCurrentMsaIdentifierMaximum` to make sure that tests can always specify an invalid target.
- Test all capacity-eligible extrinsics.
- Refactor `assertEvent` into `helpers.ts` for use in multiple test files.
- Add test for on-chain message to `addIPFSMessage.test.ts`, needed to test `pay_with_capacity`

# Checklist
- [ ] Chain spec updated
- [ ] Custom RPC OR Runtime API added/changed? Updated js/api-augment.
- [ ] Design doc(s) updated
- [x] Tests added
- [ ] Benchmarks added
- [ ] Weights updated
