### PR TITLE
build: Restore make-start to wasm execution; Add make-start-native;

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -11,6 +11,9 @@ clean:
 start:
 	./scripts/init.sh start-frequency-instant
 
+start-native:
+	./scripts/init.sh start-frequency-native
+
 start-relay:
 	./scripts/init.sh start-relay-chain
 

--- a/scripts/init.sh
+++ b/scripts/init.sh
@@ -86,6 +86,36 @@ start-frequency-instant)
     -lruntime=debug \
     --instant-sealing \
     --wasm-execution=compiled \
+    --execution=wasm \
+    --no-telemetry \
+    --no-prometheus \
+    --port $((30333)) \
+    --rpc-port $((9933)) \
+    --ws-port $((9944)) \
+    --rpc-external \
+    --rpc-cors all \
+    --ws-external \
+    --rpc-methods=Unsafe \
+    --tmp
+  ;;
+
+start-frequency-native)
+  printf "\nBuilding Frequency with runtime instant sealing, natvie execution ...\n"
+  cargo build --features frequency-no-relay
+
+  parachain_dir=$base_dir/parachain/${para_id}
+  mkdir -p $parachain_dir;
+
+  if [ "$2" == "purge" ]; then
+    echo "purging parachain..."
+    rm -rf $parachain_dir
+  fi
+
+  ./target/debug/frequency \
+    --dev \
+    -lruntime=debug \
+    --instant-sealing \
+    --wasm-execution=compiled \
     --execution=native \
     --no-telemetry \
     --no-prometheus \


### PR DESCRIPTION
# Goal
The goal of this PR is to restore make-start to wasm execution and add make-start-native target to Makefile.
Closes #1513 

# Discussion
- `make-start` will return to starting an instant-sealing node, with `--execution=wasm`.  This configuration more closely matches that of main-net for reproducing behavior.
- `make-start-native` will start an instant-sealing node with `--execution=native`. This configuration will be used for attaching a debugger to the native runtime when encountering bugs.

# Checklist
- [ ] Chain spec updated
- [ ] Custom RPC OR Runtime API added/changed? Updated js/api-augment.
- [ ] Design doc(s) updated
- [ ] Tests added
- [ ] Benchmarks added
- [ ] Weights updated
