### PR TITLE
fix: Add patch to Cargo.toml to ensure correct multihash version

### DIFF
--- a/.github/workflows/verify-pr-commit.yml
+++ b/.github/workflows/verify-pr-commit.yml
@@ -317,13 +317,13 @@ jobs:
         network: [rococo, mainnet]
         include:
           - network: rococo
-            build-profile: debug
+            build-profile: release
             package: frequency-runtime
             runtime-dir: runtime/frequency
             built-wasm-file-name-prefix: frequency_runtime
             features: frequency-rococo-testnet
           - network: mainnet
-            build-profile: debug
+            build-profile: release
             package: frequency-runtime
             runtime-dir: runtime/frequency
             built-wasm-file-name-prefix: frequency_runtime

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,5 +21,6 @@ strip = false
 codegen-units = 16
 lto = false
 
+# Remove this patch if messages/Cargo.toml::cid dependency is updated to use multihash 0.18.1 or greater
 [patch."https://github.com/multiformats/rust-cid"]
 multihash = "0.18.1"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,3 +20,6 @@ inherits = "release"
 strip = false
 codegen-units = 16
 lto = false
+
+[patch."https://github.com/multiformats/rust-cid"]
+multihash = "0.18.1"


### PR DESCRIPTION
# Goal
The goal of this PR is to add a patch to Cargo.toml to ensure the correct multihash version.
Also fixes a build issue with srtool failing on profile = debug, reverting to release.

Closes #1417 
# Discussion
<!-- List discussion items -->

# Checklist
- [ ] Chain spec updated
- [ ] Custom RPC OR Runtime API added/changed? Updated js/api-augment.
- [ ] Design doc(s) updated
- [ ] Tests added
- [ ] Benchmarks added
- [ ] Weights updated
