### PR TITLE
add rust installation to ci base image

### DIFF
--- a/.github/workflows/merge-pr.yml
+++ b/.github/workflows/merge-pr.yml
@@ -27,8 +27,6 @@ jobs:
 
   publish-js-api-augment-rc:
     name: Merge - Publish JS API Augment Release Candidate
-    env:
-      HOME: /root
     runs-on: [self-hosted, Linux, X64, testing, v2]
     container: ghcr.io/libertydsnp/frequency/ci-base-image
     steps:

--- a/.github/workflows/publish-dev-ci-base-image.yml
+++ b/.github/workflows/publish-dev-ci-base-image.yml
@@ -1,0 +1,50 @@
+# This workflow is used only when a development version of CI base image needs to be built.
+name: Publish Dev CI Base Image
+concurrency:
+  group: ${{github.workflow}}-${{github.ref}}
+  cancel-in-progress: true
+on:
+  push:
+    branches:
+      - disabled-as-this-branch-does-not-exist
+      # 1482-add-rust-toolchain-install-to-ci-base-image
+env:
+  BIN_DIR: target/release
+
+jobs:
+  publish-ci-base-image:
+    name: Publish CI Base Image
+    env:
+      # IMAGE_NAME: ci-base-image-dind
+      IMAGE_NAME: ci-base-image
+      BRANCH_NAME: ${{github.ref_name}}
+    runs-on: ubuntu-20.04
+    steps:
+      - name: Check Out Repo
+        uses: actions/checkout@v3
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v2
+        with:
+          platforms: "amd64"
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v2
+      - name: Login to GitHub Container Registry
+        uses: docker/login-action@v2
+        with:
+          registry: ghcr.io
+          username: ${{github.actor}}
+          password: ${{secrets.GITHUB_TOKEN}}
+      - name: Sanitize repo owner slug
+        uses: actions/github-script@v6
+        id: repo_slug
+        with:
+          result-encoding: string
+          script: return `ghcr.io/${context.repo.owner.toLowerCase()}/${context.repo.repo.toLowerCase()}`
+      - name: Build and Push Docker Image
+        uses: docker/build-push-action@v4
+        with:
+          context: tools/ci/docker
+          push: true
+          file: tools/ci/docker/ci-base-image.dockerfile
+          tags: |
+            ${{steps.repo_slug.outputs.result}}/${{env.IMAGE_NAME}}:${{env.BRANCH_NAME}}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -175,7 +175,7 @@ jobs:
           # - os: [self-hosted, Linux, ARM64]
           #   arch: arm64
     runs-on: ${{matrix.os}}
-    container: ubuntu:20.04
+    container: ghcr.io/libertydsnp/frequency/ci-base-image
     steps:
       - name: Install Required Packages
         run: |
@@ -190,11 +190,6 @@ jobs:
           echo "BIN_DIR=target/${{matrix.build-profile}}" >> $GITHUB_ENV
           echo "BUILT_BIN_FILENAME=frequency" >> $GITHUB_ENV
           echo "RELEASE_BIN_FILENAME=${{matrix.release-file-name-prefix}}.${{matrix.arch}}" >> $GITHUB_ENV
-      - name: Install Rust Toolchain
-        uses: dtolnay/rust-toolchain@e12eda571dc9a5ee5d58eecf4738ec291c66f295
-        with:
-          targets: wasm32-unknown-unknown
-          toolchain: stable
       - name: Compile for ${{matrix.network}}
         run: |
           CARGO_INCREMENTAL=0 RUSTFLAGS="-D warnings" cargo build \
@@ -244,8 +239,6 @@ jobs:
     outputs:
       runtime_filename_rococo: ${{steps.set-env-vars.outputs.runtime_filename_rococo}}
       runtime_filename_mainnet: ${{steps.set-env-vars.outputs.runtime_filename_mainnet}}
-    env:
-      HOME: /root
     strategy:
       fail-fast: true
       matrix:
@@ -267,21 +260,16 @@ jobs:
             release-wasm-file-name-prefix: frequency_runtime
             features: frequency
             wasm-core-version: frequency
-    runs-on: [self-hosted, Linux, X64, build]
+    runs-on: [self-hosted, Linux, X64, testing, v2]
     steps:
       - name: Install Required Packages
         run: |
           sudo apt-get update
-          sudo apt-get install -y curl protobuf-compiler build-essential libclang-dev file
-          curl -fsSL https://get.docker.com -o get-docker.sh
-          sh get-docker.sh
-          docker run hello-world
+          sudo apt install -y wget file build-essential
       - name: Check Out Repo
         uses: actions/checkout@v3
         with:
           ref: ${{env.RELEASE_BRANCH_NAME}}
-      - name: Reset Runner
-        uses: ./.github/workflows/common/reset-self-hosted-runner
       - name: Install Rust Toolchain
         uses: dtolnay/rust-toolchain@e12eda571dc9a5ee5d58eecf4738ec291c66f295
         with:
@@ -306,22 +294,21 @@ jobs:
           echo "runtime_filename_${{matrix.network}}=$release_wasm_filename" >> $GITHUB_OUTPUT
       - name: Install srtool-cli
         run: |
-          cargo install --git https://github.com/chevdor/srtool-cli
+          rustup run stable cargo install --git https://github.com/chevdor/srtool-cli
           srtool --version
       - name: Build Deterministic WASM
         run: |
           RUST_LOG=debug SRTOOL_TAG="1.66.1" srtool build \
             --build-opts="'--features on-chain-release-build,no-metadata-docs,${{matrix.features}}'" \
             --profile=${{matrix.build-profile}} \
-            --package=${{matrix.package}} \
-            --root
+            --package=${{matrix.package}}
       - name: Rename WASM file
         run: |
           cp -p ./${{env.WASM_DIR}}/${{env.BUILT_WASM_FILENAME}} \
             ./${{env.WASM_DIR}}/${{env.RELEASE_WASM_FILENAME}}
       - name: Install subwasm
         run: |
-          cargo install --locked --git https://github.com/chevdor/subwasm --tag v0.19.1 --force
+          rustup run stable cargo install --locked --git https://github.com/chevdor/subwasm --tag v0.19.1 --force
           subwasm --version
       - name: Test WASM file
         run: |
@@ -339,7 +326,7 @@ jobs:
     needs: version-code
     name: Build Rust Developer Docs
     runs-on: [self-hosted, Linux, X64, build]
-    container: ubuntu:20.04
+    container: ghcr.io/libertydsnp/frequency/ci-base-image
     steps:
       - name: Install Required Packages
         run: |
@@ -351,11 +338,6 @@ jobs:
           ref: ${{env.RELEASE_BRANCH_NAME}}
       - name: Setup Pages
         uses: actions/configure-pages@v3
-      - name: Install Rust Toolchain
-        uses: dtolnay/rust-toolchain@e12eda571dc9a5ee5d58eecf4738ec291c66f295
-        with:
-          targets: wasm32-unknown-unknown
-          toolchain: stable
       - name: Build Docs
         run: |
           RUSTDOCFLAGS="--enable-index-page -Zunstable-options" cargo doc --no-deps --features frequency

--- a/.github/workflows/verify-pr-commit.yml
+++ b/.github/workflows/verify-pr-commit.yml
@@ -290,6 +290,10 @@ jobs:
             features: frequency
     runs-on: [self-hosted, Linux, X64, testing, v2]
     steps:
+      - name: Install Required Packages
+        run: |
+          sudo apt-get update
+          sudo apt install -y wget file build-essential
       - name: Check Out Repo
         uses: actions/checkout@v3
       - name: Install Rust Toolchain
@@ -317,7 +321,6 @@ jobs:
       #   with:
       #     path: ${{env.WASM_DIR}}/${{env.BUILT_WASM_FILENAME}}
       #     key: runtimes-${{runner.os}}-${{matrix.network}}-${{github.head_ref}}
-      # REVIEW: The $PATH is not set right?
       - name: Install srtool-cli
         if: steps.cache-wasm.outputs.cache-hit != 'true'
         run: |


### PR DESCRIPTION
# Goal
The goal of this PR is to move rust installation to the CI base image. It also fixes some errors observed after runners have been upgraded to ubuntu `22.04`.

Related #1482