### PR TITLE
Message Integration Tests on Rococo

### DIFF
--- a/.github/workflows/verify-pr-commit.yml
+++ b/.github/workflows/verify-pr-commit.yml
@@ -678,7 +678,7 @@ jobs:
       - name: Run Integration Tests
         working-directory: integration-tests
         run: |
-          WS_PROVIDER_URL="ws://127.0.0.1:9944" npm test
+          CHAIN_ENVIRONMENT="local" TEST_CHAIN_VALIDATION="instant_finality" WS_PROVIDER_URL="ws://127.0.0.1:9944" npm test
       - name: Stop Local Node
         if: always()
         run: pkill ${{env.FREQUENCY_PROCESS_NAME}}

--- a/integration-tests/.relay-chain.mocharc.json
+++ b/integration-tests/.relay-chain.mocharc.json
@@ -10,7 +10,7 @@
     ],
     "loader": "ts-node/esm",
     "spec": [
-        "./{,!(node_modules|load-tests)/**}/createMsa.test.ts"
+        "./{,!(node_modules|load-tests)/**}/{createMsa,addIPFSMessage}.test.ts"
     ],
     "timeout": 200000
 }

--- a/integration-tests/messages/addIPFSMessage.test.ts
+++ b/integration-tests/messages/addIPFSMessage.test.ts
@@ -14,6 +14,7 @@ describe("Add Offchain Message", function () {
     // the test chain validation is "instant_finality". Running against a live
     // chain doesn't bump into this problem because the timeouts are higher.
     if (process.env.TEST_CHAIN_VALIDATION === "instant_finality") {
+        console.log("OVERRIDDING TIMEOUT!!!!!");
         this.timeout(5000);
     }
 

--- a/integration-tests/messages/addIPFSMessage.test.ts
+++ b/integration-tests/messages/addIPFSMessage.test.ts
@@ -10,6 +10,13 @@ import { firstValueFrom } from "rxjs";
 import { MessageResponse } from "@frequency-chain/api-augment/interfaces";
 
 describe("Add Offchain Message", function () {
+    // Increase global timeout to allow for the IPFS node startup when
+    // the test chain validation is "instant_finality". Running against a live
+    // chain doesn't bump into this problem because the timeouts are higher.
+    if (process.env.TEST_CHAIN_VALIDATION === "instant_finality") {
+        this.timeout(5000);
+    }
+
     let keys: KeyringPair;
     let schemaId: u16;
     let dummySchemaId: u16;

--- a/integration-tests/messages/addIPFSMessage.test.ts
+++ b/integration-tests/messages/addIPFSMessage.test.ts
@@ -2,7 +2,7 @@ import "@frequency-chain/api-augment";
 import { KeyringPair } from "@polkadot/keyring/types";
 import { PARQUET_BROADCAST } from "../schemas/fixtures/parquetBroadcastSchemaType";
 import assert from "assert";
-import { createAndFundKeypair, devAccounts } from "../scaffolding/helpers";
+import { createAndFundKeypair } from "../scaffolding/helpers";
 import { ExtrinsicHelper } from "../scaffolding/extrinsicHelpers";
 import { u16, u32 } from "@polkadot/types";
 import { loadIpfs, getBases } from "./loadIPFS";
@@ -49,7 +49,7 @@ describe("Add Offchain Message", function () {
         if (dummySchemaEvent && createDummySchema.api.events.schemas.SchemaCreated.is(dummySchemaEvent)) {
             [, dummySchemaId] = dummySchemaEvent.data;
         }
-    })
+    });
 
     it('should fail if insufficient funds', async function () {
         await assert.rejects(ExtrinsicHelper.addIPFSMessage(keys, schemaId, ipfs_cid_64, ipfs_payload_len).signAndSend(), {
@@ -136,5 +136,9 @@ describe("Add Offchain Message", function () {
             const response: MessageResponse = get.content[get.content.length - 1];
             assert.equal(response.payload, "0xdeadbeef", "payload should be 0xdeadbeef");
         });
+    });
+
+    after(async function() {
+        ipfs_node.stop();
     });
 });

--- a/integration-tests/messages/addIPFSMessage.test.ts
+++ b/integration-tests/messages/addIPFSMessage.test.ts
@@ -14,7 +14,6 @@ describe("Add Offchain Message", function () {
     // the test chain validation is "instant_finality". Running against a live
     // chain doesn't bump into this problem because the timeouts are higher.
     if (process.env.TEST_CHAIN_VALIDATION === "instant_finality") {
-        console.log("OVERRIDDING TIMEOUT!!!!!");
         this.timeout(5000);
     }
 

--- a/integration-tests/messages/loadIPFS.js
+++ b/integration-tests/messages/loadIPFS.js
@@ -3,7 +3,7 @@
 // but our integration tests are CommonJS. Some other dependency issues encountered
 // in attempting to make the integration tests ES; may re-attempt at a later date.
 exports.loadIpfs = async () => {
-    const { create } = await import('ipfs')
+    const { create } = await import('ipfs-core');
 
     const node = await create();
 

--- a/integration-tests/scaffolding/rootHooks.ts
+++ b/integration-tests/scaffolding/rootHooks.ts
@@ -8,7 +8,7 @@ exports.mochaHooks = {
     async beforeAll() {
         await ExtrinsicHelper.initialize();
 
-        if (process.env.CHAIN_ENVIRONMENT == "rococo") {
+        if (process.env.CHAIN_ENVIRONMENT === "rococo") {
             const seed_phrase = process.env.FUNDING_ACCOUNT_SEED_PHRASE;
 
             if (seed_phrase === undefined) {

--- a/integration-tests/scaffolding/rootHooks.ts
+++ b/integration-tests/scaffolding/rootHooks.ts
@@ -9,7 +9,12 @@ exports.mochaHooks = {
         await ExtrinsicHelper.initialize();
 
         if (process.env.CHAIN_ENVIRONMENT == "rococo") {
-            const seed_phrase = "Place holder for seed phrase";
+            const seed_phrase = process.env.FUNDING_ACCOUNT_SEED_PHRASE;
+            console.log("SEED_PHRASE:", seed_phrase);
+            if (seed_phrase === undefined) {
+                console.error("FUNDING_ACCOUNT_SEED_PHRASE must not be undefined when CHAIN_ENVIRONMENT is \"rococo\"");
+                process.exit(1);
+            }
             rococoAccounts.push({
                 uri: "RococoTestRunnerAccount",
                 keys: createKeys(seed_phrase),

--- a/integration-tests/scaffolding/rootHooks.ts
+++ b/integration-tests/scaffolding/rootHooks.ts
@@ -10,11 +10,12 @@ exports.mochaHooks = {
 
         if (process.env.CHAIN_ENVIRONMENT == "rococo") {
             const seed_phrase = process.env.FUNDING_ACCOUNT_SEED_PHRASE;
-            console.log("SEED_PHRASE:", seed_phrase);
+
             if (seed_phrase === undefined) {
                 console.error("FUNDING_ACCOUNT_SEED_PHRASE must not be undefined when CHAIN_ENVIRONMENT is \"rococo\"");
                 process.exit(1);
             }
+
             rococoAccounts.push({
                 uri: "RococoTestRunnerAccount",
                 keys: createKeys(seed_phrase),

--- a/scripts/run_integration_tests.sh
+++ b/scripts/run_integration_tests.sh
@@ -72,6 +72,9 @@ case "${CHAIN}" in
         NPM_RUN_COMMAND="test:relay"
         CHAIN_ENVIRONMENT="rococo"
         BLOCK_SEALING="instant"
+
+        read -p "Enter the seed phrase for the Frequency Rococo account funding source: " FUNDING_ACCOUNT_SEED_PHRASE
+
     ;;
 esac
 
@@ -144,4 +147,5 @@ npm install
 echo "---------------------------------------------"
 echo "Starting Tests..."
 echo "---------------------------------------------"
-CHAIN_ENVIRONMENT=$CHAIN_ENVIRONMENT WS_PROVIDER_URL="$PROVIDER_URL" npm run $NPM_RUN_COMMAND
+
+CHAIN_ENVIRONMENT=$CHAIN_ENVIRONMENT FUNDING_ACCOUNT_SEED_PHRASE=$FUNDING_ACCOUNT_SEED_PHRASE WS_PROVIDER_URL="$PROVIDER_URL" npm run $NPM_RUN_COMMAND


### PR DESCRIPTION
# Goal
The goal of this PR is to allow Message related integration tests to execute successfully both in instant sealing and Frequency on Rococo environments.

Closes #1504
Closes #1479 

# Discussion
- When `make integration-test-rococo` is run, the funding source seed phrase is now read from standard input
- Hard coded timeouts in `addIPFSMessage.test` are removed in favor of the global timeouts set in the Mocha config files: `.mocharc.json` and `.relay-chain.mocharc` 
  - A future issue to fine tune timeout values is described here https://github.com/LibertyDSNP/frequency/issues/1458#issuecomment-1540833750

