### PR TITLE
Build Optimization and Fix script warning

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -340,7 +340,7 @@ jobs:
       - name: Install subwasm
         if: steps.cache-wasm.outputs.cache-hit != 'true'
         run: |
-          cargo install --locked --git https://github.com/chevdor/subwasm --tag v0.18.0 --force
+          cargo install --locked --git https://github.com/chevdor/subwasm --tag v0.19.1 --force
           subwasm --version
       - name: Test WASM file
         if: steps.cache-wasm.outputs.cache-hit != 'true'
@@ -703,7 +703,7 @@ jobs:
           ls -la
       - name: Install subwasm
         run: |
-          cargo install --locked --git https://github.com/chevdor/subwasm --tag v0.18.0 --force
+          cargo install --locked --git https://github.com/chevdor/subwasm --tag v0.19.1 --force
           subwasm --version
       - name: Get Runtimes Info
         id: get-runtimes-info

--- a/README.md
+++ b/README.md
@@ -17,6 +17,7 @@ Frequency is a [Polkadot](https://www.parity.io/technologies/polkadot) parachain
 # Table of Contents
 
 - [Table of Contents](#table-of-contents)
+- [Security]
 - [Prerequisites](#prerequisites)
   - [Hardware](#hardware)
 - [Build](#build)
@@ -39,6 +40,7 @@ Frequency is a [Polkadot](https://www.parity.io/technologies/polkadot) parachain
 - [Verify Runtime](#verify-runtime)
 - [Local Runtime Upgrade](#local-runtime-upgrade)
 - [Contributing](#contributing)
+- [Security Issue Reporting](#security-issue-reporting)
 - [Additional Resources](#additional-resources)
 - [Miscellaneous](#miscellaneous)
 
@@ -313,6 +315,11 @@ The current scripts follow this process for upgrading locally:
 Interested in contributing?
 Wonderful!
 Please check out [the information here](./CONTRIBUTING.md).
+
+# Security Issue Reporting
+
+Do you know of an on-chain vulnerability (or possible one) that can lead to economic loss, privacy loss, or instability of the network?
+Please report it to [security@frequency.xyz](mailto:security@frequency.xyz)
 
 # Additional Resources
 

--- a/pallets/handles/src/handles-utils/build.rs
+++ b/pallets/handles/src/handles-utils/build.rs
@@ -14,6 +14,10 @@ fn allowed_char(c: char) -> bool {
 
 #[allow(clippy::unwrap_used)]
 fn main() {
+	println!("cargo:rerun-if-changed=build.rs");
+	println!("cargo:rerun-if-changed=src/data/confusable_characters.txt");
+	println!("cargo:rerun-if-changed=constants.rs");
+
 	let input_file = File::open("src/data/confusable_characters.txt");
 	assert!(input_file.is_ok());
 	let path = Path::new(&env::var("OUT_DIR").unwrap()).join("confusables.rs");
@@ -57,8 +61,4 @@ fn main() {
 		}
 	}
 	_ = output_file.write_all(b"};\n\n");
-
-	println!("cargo:rerun-if-changed=build.rs");
-	println!("cargo:rerun-if-changed=data/confusable_characters.txt");
-	println!("cargo:rerun-if-changed=constants.rs");
 }

--- a/scripts/init.sh
+++ b/scripts/init.sh
@@ -66,7 +66,7 @@ start-frequency)
     --rpc-cors all \
     --ws-external \
     --rpc-methods=Unsafe \
-    --state-cache-size 0 \
+    --trie-cache-size 0 \
   ;;
 
 start-frequency-instant)
@@ -188,7 +188,7 @@ start-frequency-container)
     --rpc-cors all \
     --ws-external \
     --rpc-methods=Unsafe \
-    --state-cache-size 0 \
+    --trie-cache-size 0 \
   ;;
 
 register-frequency-rococo-local)

--- a/tools/scripts/pallet-info.sh
+++ b/tools/scripts/pallet-info.sh
@@ -13,7 +13,7 @@ fi
 
 
 echo "checking for 🏭 subwasm and installing if needed..."
-which subwasm || cargo install --locked --git https://github.com/chevdor/subwasm --tag v0.18.0
+which subwasm || cargo install --locked --git https://github.com/chevdor/subwasm --tag v0.19.1
 
 ws_provider=$1
 


### PR DESCRIPTION
# Goal
The goal of this PR is a few different cleanups:

- Upgrade subwasm to 0.19.1
- Add security email to the Readme
- Fix trie-cache-size error
- fix build speed issue in handles-util/build.rs

Closes #1447
Closes #1499 

# How to test
- Build issue: You can now run `make build` and then `make build` and the second one will not redo stuff
- Trie-cache-size: `make start-frequency` will not show the warning

