### PR TITLE
refactor: feature frequency-local => frequency-rococo-local

### DIFF
--- a/.env.sample
+++ b/.env.sample
@@ -1,6 +1,6 @@
 RUST_TOOLCHAIN=nightly
 RELAY_CHAIN_SPEC=./resources/rococo-local.json
-PARA_CHAIN_CONFIG=frequency-local
+PARA_CHAIN_CONFIG=frequency-rococo-local
 RAW_PARACHAIN_CHAIN_SPEC=./res/genesis/local/rococo-local-frequency-2000-raw.json
 PARA_ID=2000
 DOCKER_ONBOARD=false

--- a/.github/workflows/merge-pr.yml
+++ b/.github/workflows/merge-pr.yml
@@ -41,7 +41,7 @@ jobs:
           toolchain: stable
       - name: Output Metadata
         # Run the cargo command and ignore any extra lines outside of the json result
-        run: CARGO_INCREMENTAL=0 RUSTFLAGS="-D warnings" cargo run --features frequency-rococo-local -- export-metadata  --chain=frequency-local --tmp ./js/api-augment/metadata.json
+        run: CARGO_INCREMENTAL=0 RUSTFLAGS="-D warnings" cargo run --features frequency-rococo-local -- export-metadata  --chain=frequency-rococo-local --tmp ./js/api-augment/metadata.json
       - name: Set up NodeJs
         uses: actions/setup-node@v3
         with:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -152,12 +152,16 @@ jobs:
       matrix:
         # os: [[self-hosted, Linux, X64, build], [self-hosted, Linux, ARM64,  build]]
         os: [[self-hosted, Linux, X64, build]]
-        network: [local, rococo, mainnet]
+        network: [dev, local, rococo, mainnet]
         include:
+          - network: dev
+            spec: frequency-no-relay
+            build-profile: release
+            release-file-name-prefix: frequency-dev
           - network: local
             spec: frequency-rococo-local
             build-profile: release
-            release-file-name-prefix: frequency-local
+            release-file-name-prefix: frequency-rococo-local
           - network: rococo
             spec: frequency-rococo-testnet
             build-profile: production
@@ -389,7 +393,7 @@ jobs:
       CHAIN_SPEC: frequency-rococo-local
       BUILD_PROFILE: release
       BIN_DIR: target/release
-      RELEASE_FILENAME_PREFIX: frequency-local
+      RELEASE_FILENAME_PREFIX: frequency-rococo-local
       ARCH: amd64
     runs-on: ubuntu-20.04
     steps:
@@ -423,7 +427,7 @@ jobs:
           mv ${{env.RELEASE_BIN_FILENAME}} ${{env.BIN_DIR}}
           chmod 755 ${{env.BIN_DIR}}/${{env.RELEASE_BIN_FILENAME}}
       - name: Output Metadata
-        run: ${{env.BIN_DIR}}/${{env.RELEASE_BIN_FILENAME}} export-metadata --chain=frequency-local --tmp ./js/api-augment/metadata.json
+        run: ${{env.BIN_DIR}}/${{env.RELEASE_BIN_FILENAME}} export-metadata --chain=frequency-rococo-local --tmp ./js/api-augment/metadata.json
       - name: Build
         run: npm run build
         working-directory: js/api-augment

--- a/.github/workflows/verify-pr-commit.yml
+++ b/.github/workflows/verify-pr-commit.yml
@@ -447,7 +447,7 @@ jobs:
         run: |
           chmod 755 ${{env.BIN_FILENAME}}
       - name: Output Metadata
-        run: ${{env.BIN_DIR}}/${{env.BIN_FILENAME}} export-metadata  --chain=frequency-local --tmp ./js/api-augment/metadata.json
+        run: ${{env.BIN_DIR}}/${{env.BIN_FILENAME}} export-metadata  --chain=frequency-rococo-local --tmp ./js/api-augment/metadata.json
       - name: Build
         run: npm run build
         working-directory: js/api-augment
@@ -615,9 +615,9 @@ jobs:
         working-directory: ${{env.BIN_DIR}}
         run: |
           set -x
-          ./$REF_BIN_FILENAME export-metadata --chain=frequency-local --tmp metadata-ref.json
+          ./$REF_BIN_FILENAME export-metadata --chain=frequency-rococo-local --tmp metadata-ref.json
           metadata_ref=$(cat metadata-ref.json | jq -r .result)
-          ./$TEST_BIN_FILENAME export-metadata --chain=frequency-local --tmp metadata.json
+          ./$TEST_BIN_FILENAME export-metadata --chain=frequency-rococo-local --tmp metadata.json
           metadata=$(cat metadata.json | jq -r .result)
           match=$([ "$metadata" = "$metadata_ref" ] && echo 'true' || echo 'false')
           echo "Metadata matches?: $match"

--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,7 @@
 UNAME := $(shell uname)
 
 .PHONY: all
-all: start
+all: build
 
 .PHONY: clean
 clean:

--- a/node/cli/src/cli.rs
+++ b/node/cli/src/cli.rs
@@ -79,17 +79,13 @@ pub struct Cli {
 	/// Instant block sealing
 	/// Blocks are triggered to be formed each time a transaction hits the validated transaction pool
 	/// Empty blocks can also be formed using the `engine_createBlock` RPC
-	///
-	/// Can only be used with frequency-no-relay and frequency-rococo-local feature flags
-	#[cfg(any(feature = "frequency-no-relay", feature = "frequency-rococo-local"))]
+	#[cfg(feature = "frequency-no-relay")]
 	#[clap(long = "instant-sealing")]
 	pub instant_sealing: bool,
 
 	/// Manual block sealing
 	/// Blocks are only formed using the `engine_createBlock` RPC
-	///
-	/// Can only be used with frequency-no-relay and frequency-rococo-local feature flags
-	#[cfg(any(feature = "frequency-no-relay", feature = "frequency-rococo-local"))]
+	#[cfg(feature = "frequency-no-relay")]
 	#[clap(long = "manual-sealing")]
 	pub manual_sealing: bool,
 }

--- a/node/cli/src/command.rs
+++ b/node/cli/src/command.rs
@@ -34,7 +34,7 @@ impl IdentifyChain for dyn sc_service::ChainSpec {
 			ChainIdentity::Frequency
 		} else if self.id() == "frequency-rococo" {
 			ChainIdentity::FrequencyRococo
-		} else if self.id() == "frequency-local" {
+		} else if self.id() == "frequency-rococo-local" {
 			ChainIdentity::FrequencyLocal
 		} else if self.id() == "dev" {
 			ChainIdentity::FrequencyDev
@@ -72,10 +72,10 @@ fn load_spec(id: &str) -> std::result::Result<Box<dyn ChainSpec>, String> {
 		"dev" | "frequency-no-relay" =>
 			return Ok(Box::new(chain_spec::frequency_rococo::development_config())),
 		#[cfg(feature = "frequency-rococo-local")]
-		"frequency-local" | "frequency-rococo-local" =>
+		"frequency-rococo-local" =>
 			return Ok(Box::new(chain_spec::frequency_rococo::local_testnet_config())),
 		#[cfg(feature = "frequency-rococo-testnet")]
-		"frequency-rococo" | "rococo" | "testnet" =>
+		"frequency-rococo-testnet" | "frequency-rococo" | "rococo" | "testnet" =>
 			return Ok(Box::new(chain_spec::frequency_rococo::load_frequency_rococo_spec())),
 		path => {
 			if path.is_empty() {

--- a/node/service/src/chain_spec/frequency_rococo.rs
+++ b/node/service/src/chain_spec/frequency_rococo.rs
@@ -115,7 +115,7 @@ pub fn local_testnet_config() -> ChainSpec {
 		// Name
 		"Frequency Local Testnet",
 		// ID
-		"frequency-local",
+		"frequency-rococo-local",
 		ChainType::Local,
 		move || {
 			testnet_genesis(
@@ -168,7 +168,7 @@ pub fn local_testnet_config() -> ChainSpec {
 		// Telemetry
 		None,
 		// Protocol ID
-		Some("frequency-local"),
+		Some("frequency-rococo-local"),
 		// Fork ID
 		None,
 		// Properties

--- a/scripts/generate_js_definitions.sh
+++ b/scripts/generate_js_definitions.sh
@@ -21,7 +21,7 @@ then
     echo -e "${NC}"
     echo -e "${STEP_COLOR}Generating using CLI...${NC}"
     rm -f ./js/api-augment/metadata.json
-    cargo run --features frequency-rococo-local -- export-metadata --tmp --chain=frequency-local ./js/api-augment/metadata.json
+    cargo run --features frequency-rococo-local -- export-metadata --tmp --chain=frequency-rococo-local ./js/api-augment/metadata.json
     # cd into js dir
     cd "js/api-augment"
     npm install # in case things have changed

--- a/scripts/generate_specs.sh
+++ b/scripts/generate_specs.sh
@@ -19,7 +19,7 @@ case $build_step in
   rococo-2000)
     mkdir -p ./res/genesis/local
     echo "Building Spec for  frequency rococo localnet paraid=2000"
-    $PWD/target/$profile/frequency build-spec --disable-default-bootnode --chain=frequency-local > ./res/genesis/local/frequency-spec-rococo.json
+    $PWD/target/$profile/frequency build-spec --disable-default-bootnode --chain=frequency-rococo-local > ./res/genesis/local/frequency-spec-rococo.json
     sed -i.bu "s/\"parachainId\": 2000/\"parachainId\": $parachain_id/g" ./res/genesis/local/frequency-spec-rococo.json
     sed -i.bu "s/\"para_id\": 2000/\"para_id\": $parachain_id/g" ./res/genesis/local/frequency-spec-rococo.json
     $PWD/target/$profile/frequency build-spec --raw --disable-default-bootnode --chain ./res/genesis/local/frequency-spec-rococo.json > ./res/genesis/local/rococo-local-frequency-2000-raw.json

--- a/scripts/init.sh
+++ b/scripts/init.sh
@@ -54,7 +54,7 @@ start-frequency)
   fi
 
   ./scripts/run_collator.sh \
-    --chain="frequency-local" --alice \
+    --chain="frequency-rococo-local" --alice \
     --base-path=$parachain_dir/data \
     --wasm-execution=compiled \
     --execution=wasm \
@@ -146,7 +146,7 @@ start-frequency-container)
   frequency_ws_port="${Frequency_WS_PORT:-$frequency_default_ws_port}"
 
   ./scripts/run_collator.sh \
-    --chain="frequency-local" --alice \
+    --chain="frequency-rococo-local" --alice \
     --base-path=$parachain_dir/data \
     --wasm-execution=compiled \
     --execution=wasm \
@@ -176,11 +176,11 @@ onboard-frequency-rococo-local)
 
    wasm_location="$onboard_dir/${parachain}-${para_id}.wasm"
     if [ "$docker_onboard" == "true" ]; then
-      genesis=$(docker run -it {REPO_NAME}/frequency:${frequency_docker_image_tag} export-genesis-state --chain="frequency-local")
-      docker run -it {REPO_NAME}/frequency:${frequency_docker_image_tag} export-genesis-wasm --chain="frequency-local" > $wasm_location
+      genesis=$(docker run -it {REPO_NAME}/frequency:${frequency_docker_image_tag} export-genesis-state --chain="frequency-rococo-local")
+      docker run -it {REPO_NAME}/frequency:${frequency_docker_image_tag} export-genesis-wasm --chain="frequency-rococo-local" > $wasm_location
     else
-      genesis=$(./target/release/frequency export-genesis-state --chain="frequency-local")
-      ./target/release/frequency export-genesis-wasm --chain="frequency-local" > $wasm_location
+      genesis=$(./target/release/frequency export-genesis-state --chain="frequency-rococo-local")
+      ./target/release/frequency export-genesis-wasm --chain="frequency-rococo-local" > $wasm_location
     fi
 
   echo "WASM path:" "${wasm_location}"


### PR DESCRIPTION
- Renamed feature `frequency-local` => `frequency-rococo-local`

**IMPORTANT**: The release filename prefix also changes to: `frequency-rococo-local`

Misc changes
- Changed default `Makefile` target to not start the chain automatically
- Updated `--instant-sealing `and `--manual-sealing `CLI options to only build for `frequency-no-relay.`  Removed obsolete option description.

# Goal
The goal of this PR is to rename the `frequency-local` feature to `frequency-rococo-local` and provide some cleanup for #1401 .

Closes  #1488 
