### PR TITLE
fix sanitize changelog error in release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -653,13 +653,12 @@ jobs:
             }
       - name: Sanitize Changelog
         id: sanitize-changelog
+        shell: bash
         run: |
-          echo "original: ${{steps.build-changelog.outputs.changelog}}"
-          echo "-------------------------------------------------"
           changelog='${{steps.build-changelog.outputs.changelog}}'
+          echo "-------------------------------------------------"
           clean="${changelog//[\`\[\]$'\n']/}"
           echo "sanitized: $clean"
-          echo "-------------------------------------------------"
           echo "sanitized=$clean" >> $GITHUB_OUTPUT
       - name: Get Polkadot Version
         id: polkadot-version


### PR DESCRIPTION
# Goal
The goal of this PR is to fix bad substitution error in "Sanitize Change log" of the release workflow.  This error seams happening under default `/bin/sh` shell in GitHub Actions.

Closes #1563