### PR TITLE
Replace production profile with release profile

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -164,11 +164,11 @@ jobs:
             release-file-name-prefix: frequency-rococo-local
           - network: rococo
             spec: frequency-rococo-testnet
-            build-profile: production
+            build-profile: release
             release-file-name-prefix: frequency-rococo
           - network: mainnet
             spec: frequency
-            build-profile: production
+            build-profile: release
             release-file-name-prefix: frequency
           - os: [self-hosted, Linux, X64, build]
             arch: amd64
@@ -261,7 +261,7 @@ jobs:
         network: [rococo, mainnet]
         include:
           - network: rococo
-            build-profile: production
+            build-profile: release
             package: frequency-runtime
             runtime-dir: runtime/frequency
             built-wasm-file-name-prefix: frequency_runtime
@@ -269,7 +269,7 @@ jobs:
             features: frequency-rococo-testnet
             wasm-core-version: frequency-rococo
           - network: mainnet
-            build-profile: production
+            build-profile: release
             package: frequency-runtime
             runtime-dir: runtime/frequency
             built-wasm-file-name-prefix: frequency_runtime
@@ -449,7 +449,7 @@ jobs:
         include:
           - network: mainnet
             spec: frequency
-            build-profile: production
+            build-profile: release
             release-file-name-prefix: frequency
           - os: ubuntu-20.04
             arch: amd64
@@ -491,13 +491,13 @@ jobs:
     name: Compare Metadata
     runs-on: ubuntu-20.04
     env:
-      BIN_DIR: target/production
+      BIN_DIR: target/release
       BIN_FILENAME: frequency.amd64
       TEST_BIN_FILENAME: frequency.amd64
       TEST_DOWNLOAD_DIR: download-test
       REF_BIN_FILENAME: frequency-ref.amd64
       REF_DOWNLOAD_DIR: download-ref
-      OUTPUT_DIR: target/production
+      OUTPUT_DIR: target/release
       FREQUENCY_PROCESS_NAME: frequency
     steps:
       - name: Set Env Vars
@@ -782,10 +782,10 @@ jobs:
         network: [rococo, mainnet]
         include:
           - network: rococo
-            build-profile: production
+            build-profile: release
             release-file-name-prefix: frequency-rococo
           - network: mainnet
-            build-profile: production
+            build-profile: release
             release-file-name-prefix: frequency
           - arch: amd64
             docker-platform: linux/amd64

--- a/.github/workflows/verify-pr-commit.yml
+++ b/.github/workflows/verify-pr-commit.yml
@@ -318,13 +318,13 @@ jobs:
         network: [rococo, mainnet]
         include:
           - network: rococo
-            build-profile: production
+            build-profile: debug
             package: frequency-runtime
             runtime-dir: runtime/frequency
             built-wasm-file-name-prefix: frequency_runtime
             features: frequency-rococo-testnet
           - network: mainnet
-            build-profile: production
+            build-profile: debug
             package: frequency-runtime
             runtime-dir: runtime/frequency
             built-wasm-file-name-prefix: frequency_runtime

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,12 +10,13 @@ members = [
 
 [profile.release]
 panic = "unwind"
-
-[profile.production]
-inherits = "release"
 lto = true
 codegen-units = 1
 strip = true
 
+# Faster build for bench-dev
 [profile.bench-dev]
 inherits = "release"
+strip = false
+codegen-units = 16
+lto = false

--- a/Makefile
+++ b/Makefile
@@ -142,8 +142,8 @@ benchmarks:
 
 #
 # Target to run benchmarks for local development. Uses the "bench-dev" profile,
-# since "production" is unnecessary in local development, and by using "bench-dev"
-# (which is just a clone of "release"), we don't overwrite our "release" target used
+# since "release" is unnecessary in local development, and by using "bench-dev"
+# (which is just a clone of "prodic"), we don't overwrite our "release" target used
 # for development testing.
 .PHONY: benchmarks-local
 benchmarks-local:
@@ -203,32 +203,32 @@ js:
 
 .PHONY: build
 build:
-	cargo build --locked --release --features frequency-no-relay
+	cargo build --features frequency-no-relay
 
 build-benchmarks:
-	cargo build --profile production --features runtime-benchmarks,frequency-lint-check --workspace
+	cargo build --release --features runtime-benchmarks,frequency-lint-check --workspace
 
 build-no-relay:
-	cargo build --locked --features frequency-no-relay
+	cargo build --features frequency-no-relay
 
 build-local:
-	cargo build --locked --features frequency-rococo-local
+	cargo build --features frequency-rococo-local
 
 build-rococo:
-	cargo build --locked --release --features frequency-rococo-testnet
+	cargo build --features frequency-rococo-testnet
 
 build-mainnet:
-	cargo build --locked --release --features frequency
+	cargo build --features frequency
 
 build-rococo-release:
-	cargo build --locked --features frequency-rococo-testnet --profile production
+	cargo build --locked --features frequency-rococo-testnet --release
 
 build-mainnet-release:
-	cargo build --locked --features  frequency --profile production
+	cargo build --locked --features  frequency --release
 
 .PHONY: test
 test:
-	cargo test --workspace --locked --features runtime-benchmarks,frequency-lint-check
+	cargo test --workspace --features runtime-benchmarks,frequency-lint-check
 
 integration-test:
 	./scripts/run_integration_tests.sh

--- a/docker/parachain-node.dockerfile
+++ b/docker/parachain-node.dockerfile
@@ -20,8 +20,8 @@ USER frequency
 
 COPY --from=base /etc/ssl/certs/ca-certificates.crt /etc/ssl/certs/ca-certificates.crt
 # For local testing only
-# COPY --chown=frequency target/production/frequency.amd64 ./frequency/frequency
-COPY --chown=frequency target/production/frequency ./frequency/
+# COPY --chown=frequency target/release/frequency.amd64 ./frequency/frequency
+COPY --chown=frequency target/release/frequency ./frequency/
 
 # 9933 for RPC call
 # 9944 for Websocket

--- a/pallets/capacity/src/weights.rs
+++ b/pallets/capacity/src/weights.rs
@@ -22,7 +22,7 @@
 //! EXECUTION: Some(Wasm), WASM-EXECUTION: Compiled, CHAIN: Some("frequency-bench"), DB CACHE: 1024
 
 // Executed Command:
-// ./scripts/../target/production/frequency
+// ./scripts/../target/release/frequency
 // benchmark
 // pallet
 // --pallet=pallet_capacity

--- a/pallets/frequency-tx-payment/src/capacity_stable_weights.rs
+++ b/pallets/frequency-tx-payment/src/capacity_stable_weights.rs
@@ -27,7 +27,7 @@ use sp_std::marker::PhantomData;
 ///   WEIGHT-METRIC: `Average`, WEIGHT-MUL: `1.0`, WEIGHT-ADD: `0`
 ///
 ///   Executed Command:
-///     ./scripts/../target/production/frequency
+///     ./scripts/../target/release/frequency
 ///     benchmark
 ///     overhead
 ///     --execution=wasm

--- a/pallets/frequency-tx-payment/src/weights.rs
+++ b/pallets/frequency-tx-payment/src/weights.rs
@@ -22,7 +22,7 @@
 //! EXECUTION: Some(Wasm), WASM-EXECUTION: Compiled, CHAIN: Some("frequency-bench"), DB CACHE: 1024
 
 // Executed Command:
-// ./scripts/../target/production/frequency
+// ./scripts/../target/release/frequency
 // benchmark
 // pallet
 // --pallet=pallet_frequency-tx-payment

--- a/pallets/handles/src/weights.rs
+++ b/pallets/handles/src/weights.rs
@@ -22,7 +22,7 @@
 //! EXECUTION: Some(Wasm), WASM-EXECUTION: Compiled, CHAIN: Some("frequency-bench"), DB CACHE: 1024
 
 // Executed Command:
-// ./scripts/../target/production/frequency
+// ./scripts/../target/release/frequency
 // benchmark
 // pallet
 // --pallet=pallet_handles

--- a/pallets/messages/src/weights.rs
+++ b/pallets/messages/src/weights.rs
@@ -22,7 +22,7 @@
 //! EXECUTION: Some(Wasm), WASM-EXECUTION: Compiled, CHAIN: Some("frequency-bench"), DB CACHE: 1024
 
 // Executed Command:
-// ./scripts/../target/production/frequency
+// ./scripts/../target/release/frequency
 // benchmark
 // pallet
 // --pallet=pallet_messages

--- a/pallets/msa/src/weights.rs
+++ b/pallets/msa/src/weights.rs
@@ -22,7 +22,7 @@
 //! EXECUTION: Some(Wasm), WASM-EXECUTION: Compiled, CHAIN: Some("frequency-bench"), DB CACHE: 1024
 
 // Executed Command:
-// ./scripts/../target/production/frequency
+// ./scripts/../target/release/frequency
 // benchmark
 // pallet
 // --pallet

--- a/pallets/schemas/src/weights.rs
+++ b/pallets/schemas/src/weights.rs
@@ -22,7 +22,7 @@
 //! EXECUTION: Some(Wasm), WASM-EXECUTION: Compiled, CHAIN: Some("frequency-bench"), DB CACHE: 1024
 
 // Executed Command:
-// ./scripts/../target/production/frequency
+// ./scripts/../target/release/frequency
 // benchmark
 // pallet
 // --pallet

--- a/pallets/stateful-storage/src/weights.rs
+++ b/pallets/stateful-storage/src/weights.rs
@@ -22,7 +22,7 @@
 //! EXECUTION: Some(Wasm), WASM-EXECUTION: Compiled, CHAIN: Some("frequency-bench"), DB CACHE: 1024
 
 // Executed Command:
-// ./target/production/frequency
+// ./target/release/frequency
 // benchmark
 // pallet
 // --pallet

--- a/pallets/time-release/src/weights.rs
+++ b/pallets/time-release/src/weights.rs
@@ -22,7 +22,7 @@
 //! EXECUTION: Some(Wasm), WASM-EXECUTION: Compiled, CHAIN: Some("frequency-bench"), DB CACHE: 1024
 
 // Executed Command:
-// ./scripts/../target/production/frequency
+// ./scripts/../target/release/frequency
 // benchmark
 // pallet
 // --pallet=pallet_time-release

--- a/runtime/common/src/weights/block_weights.rs
+++ b/runtime/common/src/weights/block_weights.rs
@@ -8,7 +8,7 @@
 //! WEIGHT-METRIC: `Average`, WEIGHT-MUL: `1.0`, WEIGHT-ADD: `0`
 
 // Executed Command:
-//   ./scripts/../target/production/frequency
+//   ./scripts/../target/release/frequency
 //   benchmark
 //   overhead
 //   --execution=wasm

--- a/runtime/common/src/weights/extrinsic_weights.rs
+++ b/runtime/common/src/weights/extrinsic_weights.rs
@@ -8,7 +8,7 @@
 //! WEIGHT-METRIC: `Average`, WEIGHT-MUL: `1.0`, WEIGHT-ADD: `0`
 
 // Executed Command:
-//   ./scripts/../target/production/frequency
+//   ./scripts/../target/release/frequency
 //   benchmark
 //   overhead
 //   --execution=wasm

--- a/runtime/common/src/weights/pallet_balances.rs
+++ b/runtime/common/src/weights/pallet_balances.rs
@@ -5,7 +5,7 @@
 //! EXECUTION: Some(Wasm), WASM-EXECUTION: Compiled, CHAIN: Some("frequency-bench"), DB CACHE: 1024
 
 // Executed Command:
-// ./scripts/../target/production/frequency
+// ./scripts/../target/release/frequency
 // benchmark
 // pallet
 // --pallet

--- a/runtime/common/src/weights/pallet_collator_selection.rs
+++ b/runtime/common/src/weights/pallet_collator_selection.rs
@@ -5,7 +5,7 @@
 //! EXECUTION: Some(Wasm), WASM-EXECUTION: Compiled, CHAIN: Some("frequency-bench"), DB CACHE: 1024
 
 // Executed Command:
-// ./scripts/../target/production/frequency
+// ./scripts/../target/release/frequency
 // benchmark
 // pallet
 // --pallet

--- a/runtime/common/src/weights/pallet_collective_council.rs
+++ b/runtime/common/src/weights/pallet_collective_council.rs
@@ -5,7 +5,7 @@
 //! EXECUTION: Some(Wasm), WASM-EXECUTION: Compiled, CHAIN: Some("frequency-bench"), DB CACHE: 1024
 
 // Executed Command:
-// ./scripts/../target/production/frequency
+// ./scripts/../target/release/frequency
 // benchmark
 // pallet
 // --pallet=pallet_collective

--- a/runtime/common/src/weights/pallet_collective_technical_committee.rs
+++ b/runtime/common/src/weights/pallet_collective_technical_committee.rs
@@ -5,7 +5,7 @@
 //! EXECUTION: Some(Wasm), WASM-EXECUTION: Compiled, CHAIN: Some("frequency-bench"), DB CACHE: 1024
 
 // Executed Command:
-// ./scripts/../target/production/frequency
+// ./scripts/../target/release/frequency
 // benchmark
 // pallet
 // --pallet=pallet_collective

--- a/runtime/common/src/weights/pallet_democracy.rs
+++ b/runtime/common/src/weights/pallet_democracy.rs
@@ -5,7 +5,7 @@
 //! EXECUTION: Some(Wasm), WASM-EXECUTION: Compiled, CHAIN: Some("frequency-bench"), DB CACHE: 1024
 
 // Executed Command:
-// ./scripts/../target/production/frequency
+// ./scripts/../target/release/frequency
 // benchmark
 // pallet
 // --pallet

--- a/runtime/common/src/weights/pallet_multisig.rs
+++ b/runtime/common/src/weights/pallet_multisig.rs
@@ -5,7 +5,7 @@
 //! EXECUTION: Some(Wasm), WASM-EXECUTION: Compiled, CHAIN: Some("frequency-bench"), DB CACHE: 1024
 
 // Executed Command:
-// ./scripts/../target/production/frequency
+// ./scripts/../target/release/frequency
 // benchmark
 // pallet
 // --pallet

--- a/runtime/common/src/weights/pallet_preimage.rs
+++ b/runtime/common/src/weights/pallet_preimage.rs
@@ -5,7 +5,7 @@
 //! EXECUTION: Some(Wasm), WASM-EXECUTION: Compiled, CHAIN: Some("frequency-bench"), DB CACHE: 1024
 
 // Executed Command:
-// ./scripts/../target/production/frequency
+// ./scripts/../target/release/frequency
 // benchmark
 // pallet
 // --pallet

--- a/runtime/common/src/weights/pallet_scheduler.rs
+++ b/runtime/common/src/weights/pallet_scheduler.rs
@@ -5,7 +5,7 @@
 //! EXECUTION: Some(Wasm), WASM-EXECUTION: Compiled, CHAIN: Some("frequency-bench"), DB CACHE: 1024
 
 // Executed Command:
-// ./scripts/../target/production/frequency
+// ./scripts/../target/release/frequency
 // benchmark
 // pallet
 // --pallet

--- a/runtime/common/src/weights/pallet_session.rs
+++ b/runtime/common/src/weights/pallet_session.rs
@@ -5,7 +5,7 @@
 //! EXECUTION: Some(Wasm), WASM-EXECUTION: Compiled, CHAIN: Some("frequency-bench"), DB CACHE: 1024
 
 // Executed Command:
-// ./scripts/../target/production/frequency
+// ./scripts/../target/release/frequency
 // benchmark
 // pallet
 // --pallet

--- a/runtime/common/src/weights/pallet_timestamp.rs
+++ b/runtime/common/src/weights/pallet_timestamp.rs
@@ -5,7 +5,7 @@
 //! EXECUTION: Some(Wasm), WASM-EXECUTION: Compiled, CHAIN: Some("frequency-bench"), DB CACHE: 1024
 
 // Executed Command:
-// ./scripts/../target/production/frequency
+// ./scripts/../target/release/frequency
 // benchmark
 // pallet
 // --pallet

--- a/runtime/common/src/weights/pallet_treasury.rs
+++ b/runtime/common/src/weights/pallet_treasury.rs
@@ -5,7 +5,7 @@
 //! EXECUTION: Some(Wasm), WASM-EXECUTION: Compiled, CHAIN: Some("frequency-bench"), DB CACHE: 1024
 
 // Executed Command:
-// ./scripts/../target/production/frequency
+// ./scripts/../target/release/frequency
 // benchmark
 // pallet
 // --pallet

--- a/runtime/common/src/weights/pallet_utility.rs
+++ b/runtime/common/src/weights/pallet_utility.rs
@@ -5,7 +5,7 @@
 //! EXECUTION: Some(Wasm), WASM-EXECUTION: Compiled, CHAIN: Some("frequency-bench"), DB CACHE: 1024
 
 // Executed Command:
-// ./scripts/../target/production/frequency
+// ./scripts/../target/release/frequency
 // benchmark
 // pallet
 // --pallet

--- a/scripts/init.sh
+++ b/scripts/init.sh
@@ -43,7 +43,7 @@ stop-frequency-docker)
 
 start-frequency)
   printf "\nBuilding frequency with runtime '$parachain' and id '$para_id'...\n"
-  cargo build --release --features frequency-rococo-local
+  cargo build --features frequency-rococo-local
 
   parachain_dir=$base_dir/parachain/${para_id}
   mkdir -p $parachain_dir;
@@ -131,7 +131,7 @@ start-frequency-native)
 
 start-frequency-manual)
   printf "\nBuilding frequency with runtime manual sealing ...\n"
-  cargo build --locked --features frequency-no-relay
+  cargo build --features frequency-no-relay
 
   parachain_dir=$base_dir/parachain/${para_id}
   mkdir -p $parachain_dir;
@@ -231,15 +231,13 @@ upgrade-frequency-rococo-local)
   root_dir=$(git rev-parse --show-toplevel)
   echo "root_dir is set to $root_dir"
 
-  # Due to defaults and profile=release, the target directory will be $root_dir/target/release
+  # Due to defaults and profile=debug, the target directory will be $root_dir/target/debug
   cargo build \
-    --locked \
-    --profile release \
     --package frequency-runtime \
     --features frequency-rococo-local \
     -Z unstable-options
 
-  wasm_location=$root_dir/target/release/wbuild/frequency-runtime/frequency_runtime.compact.compressed.wasm
+  wasm_location=$root_dir/target/debug/wbuild/frequency-runtime/frequency_runtime.compact.compressed.wasm
 
   ./scripts/runtime-upgrade.sh "//Alice" "ws://0.0.0.0:9944" $wasm_location
 
@@ -252,15 +250,13 @@ upgrade-frequency-no-relay)
   root_dir=$(git rev-parse --show-toplevel)
   echo "root_dir is set to $root_dir"
 
-  # Due to defaults and profile=release, the target directory will be $root_dir/target/release
+  # Due to defaults and profile=debug, the target directory will be $root_dir/target/debug
   cargo build \
-    --locked \
-    --profile release \
     --package frequency-runtime \
     --features frequency-no-relay \
     -Z unstable-options
 
-  wasm_location=$root_dir/target/release/wbuild/frequency-runtime/frequency_runtime.compact.compressed.wasm
+  wasm_location=$root_dir/target/debug/wbuild/frequency-runtime/frequency_runtime.compact.compressed.wasm
 
   ./scripts/runtime-upgrade.sh "//Alice" "ws://0.0.0.0:9944" $wasm_location
 

--- a/scripts/run_benchmarks.sh
+++ b/scripts/run_benchmarks.sh
@@ -3,7 +3,7 @@
 export RUST_LOG=info
 THIS_DIR=$( dirname -- "$0"; )
 PROJECT="${THIS_DIR}/.."
-PROFILE=production
+PROFILE=release
 PROFILE_DIR=${PROFILE}
 
 ALL_EXTERNAL_PALLETS=( \
@@ -51,7 +51,7 @@ function usage() {
         -s            Skip the build step; use existing binary for the current profile
 
         -t <profile>  Use '--profile=<profile>' in the build step & for locating the
-                      resulting binary. Valid targets are: dev,production,release,bench-dev
+                      resulting binary. Valid targets are: dev,release,bench-dev
 
                       (NOTE: using the 'bench-dev' profile will generate a warning in the WASM build.
                        this can safely be ignored. 'bench-dev' is a clone of 'release' and is useful
@@ -106,7 +106,7 @@ while getopts 'dh:p:st:v' flag; do
     t)
       # Set target profile
       case ${OPTARG} in
-        production|release|dev|bench-dev)
+        release|dev|bench-dev)
           PROFILE="${OPTARG}"
           PROFILE_DIR=${PROFILE}
           # For historical reasons, cargo puts dev builds in the "debug" directory


### PR DESCRIPTION
# Goal
The goal of this PR is to reduce confusion and have faster local builds.

Instead of having three main profiles, this reduces it to just two.

Before: `debug`, `release`, `production`
After: `debug`, `release`

Generally:
- `--profile production` -> `--release` (which is the same as `--profile release`)
- `--release` -> Removed (default `debug`)
- `--locked` -> Removed except for the release builds

The `release` profile wasn't really being used and is the more standard "production" build. So we pulled the build configuration for production into `release`

# Discussion
- Also updated all the make builds to use `debug` except ones that need `release` (which is default)
- This reduces the rebuild time as much as possible, even when switching builds.