### PR TITLE
Update api augment and integration test packages

### DIFF
--- a/integration-tests/package-lock.json
+++ b/integration-tests/package-lock.json
@@ -11,23 +11,23 @@
             "license": "Apache-2.0",
             "dependencies": {
                 "@frequency-chain/api-augment": "file:../js/api-augment/dist/frequency-chain-api-augment-0.0.0.tgz",
-                "@polkadot/api": "10.4.1",
-                "@polkadot/types": "10.4.1",
-                "@polkadot/util": "10.4.1",
+                "@polkadot/api": "10.7.3",
+                "@polkadot/types": "10.7.3",
+                "@polkadot/util": "12.2.1",
                 "ipfs": "^0.66.0",
-                "multiformats": "^11.0.1",
-                "rxjs": "^7.8.0"
+                "multiformats": "^11.0.2",
+                "rxjs": "^7.8.1"
             },
             "devDependencies": {
-                "@polkadot/typegen": "10.4.1",
-                "@types/mocha": "^10.0.0",
-                "@typescript-eslint/eslint-plugin": "^5.48.1",
-                "@typescript-eslint/parser": "^5.48.1",
-                "mocha": "^10.1.0",
-                "prettier": "^2.7.1",
-                "sinon": "^14.0.2",
+                "@polkadot/typegen": "10.7.3",
+                "@types/mocha": "^10.0.1",
+                "@typescript-eslint/eslint-plugin": "^5.59.8",
+                "@typescript-eslint/parser": "^5.59.8",
+                "mocha": "^10.2.0",
+                "prettier": "^2.8.8",
+                "sinon": "^15.1.0",
                 "ts-node": "^10.9.1",
-                "typescript": "^4.9.5"
+                "typescript": "^5.1.3"
             }
         },
         "node_modules/@achingbrain/ip-address": {
@@ -97,17 +97,6 @@
             "version": "0.9.4",
             "resolved": "https://registry.npmjs.org/@assemblyscript/loader/-/loader-0.9.4.tgz",
             "integrity": "sha512-HazVq9zwTVwGmqdwYzu7WyQ6FQVZ7SwET0KKQuKm55jD0IfUpZgN0OPIiZG3zV1iSrVYcN0bdwLRXI/VNCYsUA=="
-        },
-        "node_modules/@babel/runtime": {
-            "version": "7.21.5",
-            "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.21.5.tgz",
-            "integrity": "sha512-8jI69toZqqcsnqGGqwGS4Qb1VwLOEp4hz+CXPywcvjs60u3B4Pom/U/7rm4W8tMOYEB+E9wgD0mW1l3r8qlI9Q==",
-            "dependencies": {
-                "regenerator-runtime": "^0.13.11"
-            },
-            "engines": {
-                "node": ">=6.9.0"
-            }
         },
         "node_modules/@chainsafe/is-ip": {
             "version": "2.0.1",
@@ -267,6 +256,30 @@
                 "@jridgewell/sourcemap-codec": "^1.4.10"
             }
         },
+        "node_modules/@eslint-community/eslint-utils": {
+            "version": "4.4.0",
+            "resolved": "https://registry.npmjs.org/@eslint-community/eslint-utils/-/eslint-utils-4.4.0.tgz",
+            "integrity": "sha512-1/sA4dwrzBAyeUoQ6oxahHKmrZvsnLCg4RfxW3ZFGGmQkSNQPFNLV9CUEFQP1x9EYXHTo5p6xdhZM1Ne9p/AfA==",
+            "dev": true,
+            "dependencies": {
+                "eslint-visitor-keys": "^3.3.0"
+            },
+            "engines": {
+                "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+            },
+            "peerDependencies": {
+                "eslint": "^6.0.0 || ^7.0.0 || >=8.0.0"
+            }
+        },
+        "node_modules/@eslint-community/regexpp": {
+            "version": "4.5.1",
+            "resolved": "https://registry.npmjs.org/@eslint-community/regexpp/-/regexpp-4.5.1.tgz",
+            "integrity": "sha512-Z5ba73P98O1KUYCCJTUeVpja9RcGoMdncZ6T49FCUl2lN38JtCJ+3WgIDBv0AuY4WChU5PmtJmOCTlN6FZTFKQ==",
+            "dev": true,
+            "engines": {
+                "node": "^12.0.0 || ^14.0.0 || >=16.0.0"
+            }
+        },
         "node_modules/@eslint/eslintrc": {
             "version": "2.0.0",
             "resolved": "https://registry.npmjs.org/@eslint/eslintrc/-/eslintrc-2.0.0.tgz",
@@ -304,12 +317,12 @@
         "node_modules/@frequency-chain/api-augment": {
             "version": "0.0.0",
             "resolved": "file:../js/api-augment/dist/frequency-chain-api-augment-0.0.0.tgz",
-            "integrity": "sha512-S48YkqcoP9kC7eTbdxuaMWCddvAQGos//lXT/mchUVOKb+nYnRddWr+hYRaoP1frQgph3//gSl0ip46Mpbe7LA==",
+            "integrity": "sha512-zFX8WvE+B1hNbGRv9aBfOaAtqZCz+nKEarEAZOu2fPh41Pgccpop1GEO8CcppsR42AJvhi/IePvGbV87pXMNVQ==",
             "license": "Apache-2.0",
             "dependencies": {
-                "@polkadot/api": "10.4.1",
-                "@polkadot/rpc-provider": "10.4.1",
-                "@polkadot/types": "10.4.1"
+                "@polkadot/api": "^10.7.3",
+                "@polkadot/rpc-provider": "^10.7.3",
+                "@polkadot/types": "^10.7.3"
             }
         },
         "node_modules/@grpc/grpc-js": {
@@ -2524,312 +2537,107 @@
             }
         },
         "node_modules/@polkadot/api": {
-            "version": "10.4.1",
-            "resolved": "https://registry.npmjs.org/@polkadot/api/-/api-10.4.1.tgz",
-            "integrity": "sha512-MFIhykqvU4l5oyLxEnMhtF07VWLXwBS02gVd9Q+Gh2RxXtskQnXlos00hZFdLaCQ7g8BNggoq0Woc2BGZQEG2A==",
+            "version": "10.7.3",
+            "resolved": "https://registry.npmjs.org/@polkadot/api/-/api-10.7.3.tgz",
+            "integrity": "sha512-SqgjA5QihxSBGGtazgH5y+bYg3mYg4GQPoK7gJkz3E9avQ8glaCOAZJsm4Wmj1l87VvdCQffyew+Q9lTwrQ+JA==",
             "dependencies": {
-                "@polkadot/api-augment": "10.4.1",
-                "@polkadot/api-base": "10.4.1",
-                "@polkadot/api-derive": "10.4.1",
-                "@polkadot/keyring": "^12.0.1",
-                "@polkadot/rpc-augment": "10.4.1",
-                "@polkadot/rpc-core": "10.4.1",
-                "@polkadot/rpc-provider": "10.4.1",
-                "@polkadot/types": "10.4.1",
-                "@polkadot/types-augment": "10.4.1",
-                "@polkadot/types-codec": "10.4.1",
-                "@polkadot/types-create": "10.4.1",
-                "@polkadot/types-known": "10.4.1",
-                "@polkadot/util": "^12.0.1",
-                "@polkadot/util-crypto": "^12.0.1",
-                "eventemitter3": "^5.0.0",
-                "rxjs": "^7.8.0",
-                "tslib": "^2.5.0"
+                "@polkadot/api-augment": "10.7.3",
+                "@polkadot/api-base": "10.7.3",
+                "@polkadot/api-derive": "10.7.3",
+                "@polkadot/keyring": "^12.2.1",
+                "@polkadot/rpc-augment": "10.7.3",
+                "@polkadot/rpc-core": "10.7.3",
+                "@polkadot/rpc-provider": "10.7.3",
+                "@polkadot/types": "10.7.3",
+                "@polkadot/types-augment": "10.7.3",
+                "@polkadot/types-codec": "10.7.3",
+                "@polkadot/types-create": "10.7.3",
+                "@polkadot/types-known": "10.7.3",
+                "@polkadot/util": "^12.2.1",
+                "@polkadot/util-crypto": "^12.2.1",
+                "eventemitter3": "^5.0.1",
+                "rxjs": "^7.8.1",
+                "tslib": "^2.5.2"
             },
             "engines": {
                 "node": ">=16"
             }
         },
         "node_modules/@polkadot/api-augment": {
-            "version": "10.4.1",
-            "resolved": "https://registry.npmjs.org/@polkadot/api-augment/-/api-augment-10.4.1.tgz",
-            "integrity": "sha512-7TUFHiOsaAKwRCDXEwwYHIBi07Nd0+4vMDgP+/eKVrX5XkYCnEA+PdkE8uEpFY3LMoVVr08mPiYPn59gN0b5jw==",
+            "version": "10.7.3",
+            "resolved": "https://registry.npmjs.org/@polkadot/api-augment/-/api-augment-10.7.3.tgz",
+            "integrity": "sha512-qdMELIV/PrSmOMFXnebNHlsiYiOebeTrMqNWB+lWPiGLKHBu4PnXzuvQK/H2FcMHJXXoocYjm10teJ6uZuSS/A==",
             "dependencies": {
-                "@polkadot/api-base": "10.4.1",
-                "@polkadot/rpc-augment": "10.4.1",
-                "@polkadot/types": "10.4.1",
-                "@polkadot/types-augment": "10.4.1",
-                "@polkadot/types-codec": "10.4.1",
-                "@polkadot/util": "^12.0.1",
-                "tslib": "^2.5.0"
-            },
-            "engines": {
-                "node": ">=16"
-            }
-        },
-        "node_modules/@polkadot/api-augment/node_modules/@polkadot/util": {
-            "version": "12.1.2",
-            "resolved": "https://registry.npmjs.org/@polkadot/util/-/util-12.1.2.tgz",
-            "integrity": "sha512-Da8q+0WVWSuMMS3hLAwnIid8FKRGLmwhD69jikye47zeEXCtvp4e/bjD0YbINNKHoeIRsApchJtqmbaEoxXjIQ==",
-            "dependencies": {
-                "@polkadot/x-bigint": "12.1.2",
-                "@polkadot/x-global": "12.1.2",
-                "@polkadot/x-textdecoder": "12.1.2",
-                "@polkadot/x-textencoder": "12.1.2",
-                "@types/bn.js": "^5.1.1",
-                "bn.js": "^5.2.1",
-                "tslib": "^2.5.0"
-            },
-            "engines": {
-                "node": ">=16"
-            }
-        },
-        "node_modules/@polkadot/api-augment/node_modules/@polkadot/x-textdecoder": {
-            "version": "12.1.2",
-            "resolved": "https://registry.npmjs.org/@polkadot/x-textdecoder/-/x-textdecoder-12.1.2.tgz",
-            "integrity": "sha512-O5ygxEHdPCIQVzH7T+xVALBfCwrT5tVms7Yjp6EMT697A9gpD3U2aPr4YinsQO6JFwYpQNzvm2wjW+7EEzYitw==",
-            "dependencies": {
-                "@polkadot/x-global": "12.1.2",
-                "tslib": "^2.5.0"
-            },
-            "engines": {
-                "node": ">=16"
-            }
-        },
-        "node_modules/@polkadot/api-augment/node_modules/@polkadot/x-textencoder": {
-            "version": "12.1.2",
-            "resolved": "https://registry.npmjs.org/@polkadot/x-textencoder/-/x-textencoder-12.1.2.tgz",
-            "integrity": "sha512-N+9HIXT0eUQbfg/SfGrNRK8aLFpd2QngJzTxo8CljpjCvQ2ddqzBVFA8o/lKTaXVzX84EmPDzjIV+yJlOXnglA==",
-            "dependencies": {
-                "@polkadot/x-global": "12.1.2",
-                "tslib": "^2.5.0"
+                "@polkadot/api-base": "10.7.3",
+                "@polkadot/rpc-augment": "10.7.3",
+                "@polkadot/types": "10.7.3",
+                "@polkadot/types-augment": "10.7.3",
+                "@polkadot/types-codec": "10.7.3",
+                "@polkadot/util": "^12.2.1",
+                "tslib": "^2.5.2"
             },
             "engines": {
                 "node": ">=16"
             }
         },
         "node_modules/@polkadot/api-base": {
-            "version": "10.4.1",
-            "resolved": "https://registry.npmjs.org/@polkadot/api-base/-/api-base-10.4.1.tgz",
-            "integrity": "sha512-4uItv9NeZDu60qN8dhPN8Q7HBOYZ0Ylf7+/lAnEMldoCx0RxNP2h1T2JwdW3C5ElTsztYzYVLKg0Iz5zJpbffQ==",
+            "version": "10.7.3",
+            "resolved": "https://registry.npmjs.org/@polkadot/api-base/-/api-base-10.7.3.tgz",
+            "integrity": "sha512-FYqG4HYWji1QCFZcPSJ5k87K2NNxbxl4JNhNPHcZTtfXdOnhKXze3Wkbv68S3Az6plIEkq6+aMbmkNsq5cNaWg==",
             "dependencies": {
-                "@polkadot/rpc-core": "10.4.1",
-                "@polkadot/types": "10.4.1",
-                "@polkadot/util": "^12.0.1",
-                "rxjs": "^7.8.0",
-                "tslib": "^2.5.0"
-            },
-            "engines": {
-                "node": ">=16"
-            }
-        },
-        "node_modules/@polkadot/api-base/node_modules/@polkadot/util": {
-            "version": "12.1.2",
-            "resolved": "https://registry.npmjs.org/@polkadot/util/-/util-12.1.2.tgz",
-            "integrity": "sha512-Da8q+0WVWSuMMS3hLAwnIid8FKRGLmwhD69jikye47zeEXCtvp4e/bjD0YbINNKHoeIRsApchJtqmbaEoxXjIQ==",
-            "dependencies": {
-                "@polkadot/x-bigint": "12.1.2",
-                "@polkadot/x-global": "12.1.2",
-                "@polkadot/x-textdecoder": "12.1.2",
-                "@polkadot/x-textencoder": "12.1.2",
-                "@types/bn.js": "^5.1.1",
-                "bn.js": "^5.2.1",
-                "tslib": "^2.5.0"
-            },
-            "engines": {
-                "node": ">=16"
-            }
-        },
-        "node_modules/@polkadot/api-base/node_modules/@polkadot/x-textdecoder": {
-            "version": "12.1.2",
-            "resolved": "https://registry.npmjs.org/@polkadot/x-textdecoder/-/x-textdecoder-12.1.2.tgz",
-            "integrity": "sha512-O5ygxEHdPCIQVzH7T+xVALBfCwrT5tVms7Yjp6EMT697A9gpD3U2aPr4YinsQO6JFwYpQNzvm2wjW+7EEzYitw==",
-            "dependencies": {
-                "@polkadot/x-global": "12.1.2",
-                "tslib": "^2.5.0"
-            },
-            "engines": {
-                "node": ">=16"
-            }
-        },
-        "node_modules/@polkadot/api-base/node_modules/@polkadot/x-textencoder": {
-            "version": "12.1.2",
-            "resolved": "https://registry.npmjs.org/@polkadot/x-textencoder/-/x-textencoder-12.1.2.tgz",
-            "integrity": "sha512-N+9HIXT0eUQbfg/SfGrNRK8aLFpd2QngJzTxo8CljpjCvQ2ddqzBVFA8o/lKTaXVzX84EmPDzjIV+yJlOXnglA==",
-            "dependencies": {
-                "@polkadot/x-global": "12.1.2",
-                "tslib": "^2.5.0"
+                "@polkadot/rpc-core": "10.7.3",
+                "@polkadot/types": "10.7.3",
+                "@polkadot/util": "^12.2.1",
+                "rxjs": "^7.8.1",
+                "tslib": "^2.5.2"
             },
             "engines": {
                 "node": ">=16"
             }
         },
         "node_modules/@polkadot/api-derive": {
-            "version": "10.4.1",
-            "resolved": "https://registry.npmjs.org/@polkadot/api-derive/-/api-derive-10.4.1.tgz",
-            "integrity": "sha512-SR/L4H8oiYMyLaLzmm9Z3kb4tNLAOAIR2uBZshCo917CqMuvrkNVW+Wfh2dAtVsnoSc1FaSPfDwmKash6pqNUQ==",
+            "version": "10.7.3",
+            "resolved": "https://registry.npmjs.org/@polkadot/api-derive/-/api-derive-10.7.3.tgz",
+            "integrity": "sha512-++C+nMn6BgFdlkEVJrDez/6ILDxYe7CdCfNLKr5kOuTJu8VtmYS6kbmpCxZ0kYD5Omwe4UJ6az9hDHR5MUn94A==",
             "dependencies": {
-                "@polkadot/api": "10.4.1",
-                "@polkadot/api-augment": "10.4.1",
-                "@polkadot/api-base": "10.4.1",
-                "@polkadot/rpc-core": "10.4.1",
-                "@polkadot/types": "10.4.1",
-                "@polkadot/types-codec": "10.4.1",
-                "@polkadot/util": "^12.0.1",
-                "@polkadot/util-crypto": "^12.0.1",
-                "rxjs": "^7.8.0",
-                "tslib": "^2.5.0"
-            },
-            "engines": {
-                "node": ">=16"
-            }
-        },
-        "node_modules/@polkadot/api-derive/node_modules/@polkadot/util": {
-            "version": "12.1.2",
-            "resolved": "https://registry.npmjs.org/@polkadot/util/-/util-12.1.2.tgz",
-            "integrity": "sha512-Da8q+0WVWSuMMS3hLAwnIid8FKRGLmwhD69jikye47zeEXCtvp4e/bjD0YbINNKHoeIRsApchJtqmbaEoxXjIQ==",
-            "dependencies": {
-                "@polkadot/x-bigint": "12.1.2",
-                "@polkadot/x-global": "12.1.2",
-                "@polkadot/x-textdecoder": "12.1.2",
-                "@polkadot/x-textencoder": "12.1.2",
-                "@types/bn.js": "^5.1.1",
-                "bn.js": "^5.2.1",
-                "tslib": "^2.5.0"
-            },
-            "engines": {
-                "node": ">=16"
-            }
-        },
-        "node_modules/@polkadot/api-derive/node_modules/@polkadot/x-textdecoder": {
-            "version": "12.1.2",
-            "resolved": "https://registry.npmjs.org/@polkadot/x-textdecoder/-/x-textdecoder-12.1.2.tgz",
-            "integrity": "sha512-O5ygxEHdPCIQVzH7T+xVALBfCwrT5tVms7Yjp6EMT697A9gpD3U2aPr4YinsQO6JFwYpQNzvm2wjW+7EEzYitw==",
-            "dependencies": {
-                "@polkadot/x-global": "12.1.2",
-                "tslib": "^2.5.0"
-            },
-            "engines": {
-                "node": ">=16"
-            }
-        },
-        "node_modules/@polkadot/api-derive/node_modules/@polkadot/x-textencoder": {
-            "version": "12.1.2",
-            "resolved": "https://registry.npmjs.org/@polkadot/x-textencoder/-/x-textencoder-12.1.2.tgz",
-            "integrity": "sha512-N+9HIXT0eUQbfg/SfGrNRK8aLFpd2QngJzTxo8CljpjCvQ2ddqzBVFA8o/lKTaXVzX84EmPDzjIV+yJlOXnglA==",
-            "dependencies": {
-                "@polkadot/x-global": "12.1.2",
-                "tslib": "^2.5.0"
-            },
-            "engines": {
-                "node": ">=16"
-            }
-        },
-        "node_modules/@polkadot/api/node_modules/@polkadot/util": {
-            "version": "12.1.2",
-            "resolved": "https://registry.npmjs.org/@polkadot/util/-/util-12.1.2.tgz",
-            "integrity": "sha512-Da8q+0WVWSuMMS3hLAwnIid8FKRGLmwhD69jikye47zeEXCtvp4e/bjD0YbINNKHoeIRsApchJtqmbaEoxXjIQ==",
-            "dependencies": {
-                "@polkadot/x-bigint": "12.1.2",
-                "@polkadot/x-global": "12.1.2",
-                "@polkadot/x-textdecoder": "12.1.2",
-                "@polkadot/x-textencoder": "12.1.2",
-                "@types/bn.js": "^5.1.1",
-                "bn.js": "^5.2.1",
-                "tslib": "^2.5.0"
-            },
-            "engines": {
-                "node": ">=16"
-            }
-        },
-        "node_modules/@polkadot/api/node_modules/@polkadot/x-textdecoder": {
-            "version": "12.1.2",
-            "resolved": "https://registry.npmjs.org/@polkadot/x-textdecoder/-/x-textdecoder-12.1.2.tgz",
-            "integrity": "sha512-O5ygxEHdPCIQVzH7T+xVALBfCwrT5tVms7Yjp6EMT697A9gpD3U2aPr4YinsQO6JFwYpQNzvm2wjW+7EEzYitw==",
-            "dependencies": {
-                "@polkadot/x-global": "12.1.2",
-                "tslib": "^2.5.0"
-            },
-            "engines": {
-                "node": ">=16"
-            }
-        },
-        "node_modules/@polkadot/api/node_modules/@polkadot/x-textencoder": {
-            "version": "12.1.2",
-            "resolved": "https://registry.npmjs.org/@polkadot/x-textencoder/-/x-textencoder-12.1.2.tgz",
-            "integrity": "sha512-N+9HIXT0eUQbfg/SfGrNRK8aLFpd2QngJzTxo8CljpjCvQ2ddqzBVFA8o/lKTaXVzX84EmPDzjIV+yJlOXnglA==",
-            "dependencies": {
-                "@polkadot/x-global": "12.1.2",
-                "tslib": "^2.5.0"
+                "@polkadot/api": "10.7.3",
+                "@polkadot/api-augment": "10.7.3",
+                "@polkadot/api-base": "10.7.3",
+                "@polkadot/rpc-core": "10.7.3",
+                "@polkadot/types": "10.7.3",
+                "@polkadot/types-codec": "10.7.3",
+                "@polkadot/util": "^12.2.1",
+                "@polkadot/util-crypto": "^12.2.1",
+                "rxjs": "^7.8.1",
+                "tslib": "^2.5.2"
             },
             "engines": {
                 "node": ">=16"
             }
         },
         "node_modules/@polkadot/keyring": {
-            "version": "12.1.2",
-            "resolved": "https://registry.npmjs.org/@polkadot/keyring/-/keyring-12.1.2.tgz",
-            "integrity": "sha512-HskFoZwLwRWPthEQK50uOiOsbdIt0AY3gcrDmSS2ltkpUDY9qzlb/fAj0+QGtTrK36v5gHT8OD56Pd4l0FDMFw==",
+            "version": "12.2.1",
+            "resolved": "https://registry.npmjs.org/@polkadot/keyring/-/keyring-12.2.1.tgz",
+            "integrity": "sha512-YqgpU+97OZgnSUL56DEMib937Dpb1bTTDPYHhBiN1yNCKod7UboWXIe4xPh+1Kzugum+dEyPpdV+fHH10rtDzw==",
             "dependencies": {
-                "@polkadot/util": "12.1.2",
-                "@polkadot/util-crypto": "12.1.2",
+                "@polkadot/util": "12.2.1",
+                "@polkadot/util-crypto": "12.2.1",
                 "tslib": "^2.5.0"
             },
             "engines": {
                 "node": ">=16"
             },
             "peerDependencies": {
-                "@polkadot/util": "12.1.2",
-                "@polkadot/util-crypto": "12.1.2"
-            }
-        },
-        "node_modules/@polkadot/keyring/node_modules/@polkadot/util": {
-            "version": "12.1.2",
-            "resolved": "https://registry.npmjs.org/@polkadot/util/-/util-12.1.2.tgz",
-            "integrity": "sha512-Da8q+0WVWSuMMS3hLAwnIid8FKRGLmwhD69jikye47zeEXCtvp4e/bjD0YbINNKHoeIRsApchJtqmbaEoxXjIQ==",
-            "dependencies": {
-                "@polkadot/x-bigint": "12.1.2",
-                "@polkadot/x-global": "12.1.2",
-                "@polkadot/x-textdecoder": "12.1.2",
-                "@polkadot/x-textencoder": "12.1.2",
-                "@types/bn.js": "^5.1.1",
-                "bn.js": "^5.2.1",
-                "tslib": "^2.5.0"
-            },
-            "engines": {
-                "node": ">=16"
-            }
-        },
-        "node_modules/@polkadot/keyring/node_modules/@polkadot/x-textdecoder": {
-            "version": "12.1.2",
-            "resolved": "https://registry.npmjs.org/@polkadot/x-textdecoder/-/x-textdecoder-12.1.2.tgz",
-            "integrity": "sha512-O5ygxEHdPCIQVzH7T+xVALBfCwrT5tVms7Yjp6EMT697A9gpD3U2aPr4YinsQO6JFwYpQNzvm2wjW+7EEzYitw==",
-            "dependencies": {
-                "@polkadot/x-global": "12.1.2",
-                "tslib": "^2.5.0"
-            },
-            "engines": {
-                "node": ">=16"
-            }
-        },
-        "node_modules/@polkadot/keyring/node_modules/@polkadot/x-textencoder": {
-            "version": "12.1.2",
-            "resolved": "https://registry.npmjs.org/@polkadot/x-textencoder/-/x-textencoder-12.1.2.tgz",
-            "integrity": "sha512-N+9HIXT0eUQbfg/SfGrNRK8aLFpd2QngJzTxo8CljpjCvQ2ddqzBVFA8o/lKTaXVzX84EmPDzjIV+yJlOXnglA==",
-            "dependencies": {
-                "@polkadot/x-global": "12.1.2",
-                "tslib": "^2.5.0"
-            },
-            "engines": {
-                "node": ">=16"
+                "@polkadot/util": "12.2.1",
+                "@polkadot/util-crypto": "12.2.1"
             }
         },
         "node_modules/@polkadot/networks": {
-            "version": "12.1.2",
-            "resolved": "https://registry.npmjs.org/@polkadot/networks/-/networks-12.1.2.tgz",
-            "integrity": "sha512-9gC5GYGFKXHY4oQaMfYvLLxGJ55slT3V8Zc6uk96KKysEvpSMDXdPUAKZJ3SXN9Iz3KaEa9x6RD5ZEf5j6BJ6g==",
+            "version": "12.2.1",
+            "resolved": "https://registry.npmjs.org/@polkadot/networks/-/networks-12.2.1.tgz",
+            "integrity": "sha512-lYLvFv6iQ2UzkP66zJfsiTo2goeaNeKuwiaGoRoFrDwdwVeZK/+rCsz1uAyvbwmpZIaK8K+dTlSBVWlFoAkgcA==",
             "dependencies": {
-                "@polkadot/util": "12.1.2",
+                "@polkadot/util": "12.2.1",
                 "@substrate/ss58-registry": "^1.40.0",
                 "tslib": "^2.5.0"
             },
@@ -2837,247 +2645,83 @@
                 "node": ">=16"
             }
         },
-        "node_modules/@polkadot/networks/node_modules/@polkadot/util": {
-            "version": "12.1.2",
-            "resolved": "https://registry.npmjs.org/@polkadot/util/-/util-12.1.2.tgz",
-            "integrity": "sha512-Da8q+0WVWSuMMS3hLAwnIid8FKRGLmwhD69jikye47zeEXCtvp4e/bjD0YbINNKHoeIRsApchJtqmbaEoxXjIQ==",
-            "dependencies": {
-                "@polkadot/x-bigint": "12.1.2",
-                "@polkadot/x-global": "12.1.2",
-                "@polkadot/x-textdecoder": "12.1.2",
-                "@polkadot/x-textencoder": "12.1.2",
-                "@types/bn.js": "^5.1.1",
-                "bn.js": "^5.2.1",
-                "tslib": "^2.5.0"
-            },
-            "engines": {
-                "node": ">=16"
-            }
-        },
-        "node_modules/@polkadot/networks/node_modules/@polkadot/x-textdecoder": {
-            "version": "12.1.2",
-            "resolved": "https://registry.npmjs.org/@polkadot/x-textdecoder/-/x-textdecoder-12.1.2.tgz",
-            "integrity": "sha512-O5ygxEHdPCIQVzH7T+xVALBfCwrT5tVms7Yjp6EMT697A9gpD3U2aPr4YinsQO6JFwYpQNzvm2wjW+7EEzYitw==",
-            "dependencies": {
-                "@polkadot/x-global": "12.1.2",
-                "tslib": "^2.5.0"
-            },
-            "engines": {
-                "node": ">=16"
-            }
-        },
-        "node_modules/@polkadot/networks/node_modules/@polkadot/x-textencoder": {
-            "version": "12.1.2",
-            "resolved": "https://registry.npmjs.org/@polkadot/x-textencoder/-/x-textencoder-12.1.2.tgz",
-            "integrity": "sha512-N+9HIXT0eUQbfg/SfGrNRK8aLFpd2QngJzTxo8CljpjCvQ2ddqzBVFA8o/lKTaXVzX84EmPDzjIV+yJlOXnglA==",
-            "dependencies": {
-                "@polkadot/x-global": "12.1.2",
-                "tslib": "^2.5.0"
-            },
-            "engines": {
-                "node": ">=16"
-            }
-        },
         "node_modules/@polkadot/rpc-augment": {
-            "version": "10.4.1",
-            "resolved": "https://registry.npmjs.org/@polkadot/rpc-augment/-/rpc-augment-10.4.1.tgz",
-            "integrity": "sha512-lwwSjyboTTDzrfmBxFgBq4ZcD8mhMKkofmVqS/ntvuJePrCnBPGQG9d+tfntizIO5OpCqFGk0lgYBwae+oQ+vw==",
+            "version": "10.7.3",
+            "resolved": "https://registry.npmjs.org/@polkadot/rpc-augment/-/rpc-augment-10.7.3.tgz",
+            "integrity": "sha512-Y5bfzot3NT1QM0QDnFHG0NsZyBSV69+yOSh635q1gpZureykVnn5o36xQtLDHUKmTkiBjqgmjmYqoXByfHZ+Sg==",
             "dependencies": {
-                "@polkadot/rpc-core": "10.4.1",
-                "@polkadot/types": "10.4.1",
-                "@polkadot/types-codec": "10.4.1",
-                "@polkadot/util": "^12.0.1",
-                "tslib": "^2.5.0"
-            },
-            "engines": {
-                "node": ">=16"
-            }
-        },
-        "node_modules/@polkadot/rpc-augment/node_modules/@polkadot/util": {
-            "version": "12.1.2",
-            "resolved": "https://registry.npmjs.org/@polkadot/util/-/util-12.1.2.tgz",
-            "integrity": "sha512-Da8q+0WVWSuMMS3hLAwnIid8FKRGLmwhD69jikye47zeEXCtvp4e/bjD0YbINNKHoeIRsApchJtqmbaEoxXjIQ==",
-            "dependencies": {
-                "@polkadot/x-bigint": "12.1.2",
-                "@polkadot/x-global": "12.1.2",
-                "@polkadot/x-textdecoder": "12.1.2",
-                "@polkadot/x-textencoder": "12.1.2",
-                "@types/bn.js": "^5.1.1",
-                "bn.js": "^5.2.1",
-                "tslib": "^2.5.0"
-            },
-            "engines": {
-                "node": ">=16"
-            }
-        },
-        "node_modules/@polkadot/rpc-augment/node_modules/@polkadot/x-textdecoder": {
-            "version": "12.1.2",
-            "resolved": "https://registry.npmjs.org/@polkadot/x-textdecoder/-/x-textdecoder-12.1.2.tgz",
-            "integrity": "sha512-O5ygxEHdPCIQVzH7T+xVALBfCwrT5tVms7Yjp6EMT697A9gpD3U2aPr4YinsQO6JFwYpQNzvm2wjW+7EEzYitw==",
-            "dependencies": {
-                "@polkadot/x-global": "12.1.2",
-                "tslib": "^2.5.0"
-            },
-            "engines": {
-                "node": ">=16"
-            }
-        },
-        "node_modules/@polkadot/rpc-augment/node_modules/@polkadot/x-textencoder": {
-            "version": "12.1.2",
-            "resolved": "https://registry.npmjs.org/@polkadot/x-textencoder/-/x-textencoder-12.1.2.tgz",
-            "integrity": "sha512-N+9HIXT0eUQbfg/SfGrNRK8aLFpd2QngJzTxo8CljpjCvQ2ddqzBVFA8o/lKTaXVzX84EmPDzjIV+yJlOXnglA==",
-            "dependencies": {
-                "@polkadot/x-global": "12.1.2",
-                "tslib": "^2.5.0"
+                "@polkadot/rpc-core": "10.7.3",
+                "@polkadot/types": "10.7.3",
+                "@polkadot/types-codec": "10.7.3",
+                "@polkadot/util": "^12.2.1",
+                "tslib": "^2.5.2"
             },
             "engines": {
                 "node": ">=16"
             }
         },
         "node_modules/@polkadot/rpc-core": {
-            "version": "10.4.1",
-            "resolved": "https://registry.npmjs.org/@polkadot/rpc-core/-/rpc-core-10.4.1.tgz",
-            "integrity": "sha512-jE3dBzfOFkiROMsiXpge/njvwPDCXF990VPFtlFqVWpr9ypXY7eZT1gduanN6YkXRjzcBVVPHaPfWLejie6hZA==",
+            "version": "10.7.3",
+            "resolved": "https://registry.npmjs.org/@polkadot/rpc-core/-/rpc-core-10.7.3.tgz",
+            "integrity": "sha512-SL8PDfuYEwDx+g1KBq7DVFqP/dSEromhDfQHWs/mlxh+YSD4sOJBVvd1HN0PIsG/Xi6qJwzWoj0sLNy4wymhcA==",
             "dependencies": {
-                "@polkadot/rpc-augment": "10.4.1",
-                "@polkadot/rpc-provider": "10.4.1",
-                "@polkadot/types": "10.4.1",
-                "@polkadot/util": "^12.0.1",
-                "rxjs": "^7.8.0",
-                "tslib": "^2.5.0"
-            },
-            "engines": {
-                "node": ">=16"
-            }
-        },
-        "node_modules/@polkadot/rpc-core/node_modules/@polkadot/util": {
-            "version": "12.1.2",
-            "resolved": "https://registry.npmjs.org/@polkadot/util/-/util-12.1.2.tgz",
-            "integrity": "sha512-Da8q+0WVWSuMMS3hLAwnIid8FKRGLmwhD69jikye47zeEXCtvp4e/bjD0YbINNKHoeIRsApchJtqmbaEoxXjIQ==",
-            "dependencies": {
-                "@polkadot/x-bigint": "12.1.2",
-                "@polkadot/x-global": "12.1.2",
-                "@polkadot/x-textdecoder": "12.1.2",
-                "@polkadot/x-textencoder": "12.1.2",
-                "@types/bn.js": "^5.1.1",
-                "bn.js": "^5.2.1",
-                "tslib": "^2.5.0"
-            },
-            "engines": {
-                "node": ">=16"
-            }
-        },
-        "node_modules/@polkadot/rpc-core/node_modules/@polkadot/x-textdecoder": {
-            "version": "12.1.2",
-            "resolved": "https://registry.npmjs.org/@polkadot/x-textdecoder/-/x-textdecoder-12.1.2.tgz",
-            "integrity": "sha512-O5ygxEHdPCIQVzH7T+xVALBfCwrT5tVms7Yjp6EMT697A9gpD3U2aPr4YinsQO6JFwYpQNzvm2wjW+7EEzYitw==",
-            "dependencies": {
-                "@polkadot/x-global": "12.1.2",
-                "tslib": "^2.5.0"
-            },
-            "engines": {
-                "node": ">=16"
-            }
-        },
-        "node_modules/@polkadot/rpc-core/node_modules/@polkadot/x-textencoder": {
-            "version": "12.1.2",
-            "resolved": "https://registry.npmjs.org/@polkadot/x-textencoder/-/x-textencoder-12.1.2.tgz",
-            "integrity": "sha512-N+9HIXT0eUQbfg/SfGrNRK8aLFpd2QngJzTxo8CljpjCvQ2ddqzBVFA8o/lKTaXVzX84EmPDzjIV+yJlOXnglA==",
-            "dependencies": {
-                "@polkadot/x-global": "12.1.2",
-                "tslib": "^2.5.0"
+                "@polkadot/rpc-augment": "10.7.3",
+                "@polkadot/rpc-provider": "10.7.3",
+                "@polkadot/types": "10.7.3",
+                "@polkadot/util": "^12.2.1",
+                "rxjs": "^7.8.1",
+                "tslib": "^2.5.2"
             },
             "engines": {
                 "node": ">=16"
             }
         },
         "node_modules/@polkadot/rpc-provider": {
-            "version": "10.4.1",
-            "resolved": "https://registry.npmjs.org/@polkadot/rpc-provider/-/rpc-provider-10.4.1.tgz",
-            "integrity": "sha512-DwXs5dB1hp0P17I/Aqg+BnILQRMWlmMlABfSwwPprOh+16BBDw4P7bEuvaYw3gl/Zrxt4UhDcPl48jD+4j5OrQ==",
+            "version": "10.7.3",
+            "resolved": "https://registry.npmjs.org/@polkadot/rpc-provider/-/rpc-provider-10.7.3.tgz",
+            "integrity": "sha512-A87O8UH3erxV8G8LFxDVYvWy9DPx30sPPPaPoDju2vtd7b9yyGMIdazJwhx1rXwD2PYsu7gEMdUNo8oVtDQf4A==",
             "dependencies": {
-                "@polkadot/keyring": "^12.0.1",
-                "@polkadot/types": "10.4.1",
-                "@polkadot/types-support": "10.4.1",
-                "@polkadot/util": "^12.0.1",
-                "@polkadot/util-crypto": "^12.0.1",
-                "@polkadot/x-fetch": "^12.0.1",
-                "@polkadot/x-global": "^12.0.1",
-                "@polkadot/x-ws": "^12.0.1",
-                "eventemitter3": "^5.0.0",
+                "@polkadot/keyring": "^12.2.1",
+                "@polkadot/types": "10.7.3",
+                "@polkadot/types-support": "10.7.3",
+                "@polkadot/util": "^12.2.1",
+                "@polkadot/util-crypto": "^12.2.1",
+                "@polkadot/x-fetch": "^12.2.1",
+                "@polkadot/x-global": "^12.2.1",
+                "@polkadot/x-ws": "^12.2.1",
+                "eventemitter3": "^5.0.1",
                 "mock-socket": "^9.2.1",
-                "nock": "^13.3.0",
-                "tslib": "^2.5.0"
+                "nock": "^13.3.1",
+                "tslib": "^2.5.2"
             },
             "engines": {
                 "node": ">=16"
             },
             "optionalDependencies": {
-                "@substrate/connect": "0.7.24"
-            }
-        },
-        "node_modules/@polkadot/rpc-provider/node_modules/@polkadot/util": {
-            "version": "12.1.2",
-            "resolved": "https://registry.npmjs.org/@polkadot/util/-/util-12.1.2.tgz",
-            "integrity": "sha512-Da8q+0WVWSuMMS3hLAwnIid8FKRGLmwhD69jikye47zeEXCtvp4e/bjD0YbINNKHoeIRsApchJtqmbaEoxXjIQ==",
-            "dependencies": {
-                "@polkadot/x-bigint": "12.1.2",
-                "@polkadot/x-global": "12.1.2",
-                "@polkadot/x-textdecoder": "12.1.2",
-                "@polkadot/x-textencoder": "12.1.2",
-                "@types/bn.js": "^5.1.1",
-                "bn.js": "^5.2.1",
-                "tslib": "^2.5.0"
-            },
-            "engines": {
-                "node": ">=16"
-            }
-        },
-        "node_modules/@polkadot/rpc-provider/node_modules/@polkadot/x-textdecoder": {
-            "version": "12.1.2",
-            "resolved": "https://registry.npmjs.org/@polkadot/x-textdecoder/-/x-textdecoder-12.1.2.tgz",
-            "integrity": "sha512-O5ygxEHdPCIQVzH7T+xVALBfCwrT5tVms7Yjp6EMT697A9gpD3U2aPr4YinsQO6JFwYpQNzvm2wjW+7EEzYitw==",
-            "dependencies": {
-                "@polkadot/x-global": "12.1.2",
-                "tslib": "^2.5.0"
-            },
-            "engines": {
-                "node": ">=16"
-            }
-        },
-        "node_modules/@polkadot/rpc-provider/node_modules/@polkadot/x-textencoder": {
-            "version": "12.1.2",
-            "resolved": "https://registry.npmjs.org/@polkadot/x-textencoder/-/x-textencoder-12.1.2.tgz",
-            "integrity": "sha512-N+9HIXT0eUQbfg/SfGrNRK8aLFpd2QngJzTxo8CljpjCvQ2ddqzBVFA8o/lKTaXVzX84EmPDzjIV+yJlOXnglA==",
-            "dependencies": {
-                "@polkadot/x-global": "12.1.2",
-                "tslib": "^2.5.0"
-            },
-            "engines": {
-                "node": ">=16"
+                "@substrate/connect": "0.7.26"
             }
         },
         "node_modules/@polkadot/typegen": {
-            "version": "10.4.1",
-            "resolved": "https://registry.npmjs.org/@polkadot/typegen/-/typegen-10.4.1.tgz",
-            "integrity": "sha512-M2DwurCqX4n7IAXWRK/T9yLERC6y+rKzg3YpIiQ6RdOz5Hmr0vimU/1KVunW/0I8gOI+dCvHR6ybXftRrLhabg==",
+            "version": "10.7.3",
+            "resolved": "https://registry.npmjs.org/@polkadot/typegen/-/typegen-10.7.3.tgz",
+            "integrity": "sha512-BtaUs1SOW58ilbrvDom6t5J8P0uT4pBYQxJtts+8df6lkggr/UiXWP7xPMIRWXs2U0sHp6TZnYOE9TE2/qjdRw==",
             "dev": true,
             "dependencies": {
-                "@polkadot/api": "10.4.1",
-                "@polkadot/api-augment": "10.4.1",
-                "@polkadot/rpc-augment": "10.4.1",
-                "@polkadot/rpc-provider": "10.4.1",
-                "@polkadot/types": "10.4.1",
-                "@polkadot/types-augment": "10.4.1",
-                "@polkadot/types-codec": "10.4.1",
-                "@polkadot/types-create": "10.4.1",
-                "@polkadot/types-support": "10.4.1",
-                "@polkadot/util": "^12.0.1",
-                "@polkadot/util-crypto": "^12.0.1",
-                "@polkadot/x-ws": "^12.0.1",
+                "@polkadot/api": "10.7.3",
+                "@polkadot/api-augment": "10.7.3",
+                "@polkadot/rpc-augment": "10.7.3",
+                "@polkadot/rpc-provider": "10.7.3",
+                "@polkadot/types": "10.7.3",
+                "@polkadot/types-augment": "10.7.3",
+                "@polkadot/types-codec": "10.7.3",
+                "@polkadot/types-create": "10.7.3",
+                "@polkadot/types-support": "10.7.3",
+                "@polkadot/util": "^12.2.1",
+                "@polkadot/util-crypto": "^12.2.1",
+                "@polkadot/x-ws": "^12.2.1",
                 "handlebars": "^4.7.7",
-                "tslib": "^2.5.0",
-                "yargs": "^17.7.1"
+                "tslib": "^2.5.2",
+                "yargs": "^17.7.2"
             },
             "bin": {
                 "polkadot-types-chain-info": "scripts/polkadot-types-chain-info.mjs",
@@ -3090,412 +2734,122 @@
                 "node": ">=16"
             }
         },
-        "node_modules/@polkadot/typegen/node_modules/@polkadot/util": {
-            "version": "12.1.2",
-            "resolved": "https://registry.npmjs.org/@polkadot/util/-/util-12.1.2.tgz",
-            "integrity": "sha512-Da8q+0WVWSuMMS3hLAwnIid8FKRGLmwhD69jikye47zeEXCtvp4e/bjD0YbINNKHoeIRsApchJtqmbaEoxXjIQ==",
-            "dev": true,
-            "dependencies": {
-                "@polkadot/x-bigint": "12.1.2",
-                "@polkadot/x-global": "12.1.2",
-                "@polkadot/x-textdecoder": "12.1.2",
-                "@polkadot/x-textencoder": "12.1.2",
-                "@types/bn.js": "^5.1.1",
-                "bn.js": "^5.2.1",
-                "tslib": "^2.5.0"
-            },
-            "engines": {
-                "node": ">=16"
-            }
-        },
-        "node_modules/@polkadot/typegen/node_modules/@polkadot/x-textdecoder": {
-            "version": "12.1.2",
-            "resolved": "https://registry.npmjs.org/@polkadot/x-textdecoder/-/x-textdecoder-12.1.2.tgz",
-            "integrity": "sha512-O5ygxEHdPCIQVzH7T+xVALBfCwrT5tVms7Yjp6EMT697A9gpD3U2aPr4YinsQO6JFwYpQNzvm2wjW+7EEzYitw==",
-            "dev": true,
-            "dependencies": {
-                "@polkadot/x-global": "12.1.2",
-                "tslib": "^2.5.0"
-            },
-            "engines": {
-                "node": ">=16"
-            }
-        },
-        "node_modules/@polkadot/typegen/node_modules/@polkadot/x-textencoder": {
-            "version": "12.1.2",
-            "resolved": "https://registry.npmjs.org/@polkadot/x-textencoder/-/x-textencoder-12.1.2.tgz",
-            "integrity": "sha512-N+9HIXT0eUQbfg/SfGrNRK8aLFpd2QngJzTxo8CljpjCvQ2ddqzBVFA8o/lKTaXVzX84EmPDzjIV+yJlOXnglA==",
-            "dev": true,
-            "dependencies": {
-                "@polkadot/x-global": "12.1.2",
-                "tslib": "^2.5.0"
-            },
-            "engines": {
-                "node": ">=16"
-            }
-        },
         "node_modules/@polkadot/types": {
-            "version": "10.4.1",
-            "resolved": "https://registry.npmjs.org/@polkadot/types/-/types-10.4.1.tgz",
-            "integrity": "sha512-w4spUa4CMLoPuIHOANR8X5F/Hfs4b4OnxsofA9SOl2aaQNRgu77Qu0y60rReu8HxBKD/FUBJJmRpZeY/2WQAAQ==",
+            "version": "10.7.3",
+            "resolved": "https://registry.npmjs.org/@polkadot/types/-/types-10.7.3.tgz",
+            "integrity": "sha512-F+h8tvlvMgwF+oVLu/bTV1WtsqMoosoGKL96a/6LY1a1ykKhK1HiB11Lodu3VkRTQa3oie5ftjg/iCQ2pilgDA==",
             "dependencies": {
-                "@polkadot/keyring": "^12.0.1",
-                "@polkadot/types-augment": "10.4.1",
-                "@polkadot/types-codec": "10.4.1",
-                "@polkadot/types-create": "10.4.1",
-                "@polkadot/util": "^12.0.1",
-                "@polkadot/util-crypto": "^12.0.1",
-                "rxjs": "^7.8.0",
-                "tslib": "^2.5.0"
+                "@polkadot/keyring": "^12.2.1",
+                "@polkadot/types-augment": "10.7.3",
+                "@polkadot/types-codec": "10.7.3",
+                "@polkadot/types-create": "10.7.3",
+                "@polkadot/util": "^12.2.1",
+                "@polkadot/util-crypto": "^12.2.1",
+                "rxjs": "^7.8.1",
+                "tslib": "^2.5.2"
             },
             "engines": {
                 "node": ">=16"
             }
         },
         "node_modules/@polkadot/types-augment": {
-            "version": "10.4.1",
-            "resolved": "https://registry.npmjs.org/@polkadot/types-augment/-/types-augment-10.4.1.tgz",
-            "integrity": "sha512-4QWfxf6nA+sBf2X88S454N5Wpc4yTL+9uwdCP5PiqyDuCv96l+G0jQWurolywADJcKMKcnu8zHdQdv4rcgUyxQ==",
+            "version": "10.7.3",
+            "resolved": "https://registry.npmjs.org/@polkadot/types-augment/-/types-augment-10.7.3.tgz",
+            "integrity": "sha512-iWw0Qfqko/D2XDKKjI3syPMZol24k0BEJWsk8HX4waqFDNa+DIGz729J5cj1NopHg7re6BkGhYloMAaH0r2Q7g==",
             "dependencies": {
-                "@polkadot/types": "10.4.1",
-                "@polkadot/types-codec": "10.4.1",
-                "@polkadot/util": "^12.0.1",
-                "tslib": "^2.5.0"
-            },
-            "engines": {
-                "node": ">=16"
-            }
-        },
-        "node_modules/@polkadot/types-augment/node_modules/@polkadot/util": {
-            "version": "12.1.2",
-            "resolved": "https://registry.npmjs.org/@polkadot/util/-/util-12.1.2.tgz",
-            "integrity": "sha512-Da8q+0WVWSuMMS3hLAwnIid8FKRGLmwhD69jikye47zeEXCtvp4e/bjD0YbINNKHoeIRsApchJtqmbaEoxXjIQ==",
-            "dependencies": {
-                "@polkadot/x-bigint": "12.1.2",
-                "@polkadot/x-global": "12.1.2",
-                "@polkadot/x-textdecoder": "12.1.2",
-                "@polkadot/x-textencoder": "12.1.2",
-                "@types/bn.js": "^5.1.1",
-                "bn.js": "^5.2.1",
-                "tslib": "^2.5.0"
-            },
-            "engines": {
-                "node": ">=16"
-            }
-        },
-        "node_modules/@polkadot/types-augment/node_modules/@polkadot/x-textdecoder": {
-            "version": "12.1.2",
-            "resolved": "https://registry.npmjs.org/@polkadot/x-textdecoder/-/x-textdecoder-12.1.2.tgz",
-            "integrity": "sha512-O5ygxEHdPCIQVzH7T+xVALBfCwrT5tVms7Yjp6EMT697A9gpD3U2aPr4YinsQO6JFwYpQNzvm2wjW+7EEzYitw==",
-            "dependencies": {
-                "@polkadot/x-global": "12.1.2",
-                "tslib": "^2.5.0"
-            },
-            "engines": {
-                "node": ">=16"
-            }
-        },
-        "node_modules/@polkadot/types-augment/node_modules/@polkadot/x-textencoder": {
-            "version": "12.1.2",
-            "resolved": "https://registry.npmjs.org/@polkadot/x-textencoder/-/x-textencoder-12.1.2.tgz",
-            "integrity": "sha512-N+9HIXT0eUQbfg/SfGrNRK8aLFpd2QngJzTxo8CljpjCvQ2ddqzBVFA8o/lKTaXVzX84EmPDzjIV+yJlOXnglA==",
-            "dependencies": {
-                "@polkadot/x-global": "12.1.2",
-                "tslib": "^2.5.0"
+                "@polkadot/types": "10.7.3",
+                "@polkadot/types-codec": "10.7.3",
+                "@polkadot/util": "^12.2.1",
+                "tslib": "^2.5.2"
             },
             "engines": {
                 "node": ">=16"
             }
         },
         "node_modules/@polkadot/types-codec": {
-            "version": "10.4.1",
-            "resolved": "https://registry.npmjs.org/@polkadot/types-codec/-/types-codec-10.4.1.tgz",
-            "integrity": "sha512-h6OCSF6i0b/Q4uCOEEiibMkGefhb7daaDGwoxjTEOeSqDE9gMIkhkyXVjqcOGbsHsFaYqYhuJakRQe/LICykTw==",
+            "version": "10.7.3",
+            "resolved": "https://registry.npmjs.org/@polkadot/types-codec/-/types-codec-10.7.3.tgz",
+            "integrity": "sha512-/9C50FZFSL4qGIOXYUDkNUt1YJSsEGbo2aSxJLMwki7U3UuBdbBqolsbKQRM4g6dtAS0FSM8lFYaKXFiz4VxNw==",
             "dependencies": {
-                "@polkadot/util": "^12.0.1",
-                "@polkadot/x-bigint": "^12.0.1",
-                "tslib": "^2.5.0"
-            },
-            "engines": {
-                "node": ">=16"
-            }
-        },
-        "node_modules/@polkadot/types-codec/node_modules/@polkadot/util": {
-            "version": "12.1.2",
-            "resolved": "https://registry.npmjs.org/@polkadot/util/-/util-12.1.2.tgz",
-            "integrity": "sha512-Da8q+0WVWSuMMS3hLAwnIid8FKRGLmwhD69jikye47zeEXCtvp4e/bjD0YbINNKHoeIRsApchJtqmbaEoxXjIQ==",
-            "dependencies": {
-                "@polkadot/x-bigint": "12.1.2",
-                "@polkadot/x-global": "12.1.2",
-                "@polkadot/x-textdecoder": "12.1.2",
-                "@polkadot/x-textencoder": "12.1.2",
-                "@types/bn.js": "^5.1.1",
-                "bn.js": "^5.2.1",
-                "tslib": "^2.5.0"
-            },
-            "engines": {
-                "node": ">=16"
-            }
-        },
-        "node_modules/@polkadot/types-codec/node_modules/@polkadot/x-textdecoder": {
-            "version": "12.1.2",
-            "resolved": "https://registry.npmjs.org/@polkadot/x-textdecoder/-/x-textdecoder-12.1.2.tgz",
-            "integrity": "sha512-O5ygxEHdPCIQVzH7T+xVALBfCwrT5tVms7Yjp6EMT697A9gpD3U2aPr4YinsQO6JFwYpQNzvm2wjW+7EEzYitw==",
-            "dependencies": {
-                "@polkadot/x-global": "12.1.2",
-                "tslib": "^2.5.0"
-            },
-            "engines": {
-                "node": ">=16"
-            }
-        },
-        "node_modules/@polkadot/types-codec/node_modules/@polkadot/x-textencoder": {
-            "version": "12.1.2",
-            "resolved": "https://registry.npmjs.org/@polkadot/x-textencoder/-/x-textencoder-12.1.2.tgz",
-            "integrity": "sha512-N+9HIXT0eUQbfg/SfGrNRK8aLFpd2QngJzTxo8CljpjCvQ2ddqzBVFA8o/lKTaXVzX84EmPDzjIV+yJlOXnglA==",
-            "dependencies": {
-                "@polkadot/x-global": "12.1.2",
-                "tslib": "^2.5.0"
+                "@polkadot/util": "^12.2.1",
+                "@polkadot/x-bigint": "^12.2.1",
+                "tslib": "^2.5.2"
             },
             "engines": {
                 "node": ">=16"
             }
         },
         "node_modules/@polkadot/types-create": {
-            "version": "10.4.1",
-            "resolved": "https://registry.npmjs.org/@polkadot/types-create/-/types-create-10.4.1.tgz",
-            "integrity": "sha512-E15P4ZQSAIq90Gnc+ZVK7XmEWRIF9qbCAQvJQ6nxikb6u5A9AzePAZ4XwxjJ3JXC5/t0Wxnij+pddtfxOkUi2w==",
+            "version": "10.7.3",
+            "resolved": "https://registry.npmjs.org/@polkadot/types-create/-/types-create-10.7.3.tgz",
+            "integrity": "sha512-xFJqssVGICLoclc3nTBhoZG74Z/yltMUYQmmiqm0ByE5W6451rf76IMNcWpoNe7EuWmA4Ccjy0jG1yEhOTtRuQ==",
             "dependencies": {
-                "@polkadot/types-codec": "10.4.1",
-                "@polkadot/util": "^12.0.1",
-                "tslib": "^2.5.0"
-            },
-            "engines": {
-                "node": ">=16"
-            }
-        },
-        "node_modules/@polkadot/types-create/node_modules/@polkadot/util": {
-            "version": "12.1.2",
-            "resolved": "https://registry.npmjs.org/@polkadot/util/-/util-12.1.2.tgz",
-            "integrity": "sha512-Da8q+0WVWSuMMS3hLAwnIid8FKRGLmwhD69jikye47zeEXCtvp4e/bjD0YbINNKHoeIRsApchJtqmbaEoxXjIQ==",
-            "dependencies": {
-                "@polkadot/x-bigint": "12.1.2",
-                "@polkadot/x-global": "12.1.2",
-                "@polkadot/x-textdecoder": "12.1.2",
-                "@polkadot/x-textencoder": "12.1.2",
-                "@types/bn.js": "^5.1.1",
-                "bn.js": "^5.2.1",
-                "tslib": "^2.5.0"
-            },
-            "engines": {
-                "node": ">=16"
-            }
-        },
-        "node_modules/@polkadot/types-create/node_modules/@polkadot/x-textdecoder": {
-            "version": "12.1.2",
-            "resolved": "https://registry.npmjs.org/@polkadot/x-textdecoder/-/x-textdecoder-12.1.2.tgz",
-            "integrity": "sha512-O5ygxEHdPCIQVzH7T+xVALBfCwrT5tVms7Yjp6EMT697A9gpD3U2aPr4YinsQO6JFwYpQNzvm2wjW+7EEzYitw==",
-            "dependencies": {
-                "@polkadot/x-global": "12.1.2",
-                "tslib": "^2.5.0"
-            },
-            "engines": {
-                "node": ">=16"
-            }
-        },
-        "node_modules/@polkadot/types-create/node_modules/@polkadot/x-textencoder": {
-            "version": "12.1.2",
-            "resolved": "https://registry.npmjs.org/@polkadot/x-textencoder/-/x-textencoder-12.1.2.tgz",
-            "integrity": "sha512-N+9HIXT0eUQbfg/SfGrNRK8aLFpd2QngJzTxo8CljpjCvQ2ddqzBVFA8o/lKTaXVzX84EmPDzjIV+yJlOXnglA==",
-            "dependencies": {
-                "@polkadot/x-global": "12.1.2",
-                "tslib": "^2.5.0"
+                "@polkadot/types-codec": "10.7.3",
+                "@polkadot/util": "^12.2.1",
+                "tslib": "^2.5.2"
             },
             "engines": {
                 "node": ">=16"
             }
         },
         "node_modules/@polkadot/types-known": {
-            "version": "10.4.1",
-            "resolved": "https://registry.npmjs.org/@polkadot/types-known/-/types-known-10.4.1.tgz",
-            "integrity": "sha512-vgxsJeZTdbNJ55CCICRcSeOJD6Qy4D2NaMhR2j24xxHRY1lL8uBfCE/ReIEY2Bxa8cCIjCtw5fXJiCWPjnQQoQ==",
+            "version": "10.7.3",
+            "resolved": "https://registry.npmjs.org/@polkadot/types-known/-/types-known-10.7.3.tgz",
+            "integrity": "sha512-sS8zK/3wds/NmosMupg2TJ/p+dW40jcgzFn42WYSxA1kOP0vtxVMeqM81Xrsig0ENl4Y0Fb+8EDlrmxo9DWdOw==",
             "dependencies": {
-                "@polkadot/networks": "^12.0.1",
-                "@polkadot/types": "10.4.1",
-                "@polkadot/types-codec": "10.4.1",
-                "@polkadot/types-create": "10.4.1",
-                "@polkadot/util": "^12.0.1",
-                "tslib": "^2.5.0"
-            },
-            "engines": {
-                "node": ">=16"
-            }
-        },
-        "node_modules/@polkadot/types-known/node_modules/@polkadot/util": {
-            "version": "12.1.2",
-            "resolved": "https://registry.npmjs.org/@polkadot/util/-/util-12.1.2.tgz",
-            "integrity": "sha512-Da8q+0WVWSuMMS3hLAwnIid8FKRGLmwhD69jikye47zeEXCtvp4e/bjD0YbINNKHoeIRsApchJtqmbaEoxXjIQ==",
-            "dependencies": {
-                "@polkadot/x-bigint": "12.1.2",
-                "@polkadot/x-global": "12.1.2",
-                "@polkadot/x-textdecoder": "12.1.2",
-                "@polkadot/x-textencoder": "12.1.2",
-                "@types/bn.js": "^5.1.1",
-                "bn.js": "^5.2.1",
-                "tslib": "^2.5.0"
-            },
-            "engines": {
-                "node": ">=16"
-            }
-        },
-        "node_modules/@polkadot/types-known/node_modules/@polkadot/x-textdecoder": {
-            "version": "12.1.2",
-            "resolved": "https://registry.npmjs.org/@polkadot/x-textdecoder/-/x-textdecoder-12.1.2.tgz",
-            "integrity": "sha512-O5ygxEHdPCIQVzH7T+xVALBfCwrT5tVms7Yjp6EMT697A9gpD3U2aPr4YinsQO6JFwYpQNzvm2wjW+7EEzYitw==",
-            "dependencies": {
-                "@polkadot/x-global": "12.1.2",
-                "tslib": "^2.5.0"
-            },
-            "engines": {
-                "node": ">=16"
-            }
-        },
-        "node_modules/@polkadot/types-known/node_modules/@polkadot/x-textencoder": {
-            "version": "12.1.2",
-            "resolved": "https://registry.npmjs.org/@polkadot/x-textencoder/-/x-textencoder-12.1.2.tgz",
-            "integrity": "sha512-N+9HIXT0eUQbfg/SfGrNRK8aLFpd2QngJzTxo8CljpjCvQ2ddqzBVFA8o/lKTaXVzX84EmPDzjIV+yJlOXnglA==",
-            "dependencies": {
-                "@polkadot/x-global": "12.1.2",
-                "tslib": "^2.5.0"
+                "@polkadot/networks": "^12.2.1",
+                "@polkadot/types": "10.7.3",
+                "@polkadot/types-codec": "10.7.3",
+                "@polkadot/types-create": "10.7.3",
+                "@polkadot/util": "^12.2.1",
+                "tslib": "^2.5.2"
             },
             "engines": {
                 "node": ">=16"
             }
         },
         "node_modules/@polkadot/types-support": {
-            "version": "10.4.1",
-            "resolved": "https://registry.npmjs.org/@polkadot/types-support/-/types-support-10.4.1.tgz",
-            "integrity": "sha512-kt/TGVAGaGD76eM/kye8qdYxQDZtpc6GS58xYvgnsk59KkCvaOzOE+hHFDXx0UDy4pPgXKquk1EHxwiFTKSb4g==",
+            "version": "10.7.3",
+            "resolved": "https://registry.npmjs.org/@polkadot/types-support/-/types-support-10.7.3.tgz",
+            "integrity": "sha512-3RYIveHUyIysC21YR0XEuTL0ijQQQjFHUbmI3bdjbKgIaQKmgEkRGhFCutkvr9HgB/jUDOpmdxW0t0OJe1etmg==",
             "dependencies": {
-                "@polkadot/util": "^12.0.1",
-                "tslib": "^2.5.0"
-            },
-            "engines": {
-                "node": ">=16"
-            }
-        },
-        "node_modules/@polkadot/types-support/node_modules/@polkadot/util": {
-            "version": "12.1.2",
-            "resolved": "https://registry.npmjs.org/@polkadot/util/-/util-12.1.2.tgz",
-            "integrity": "sha512-Da8q+0WVWSuMMS3hLAwnIid8FKRGLmwhD69jikye47zeEXCtvp4e/bjD0YbINNKHoeIRsApchJtqmbaEoxXjIQ==",
-            "dependencies": {
-                "@polkadot/x-bigint": "12.1.2",
-                "@polkadot/x-global": "12.1.2",
-                "@polkadot/x-textdecoder": "12.1.2",
-                "@polkadot/x-textencoder": "12.1.2",
-                "@types/bn.js": "^5.1.1",
-                "bn.js": "^5.2.1",
-                "tslib": "^2.5.0"
-            },
-            "engines": {
-                "node": ">=16"
-            }
-        },
-        "node_modules/@polkadot/types-support/node_modules/@polkadot/x-textdecoder": {
-            "version": "12.1.2",
-            "resolved": "https://registry.npmjs.org/@polkadot/x-textdecoder/-/x-textdecoder-12.1.2.tgz",
-            "integrity": "sha512-O5ygxEHdPCIQVzH7T+xVALBfCwrT5tVms7Yjp6EMT697A9gpD3U2aPr4YinsQO6JFwYpQNzvm2wjW+7EEzYitw==",
-            "dependencies": {
-                "@polkadot/x-global": "12.1.2",
-                "tslib": "^2.5.0"
-            },
-            "engines": {
-                "node": ">=16"
-            }
-        },
-        "node_modules/@polkadot/types-support/node_modules/@polkadot/x-textencoder": {
-            "version": "12.1.2",
-            "resolved": "https://registry.npmjs.org/@polkadot/x-textencoder/-/x-textencoder-12.1.2.tgz",
-            "integrity": "sha512-N+9HIXT0eUQbfg/SfGrNRK8aLFpd2QngJzTxo8CljpjCvQ2ddqzBVFA8o/lKTaXVzX84EmPDzjIV+yJlOXnglA==",
-            "dependencies": {
-                "@polkadot/x-global": "12.1.2",
-                "tslib": "^2.5.0"
-            },
-            "engines": {
-                "node": ">=16"
-            }
-        },
-        "node_modules/@polkadot/types/node_modules/@polkadot/util": {
-            "version": "12.1.2",
-            "resolved": "https://registry.npmjs.org/@polkadot/util/-/util-12.1.2.tgz",
-            "integrity": "sha512-Da8q+0WVWSuMMS3hLAwnIid8FKRGLmwhD69jikye47zeEXCtvp4e/bjD0YbINNKHoeIRsApchJtqmbaEoxXjIQ==",
-            "dependencies": {
-                "@polkadot/x-bigint": "12.1.2",
-                "@polkadot/x-global": "12.1.2",
-                "@polkadot/x-textdecoder": "12.1.2",
-                "@polkadot/x-textencoder": "12.1.2",
-                "@types/bn.js": "^5.1.1",
-                "bn.js": "^5.2.1",
-                "tslib": "^2.5.0"
-            },
-            "engines": {
-                "node": ">=16"
-            }
-        },
-        "node_modules/@polkadot/types/node_modules/@polkadot/x-textdecoder": {
-            "version": "12.1.2",
-            "resolved": "https://registry.npmjs.org/@polkadot/x-textdecoder/-/x-textdecoder-12.1.2.tgz",
-            "integrity": "sha512-O5ygxEHdPCIQVzH7T+xVALBfCwrT5tVms7Yjp6EMT697A9gpD3U2aPr4YinsQO6JFwYpQNzvm2wjW+7EEzYitw==",
-            "dependencies": {
-                "@polkadot/x-global": "12.1.2",
-                "tslib": "^2.5.0"
-            },
-            "engines": {
-                "node": ">=16"
-            }
-        },
-        "node_modules/@polkadot/types/node_modules/@polkadot/x-textencoder": {
-            "version": "12.1.2",
-            "resolved": "https://registry.npmjs.org/@polkadot/x-textencoder/-/x-textencoder-12.1.2.tgz",
-            "integrity": "sha512-N+9HIXT0eUQbfg/SfGrNRK8aLFpd2QngJzTxo8CljpjCvQ2ddqzBVFA8o/lKTaXVzX84EmPDzjIV+yJlOXnglA==",
-            "dependencies": {
-                "@polkadot/x-global": "12.1.2",
-                "tslib": "^2.5.0"
+                "@polkadot/util": "^12.2.1",
+                "tslib": "^2.5.2"
             },
             "engines": {
                 "node": ">=16"
             }
         },
         "node_modules/@polkadot/util": {
-            "version": "10.4.1",
-            "resolved": "https://registry.npmjs.org/@polkadot/util/-/util-10.4.1.tgz",
-            "integrity": "sha512-dOlmue4nhbk8msbs/YgoBqVtUzDx5iqhiDnC62GWC8b+JmIlIM4Ddgg1rhBf1KJ6TfEQrzQA0FwLaqCCH5vYmA==",
+            "version": "12.2.1",
+            "resolved": "https://registry.npmjs.org/@polkadot/util/-/util-12.2.1.tgz",
+            "integrity": "sha512-MQmPx9aCX4GTpDY/USUQywXRyaDbaibg4V1+c/CoRTsoDu+XHNM8G3lpabdNAYKZrtxg+3/1bTS0ojm6ANSQRw==",
             "dependencies": {
-                "@babel/runtime": "^7.20.13",
-                "@polkadot/x-bigint": "10.4.1",
-                "@polkadot/x-global": "10.4.1",
-                "@polkadot/x-textdecoder": "10.4.1",
-                "@polkadot/x-textencoder": "10.4.1",
+                "@polkadot/x-bigint": "12.2.1",
+                "@polkadot/x-global": "12.2.1",
+                "@polkadot/x-textdecoder": "12.2.1",
+                "@polkadot/x-textencoder": "12.2.1",
                 "@types/bn.js": "^5.1.1",
-                "bn.js": "^5.2.1"
+                "bn.js": "^5.2.1",
+                "tslib": "^2.5.0"
             },
             "engines": {
-                "node": ">=14.0.0"
+                "node": ">=16"
             }
         },
         "node_modules/@polkadot/util-crypto": {
-            "version": "12.1.2",
-            "resolved": "https://registry.npmjs.org/@polkadot/util-crypto/-/util-crypto-12.1.2.tgz",
-            "integrity": "sha512-xV5P7auvs2Qck+HGGk2uaJWyujbJSFc+VDlM/giqM2xKgfmkRUTgGtcBuLLLZq5R1A9tGW5DUQg0VgVHYJaNvw==",
+            "version": "12.2.1",
+            "resolved": "https://registry.npmjs.org/@polkadot/util-crypto/-/util-crypto-12.2.1.tgz",
+            "integrity": "sha512-MFh7Sdm7/G9ot5eIBZGuQXTYP/EbOCh1+ODyygp9/TjWAmJZMq1J73Uqk4KmzkwpDBpNZO8TGjiYwL8lR6BnGg==",
             "dependencies": {
                 "@noble/curves": "1.0.0",
                 "@noble/hashes": "1.3.0",
-                "@polkadot/networks": "12.1.2",
-                "@polkadot/util": "12.1.2",
-                "@polkadot/wasm-crypto": "^7.1.2",
-                "@polkadot/wasm-util": "^7.1.2",
-                "@polkadot/x-bigint": "12.1.2",
-                "@polkadot/x-randomvalues": "12.1.2",
+                "@polkadot/networks": "12.2.1",
+                "@polkadot/util": "12.2.1",
+                "@polkadot/wasm-crypto": "^7.2.1",
+                "@polkadot/wasm-util": "^7.2.1",
+                "@polkadot/x-bigint": "12.2.1",
+                "@polkadot/x-randomvalues": "12.2.1",
                 "@scure/base": "1.1.1",
                 "tslib": "^2.5.0"
             },
@@ -3503,32 +2857,15 @@
                 "node": ">=16"
             },
             "peerDependencies": {
-                "@polkadot/util": "12.1.2"
+                "@polkadot/util": "12.2.1"
             }
         },
-        "node_modules/@polkadot/util-crypto/node_modules/@polkadot/util": {
-            "version": "12.1.2",
-            "resolved": "https://registry.npmjs.org/@polkadot/util/-/util-12.1.2.tgz",
-            "integrity": "sha512-Da8q+0WVWSuMMS3hLAwnIid8FKRGLmwhD69jikye47zeEXCtvp4e/bjD0YbINNKHoeIRsApchJtqmbaEoxXjIQ==",
+        "node_modules/@polkadot/wasm-bridge": {
+            "version": "7.2.1",
+            "resolved": "https://registry.npmjs.org/@polkadot/wasm-bridge/-/wasm-bridge-7.2.1.tgz",
+            "integrity": "sha512-uV/LHREDBGBbHrrv7HTki+Klw0PYZzFomagFWII4lp6Toj/VCvRh5WMzooVC+g/XsBGosAwrvBhoModabyHx+A==",
             "dependencies": {
-                "@polkadot/x-bigint": "12.1.2",
-                "@polkadot/x-global": "12.1.2",
-                "@polkadot/x-textdecoder": "12.1.2",
-                "@polkadot/x-textencoder": "12.1.2",
-                "@types/bn.js": "^5.1.1",
-                "bn.js": "^5.2.1",
-                "tslib": "^2.5.0"
-            },
-            "engines": {
-                "node": ">=16"
-            }
-        },
-        "node_modules/@polkadot/util-crypto/node_modules/@polkadot/wasm-bridge": {
-            "version": "7.1.2",
-            "resolved": "https://registry.npmjs.org/@polkadot/wasm-bridge/-/wasm-bridge-7.1.2.tgz",
-            "integrity": "sha512-6t8b1el/03b30ZFKVFYU5pQEx9OeDZ3GBndgZ5b6fMNFRoowFWTwx74HLqhXlQb+hOTjGJA70jHdxkplh1sO3A==",
-            "dependencies": {
-                "@polkadot/wasm-util": "7.1.2",
+                "@polkadot/wasm-util": "7.2.1",
                 "tslib": "^2.5.0"
             },
             "engines": {
@@ -3539,16 +2876,16 @@
                 "@polkadot/x-randomvalues": "*"
             }
         },
-        "node_modules/@polkadot/util-crypto/node_modules/@polkadot/wasm-crypto": {
-            "version": "7.1.2",
-            "resolved": "https://registry.npmjs.org/@polkadot/wasm-crypto/-/wasm-crypto-7.1.2.tgz",
-            "integrity": "sha512-DO5Xf5nA2mSVdWnRM+PLAVE/wcg9vZAQkSHHSE+/qDmDVCQYygksHOA8ecRvn8nGfMNZQ0rmlIlsgyvAEtX1pw==",
+        "node_modules/@polkadot/wasm-crypto": {
+            "version": "7.2.1",
+            "resolved": "https://registry.npmjs.org/@polkadot/wasm-crypto/-/wasm-crypto-7.2.1.tgz",
+            "integrity": "sha512-SA2+33S9TAwGhniKgztVN6pxUKpGfN4Tre/eUZGUfpgRkT92wIUT2GpGWQE+fCCqGQgADrNiBcwt6XwdPqMQ4Q==",
             "dependencies": {
-                "@polkadot/wasm-bridge": "7.1.2",
-                "@polkadot/wasm-crypto-asmjs": "7.1.2",
-                "@polkadot/wasm-crypto-init": "7.1.2",
-                "@polkadot/wasm-crypto-wasm": "7.1.2",
-                "@polkadot/wasm-util": "7.1.2",
+                "@polkadot/wasm-bridge": "7.2.1",
+                "@polkadot/wasm-crypto-asmjs": "7.2.1",
+                "@polkadot/wasm-crypto-init": "7.2.1",
+                "@polkadot/wasm-crypto-wasm": "7.2.1",
+                "@polkadot/wasm-util": "7.2.1",
                 "tslib": "^2.5.0"
             },
             "engines": {
@@ -3557,94 +2894,12 @@
             "peerDependencies": {
                 "@polkadot/util": "*",
                 "@polkadot/x-randomvalues": "*"
-            }
-        },
-        "node_modules/@polkadot/util-crypto/node_modules/@polkadot/wasm-crypto-init": {
-            "version": "7.1.2",
-            "resolved": "https://registry.npmjs.org/@polkadot/wasm-crypto-init/-/wasm-crypto-init-7.1.2.tgz",
-            "integrity": "sha512-jqeK04MYofvCU7kFMJDoKUM9SjfDEBDizIxgurxAZZvF4jMOhgStZTLTr9QkKTOMTrMUE9PWRMzrnDM/Od3kzA==",
-            "dependencies": {
-                "@polkadot/wasm-bridge": "7.1.2",
-                "@polkadot/wasm-crypto-asmjs": "7.1.2",
-                "@polkadot/wasm-crypto-wasm": "7.1.2",
-                "@polkadot/wasm-util": "7.1.2",
-                "tslib": "^2.5.0"
-            },
-            "engines": {
-                "node": ">=16"
-            },
-            "peerDependencies": {
-                "@polkadot/util": "*",
-                "@polkadot/x-randomvalues": "*"
-            }
-        },
-        "node_modules/@polkadot/util-crypto/node_modules/@polkadot/x-randomvalues": {
-            "version": "12.1.2",
-            "resolved": "https://registry.npmjs.org/@polkadot/x-randomvalues/-/x-randomvalues-12.1.2.tgz",
-            "integrity": "sha512-Jqwftgl+t8egG5miwI3f+MUNp3GIJUxZ0mcYbGDc3dY8LueY3yhKs94MQF/S6h8XPpRFI5/8mUZnmMgmNXsX6Q==",
-            "dependencies": {
-                "@polkadot/x-global": "12.1.2",
-                "tslib": "^2.5.0"
-            },
-            "engines": {
-                "node": ">=16"
-            },
-            "peerDependencies": {
-                "@polkadot/util": "12.1.2",
-                "@polkadot/wasm-util": "*"
-            }
-        },
-        "node_modules/@polkadot/util-crypto/node_modules/@polkadot/x-textdecoder": {
-            "version": "12.1.2",
-            "resolved": "https://registry.npmjs.org/@polkadot/x-textdecoder/-/x-textdecoder-12.1.2.tgz",
-            "integrity": "sha512-O5ygxEHdPCIQVzH7T+xVALBfCwrT5tVms7Yjp6EMT697A9gpD3U2aPr4YinsQO6JFwYpQNzvm2wjW+7EEzYitw==",
-            "dependencies": {
-                "@polkadot/x-global": "12.1.2",
-                "tslib": "^2.5.0"
-            },
-            "engines": {
-                "node": ">=16"
-            }
-        },
-        "node_modules/@polkadot/util-crypto/node_modules/@polkadot/x-textencoder": {
-            "version": "12.1.2",
-            "resolved": "https://registry.npmjs.org/@polkadot/x-textencoder/-/x-textencoder-12.1.2.tgz",
-            "integrity": "sha512-N+9HIXT0eUQbfg/SfGrNRK8aLFpd2QngJzTxo8CljpjCvQ2ddqzBVFA8o/lKTaXVzX84EmPDzjIV+yJlOXnglA==",
-            "dependencies": {
-                "@polkadot/x-global": "12.1.2",
-                "tslib": "^2.5.0"
-            },
-            "engines": {
-                "node": ">=16"
-            }
-        },
-        "node_modules/@polkadot/util/node_modules/@polkadot/x-bigint": {
-            "version": "10.4.1",
-            "resolved": "https://registry.npmjs.org/@polkadot/x-bigint/-/x-bigint-10.4.1.tgz",
-            "integrity": "sha512-CpTGPwNUDrJcrnfDU/94mfZ16TZoTwWAwTLH0oMUJtrM2mHo+LtWZBlCTG+thhkcGcSRy/rrpzx4ffNsj5Sy1w==",
-            "dependencies": {
-                "@babel/runtime": "^7.20.13",
-                "@polkadot/x-global": "10.4.1"
-            },
-            "engines": {
-                "node": ">=14.0.0"
-            }
-        },
-        "node_modules/@polkadot/util/node_modules/@polkadot/x-global": {
-            "version": "10.4.1",
-            "resolved": "https://registry.npmjs.org/@polkadot/x-global/-/x-global-10.4.1.tgz",
-            "integrity": "sha512-Kdh2Fzl1fpEwU6vL1HMaXJy+fadX79eSy4VAnIx/uyCF3H5Z4WaxzoiNVmHdDZSVaamqtbuKepi1nkE3q1nvlA==",
-            "dependencies": {
-                "@babel/runtime": "^7.20.13"
-            },
-            "engines": {
-                "node": ">=14.0.0"
             }
         },
         "node_modules/@polkadot/wasm-crypto-asmjs": {
-            "version": "7.1.2",
-            "resolved": "https://registry.npmjs.org/@polkadot/wasm-crypto-asmjs/-/wasm-crypto-asmjs-7.1.2.tgz",
-            "integrity": "sha512-Gdb824MoeWjESv7fu57Dqpvmx7FR2zhM2Os34/H8s1LcZ8m5qUxvm22kjtq+6DRJlGo7KxpS0OA4xCbSDDe0rA==",
+            "version": "7.2.1",
+            "resolved": "https://registry.npmjs.org/@polkadot/wasm-crypto-asmjs/-/wasm-crypto-asmjs-7.2.1.tgz",
+            "integrity": "sha512-z/d21bmxyVfkzGsKef/FWswKX02x5lK97f4NPBZ9XBeiFkmzlXhdSnu58/+b1sKsRAGdW/Rn/rTNRDhW0GqCAg==",
             "dependencies": {
                 "tslib": "^2.5.0"
             },
@@ -3655,12 +2910,31 @@
                 "@polkadot/util": "*"
             }
         },
-        "node_modules/@polkadot/wasm-crypto-wasm": {
-            "version": "7.1.2",
-            "resolved": "https://registry.npmjs.org/@polkadot/wasm-crypto-wasm/-/wasm-crypto-wasm-7.1.2.tgz",
-            "integrity": "sha512-p2RBfXc43r6rXkFo811LboSfRQFpCgOC6+ByqMs/geTA/+/I4l2ajz95aL6cQ20AA3W5x/ZwHxhwvmJ0HBjJ6A==",
+        "node_modules/@polkadot/wasm-crypto-init": {
+            "version": "7.2.1",
+            "resolved": "https://registry.npmjs.org/@polkadot/wasm-crypto-init/-/wasm-crypto-init-7.2.1.tgz",
+            "integrity": "sha512-GcEXtwN9LcSf32V9zSaYjHImFw16hCyo2Xzg4GLLDPPeaAAfbFr2oQMgwyDbvBrBjLKHVHjsPZyGhXae831amw==",
             "dependencies": {
-                "@polkadot/wasm-util": "7.1.2",
+                "@polkadot/wasm-bridge": "7.2.1",
+                "@polkadot/wasm-crypto-asmjs": "7.2.1",
+                "@polkadot/wasm-crypto-wasm": "7.2.1",
+                "@polkadot/wasm-util": "7.2.1",
+                "tslib": "^2.5.0"
+            },
+            "engines": {
+                "node": ">=16"
+            },
+            "peerDependencies": {
+                "@polkadot/util": "*",
+                "@polkadot/x-randomvalues": "*"
+            }
+        },
+        "node_modules/@polkadot/wasm-crypto-wasm": {
+            "version": "7.2.1",
+            "resolved": "https://registry.npmjs.org/@polkadot/wasm-crypto-wasm/-/wasm-crypto-wasm-7.2.1.tgz",
+            "integrity": "sha512-DqyXE4rSD0CVlLIw88B58+HHNyrvm+JAnYyuEDYZwCvzUWOCNos/DDg9wi/K39VAIsCCKDmwKqkkfIofuOj/lA==",
+            "dependencies": {
+                "@polkadot/wasm-util": "7.2.1",
                 "tslib": "^2.5.0"
             },
             "engines": {
@@ -3671,9 +2945,9 @@
             }
         },
         "node_modules/@polkadot/wasm-util": {
-            "version": "7.1.2",
-            "resolved": "https://registry.npmjs.org/@polkadot/wasm-util/-/wasm-util-7.1.2.tgz",
-            "integrity": "sha512-lHQJFG0iotgmUovXYcw/HM3QhGxtze6ozAgRMd0/maTQjYwbV/7z1NzEle9fBwxX6GijTnpWc1vzW+YU0O1lLw==",
+            "version": "7.2.1",
+            "resolved": "https://registry.npmjs.org/@polkadot/wasm-util/-/wasm-util-7.2.1.tgz",
+            "integrity": "sha512-FBSn/3aYJzhN0sYAYhHB8y9JL8mVgxLy4M1kUXYbyo+8GLRQEN5rns8Vcb8TAlIzBWgVTOOptYBvxo0oj0h7Og==",
             "dependencies": {
                 "tslib": "^2.5.0"
             },
@@ -3685,11 +2959,11 @@
             }
         },
         "node_modules/@polkadot/x-bigint": {
-            "version": "12.1.2",
-            "resolved": "https://registry.npmjs.org/@polkadot/x-bigint/-/x-bigint-12.1.2.tgz",
-            "integrity": "sha512-KU7C8HlJ2kO6Igg2Jq2Q/eAdll3HuVoylYcyVQxevcrC2fXhC2PDIEa+iWHBPz40p2TvI9sBZKrCsDDGz9K6sw==",
+            "version": "12.2.1",
+            "resolved": "https://registry.npmjs.org/@polkadot/x-bigint/-/x-bigint-12.2.1.tgz",
+            "integrity": "sha512-3cZLsV8kU1MFOTcyloeg61CF+qdBkbZxWZJkSjh4AGlPXy+2tKwwoBPExxfCWXK61+Lo/q3/U1+lln8DSBCI2A==",
             "dependencies": {
-                "@polkadot/x-global": "12.1.2",
+                "@polkadot/x-global": "12.2.1",
                 "tslib": "^2.5.0"
             },
             "engines": {
@@ -3697,11 +2971,11 @@
             }
         },
         "node_modules/@polkadot/x-fetch": {
-            "version": "12.1.2",
-            "resolved": "https://registry.npmjs.org/@polkadot/x-fetch/-/x-fetch-12.1.2.tgz",
-            "integrity": "sha512-X+MY1UT25Xcvp6iUQOdmukOle1KsKaAblEhl+CrDfXGwM90wDLc5U3TZzddrKnQRcIgcNDyn9gRlHGQkZEbL9Q==",
+            "version": "12.2.1",
+            "resolved": "https://registry.npmjs.org/@polkadot/x-fetch/-/x-fetch-12.2.1.tgz",
+            "integrity": "sha512-N2MIcn1g7LVZLZNDEkRkDD/LRY680PFqxziRoqb11SV52kRe6oVsdMIfaWH77UheniRR3br8YiQMUdvBVkak9Q==",
             "dependencies": {
-                "@polkadot/x-global": "12.1.2",
+                "@polkadot/x-global": "12.2.1",
                 "node-fetch": "^3.3.1",
                 "tslib": "^2.5.0"
             },
@@ -3710,9 +2984,9 @@
             }
         },
         "node_modules/@polkadot/x-global": {
-            "version": "12.1.2",
-            "resolved": "https://registry.npmjs.org/@polkadot/x-global/-/x-global-12.1.2.tgz",
-            "integrity": "sha512-WGwPQN27hpwhVOQGUizJfmNJRxkijMwECMPUAYtSSgJhkV5MwWeFuVebfUjgHceakEvDRQWzEX6JjV6TttnPZw==",
+            "version": "12.2.1",
+            "resolved": "https://registry.npmjs.org/@polkadot/x-global/-/x-global-12.2.1.tgz",
+            "integrity": "sha512-JNMziAZjvfzMrXASuBPCvSzEqlhsgw0x95SOBtqJWsxmbCMAiZbYAC51vI1B9Z9wiKuzPtSh9Sk7YHsUOGCrIQ==",
             "dependencies": {
                 "tslib": "^2.5.0"
             },
@@ -3720,58 +2994,52 @@
                 "node": ">=16"
             }
         },
-        "node_modules/@polkadot/x-textdecoder": {
-            "version": "10.4.1",
-            "resolved": "https://registry.npmjs.org/@polkadot/x-textdecoder/-/x-textdecoder-10.4.1.tgz",
-            "integrity": "sha512-OcAL0napRM4hukgvH6kYGdiczqvbkFYoLBgQFalZChktjL1tDNiF6tzzt4Nn8WQXYYFlfyxp5LoZRtNrcFJq4w==",
+        "node_modules/@polkadot/x-randomvalues": {
+            "version": "12.2.1",
+            "resolved": "https://registry.npmjs.org/@polkadot/x-randomvalues/-/x-randomvalues-12.2.1.tgz",
+            "integrity": "sha512-NwSDLcLjgHa0C7Un54Yhg2/E3Y/PcVfW5QNB9TDyzDbkmod3ziaVhh0iWG0sOmm26K6Q3phY+0uYt0etq0Gu3w==",
             "dependencies": {
-                "@babel/runtime": "^7.20.13",
-                "@polkadot/x-global": "10.4.1"
+                "@polkadot/x-global": "12.2.1",
+                "tslib": "^2.5.0"
             },
             "engines": {
-                "node": ">=14.0.0"
+                "node": ">=16"
+            },
+            "peerDependencies": {
+                "@polkadot/util": "12.2.1",
+                "@polkadot/wasm-util": "*"
             }
         },
-        "node_modules/@polkadot/x-textdecoder/node_modules/@polkadot/x-global": {
-            "version": "10.4.1",
-            "resolved": "https://registry.npmjs.org/@polkadot/x-global/-/x-global-10.4.1.tgz",
-            "integrity": "sha512-Kdh2Fzl1fpEwU6vL1HMaXJy+fadX79eSy4VAnIx/uyCF3H5Z4WaxzoiNVmHdDZSVaamqtbuKepi1nkE3q1nvlA==",
+        "node_modules/@polkadot/x-textdecoder": {
+            "version": "12.2.1",
+            "resolved": "https://registry.npmjs.org/@polkadot/x-textdecoder/-/x-textdecoder-12.2.1.tgz",
+            "integrity": "sha512-5nQCIwyaGS0fXU2cbtMOSjFo0yTw1Z94m/UC+Gu5lm3ZU+kK4DpKFxhfLQORWAbvQkn12chRj3LI5Gm944hcrQ==",
             "dependencies": {
-                "@babel/runtime": "^7.20.13"
+                "@polkadot/x-global": "12.2.1",
+                "tslib": "^2.5.0"
             },
             "engines": {
-                "node": ">=14.0.0"
+                "node": ">=16"
             }
         },
         "node_modules/@polkadot/x-textencoder": {
-            "version": "10.4.1",
-            "resolved": "https://registry.npmjs.org/@polkadot/x-textencoder/-/x-textencoder-10.4.1.tgz",
-            "integrity": "sha512-YBS04HV/QgRppt0XC5n48c89ueH3ErivrcmqFTlkKMcXNzvtpMCTZGCTzG5vU8ozP0tl/4Is5N8agmYHLMu1Cg==",
+            "version": "12.2.1",
+            "resolved": "https://registry.npmjs.org/@polkadot/x-textencoder/-/x-textencoder-12.2.1.tgz",
+            "integrity": "sha512-Ou6OXypRsJloK5a7Kn7re3ImqcL26h22fVw1cNv4fsTgkRFUdJDgPux2TpCZ3N+cyrfGVv42xKYFbdKMQCczjg==",
             "dependencies": {
-                "@babel/runtime": "^7.20.13",
-                "@polkadot/x-global": "10.4.1"
+                "@polkadot/x-global": "12.2.1",
+                "tslib": "^2.5.0"
             },
             "engines": {
-                "node": ">=14.0.0"
-            }
-        },
-        "node_modules/@polkadot/x-textencoder/node_modules/@polkadot/x-global": {
-            "version": "10.4.1",
-            "resolved": "https://registry.npmjs.org/@polkadot/x-global/-/x-global-10.4.1.tgz",
-            "integrity": "sha512-Kdh2Fzl1fpEwU6vL1HMaXJy+fadX79eSy4VAnIx/uyCF3H5Z4WaxzoiNVmHdDZSVaamqtbuKepi1nkE3q1nvlA==",
-            "dependencies": {
-                "@babel/runtime": "^7.20.13"
-            },
-            "engines": {
-                "node": ">=14.0.0"
+                "node": ">=16"
             }
         },
         "node_modules/@polkadot/x-ws": {
-            "version": "12.1.2",
-            "resolved": "https://registry.npmjs.org/@polkadot/x-ws/-/x-ws-12.1.2.tgz",
-            "integrity": "sha512-xmwBtn0WIstrviNuLNladsVHXUWeh4/HHAuCCeTp5Rld+8pJ6D1snhl+qvicmm4t1Si9mpb6y4yfnWFm5fLHVA==",
+            "version": "12.2.1",
+            "resolved": "https://registry.npmjs.org/@polkadot/x-ws/-/x-ws-12.2.1.tgz",
+            "integrity": "sha512-jPfNR/QFwPmXCk9hGEAyCo50xBNHm3s+XavmpHEKQSulnLn5des5X/pKn+g8ttaO9nqrXYnUFO6VEmILgUa/IQ==",
             "dependencies": {
-                "@polkadot/x-global": "12.1.2",
+                "@polkadot/x-global": "12.2.1",
                 "tslib": "^2.5.0",
                 "ws": "^8.13.0"
             },
@@ -3883,27 +3151,27 @@
             }
         },
         "node_modules/@sinonjs/fake-timers": {
-            "version": "9.1.2",
-            "resolved": "https://registry.npmjs.org/@sinonjs/fake-timers/-/fake-timers-9.1.2.tgz",
-            "integrity": "sha512-BPS4ynJW/o92PUR4wgriz2Ud5gpST5vz6GQfMixEDK0Z8ZCUv2M7SkBLykH56T++Xs+8ln9zTGbOvNGIe02/jw==",
+            "version": "10.2.0",
+            "resolved": "https://registry.npmjs.org/@sinonjs/fake-timers/-/fake-timers-10.2.0.tgz",
+            "integrity": "sha512-OPwQlEdg40HAj5KNF8WW6q2KG4Z+cBCZb3m4ninfTZKaBmbIJodviQsDBoYMPHkOyJJMHnOJo5j2+LKDOhOACg==",
             "dev": true,
             "dependencies": {
-                "@sinonjs/commons": "^1.7.0"
+                "@sinonjs/commons": "^3.0.0"
             }
         },
         "node_modules/@sinonjs/fake-timers/node_modules/@sinonjs/commons": {
-            "version": "1.8.6",
-            "resolved": "https://registry.npmjs.org/@sinonjs/commons/-/commons-1.8.6.tgz",
-            "integrity": "sha512-Ky+XkAkqPZSm3NLBeUng77EBQl3cmeJhITaGHdYH8kjVB+aun3S4XBRti2zt17mtt0mIUDiNxYeoJm6drVvBJQ==",
+            "version": "3.0.0",
+            "resolved": "https://registry.npmjs.org/@sinonjs/commons/-/commons-3.0.0.tgz",
+            "integrity": "sha512-jXBtWAF4vmdNmZgD5FoKsVLv3rPgDnLgPbU84LIJ3otV44vJlDRokVng5v8NFJdCf/da9legHcKaRuZs4L7faA==",
             "dev": true,
             "dependencies": {
                 "type-detect": "4.0.8"
             }
         },
         "node_modules/@sinonjs/samsam": {
-            "version": "7.0.1",
-            "resolved": "https://registry.npmjs.org/@sinonjs/samsam/-/samsam-7.0.1.tgz",
-            "integrity": "sha512-zsAk2Jkiq89mhZovB2LLOdTCxJF4hqqTToGP0ASWlhp4I1hqOjcfmZGafXntCN7MDC6yySH0mFHrYtHceOeLmw==",
+            "version": "8.0.0",
+            "resolved": "https://registry.npmjs.org/@sinonjs/samsam/-/samsam-8.0.0.tgz",
+            "integrity": "sha512-Bp8KUVlLp8ibJZrnvq2foVhP0IVX2CIprMJPK0vqGqgrDa0OHVKeZyBykqskkrdxV6yKBPmGasO8LVjAKR3Gew==",
             "dev": true,
             "dependencies": {
                 "@sinonjs/commons": "^2.0.0",
@@ -4049,14 +3317,14 @@
             }
         },
         "node_modules/@substrate/connect": {
-            "version": "0.7.24",
-            "resolved": "https://registry.npmjs.org/@substrate/connect/-/connect-0.7.24.tgz",
-            "integrity": "sha512-vF82taiM0yME+ibiJgEv0xn/NZd9TQ4atXk1AQCe2z82SEKzw0Lwx9ZLFEOvlgnh+Nc2EtQi7y4cXJ+48rOqxw==",
+            "version": "0.7.26",
+            "resolved": "https://registry.npmjs.org/@substrate/connect/-/connect-0.7.26.tgz",
+            "integrity": "sha512-uuGSiroGuKWj1+38n1kY5HReer5iL9bRwPCzuoLtqAOmI1fGI0hsSI2LlNQMAbfRgr7VRHXOk5MTuQf5ulsFRw==",
             "optional": true,
             "dependencies": {
                 "@substrate/connect-extension-protocol": "^1.0.1",
                 "eventemitter3": "^4.0.7",
-                "smoldot": "1.0.2"
+                "smoldot": "1.0.4"
             }
         },
         "node_modules/@substrate/connect-extension-protocol": {
@@ -4138,9 +3406,9 @@
             "integrity": "sha512-SZs7ekbP8CN0txVG2xVRH6EgKmEm31BOxA07vkFaETzZz1xh+cbt8BcI0slpymvwhx5dlFnQG2rTlPVQn+iRPQ=="
         },
         "node_modules/@types/json-schema": {
-            "version": "7.0.11",
-            "resolved": "https://registry.npmjs.org/@types/json-schema/-/json-schema-7.0.11.tgz",
-            "integrity": "sha512-wOuvG1SN4Us4rez+tylwwwCV1psiNVOkJeM3AUWUNWg/jDQY2+HE/444y5gc+jBmRqASOm2Oeh5c1axHobwRKQ==",
+            "version": "7.0.12",
+            "resolved": "https://registry.npmjs.org/@types/json-schema/-/json-schema-7.0.12.tgz",
+            "integrity": "sha512-Hr5Jfhc9eYOQNPYO5WLDq/n4jqijdHNlDXjuAQkkt+mWdQR+XJToOHrsD4cPaMXpn6KO7y2+wM8AZEs8VpBLVA==",
             "dev": true
         },
         "node_modules/@types/long": {
@@ -4179,25 +3447,25 @@
             "integrity": "sha512-xoDlM2S4ortawSWORYqsdU+2rxdh4LRW9ytc3zmT37RIKQh6IHyKwwtKhKis9ah8ol07DCkZxPt8BBvPjC6v4g=="
         },
         "node_modules/@types/semver": {
-            "version": "7.3.13",
-            "resolved": "https://registry.npmjs.org/@types/semver/-/semver-7.3.13.tgz",
-            "integrity": "sha512-21cFJr9z3g5dW8B0CVI9g2O9beqaThGQ6ZFBqHfwhzLDKUxaqTIy3vnfah/UPkfOiF2pLq+tGz+W8RyCskuslw==",
+            "version": "7.5.0",
+            "resolved": "https://registry.npmjs.org/@types/semver/-/semver-7.5.0.tgz",
+            "integrity": "sha512-G8hZ6XJiHnuhQKR7ZmysCeJWE08o8T0AXtk5darsCaTVsYZhhgUrq53jizaR2FvsoeCwJhlmwTjkXBY5Pn/ZHw==",
             "dev": true
         },
         "node_modules/@typescript-eslint/eslint-plugin": {
-            "version": "5.54.1",
-            "resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-5.54.1.tgz",
-            "integrity": "sha512-a2RQAkosH3d3ZIV08s3DcL/mcGc2M/UC528VkPULFxR9VnVPT8pBu0IyBAJJmVsCmhVfwQX1v6q+QGnmSe1bew==",
+            "version": "5.59.8",
+            "resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-5.59.8.tgz",
+            "integrity": "sha512-JDMOmhXteJ4WVKOiHXGCoB96ADWg9q7efPWHRViT/f09bA8XOMLAVHHju3l0MkZnG1izaWXYmgvQcUjTRcpShQ==",
             "dev": true,
             "dependencies": {
-                "@typescript-eslint/scope-manager": "5.54.1",
-                "@typescript-eslint/type-utils": "5.54.1",
-                "@typescript-eslint/utils": "5.54.1",
+                "@eslint-community/regexpp": "^4.4.0",
+                "@typescript-eslint/scope-manager": "5.59.8",
+                "@typescript-eslint/type-utils": "5.59.8",
+                "@typescript-eslint/utils": "5.59.8",
                 "debug": "^4.3.4",
                 "grapheme-splitter": "^1.0.4",
                 "ignore": "^5.2.0",
                 "natural-compare-lite": "^1.4.0",
-                "regexpp": "^3.2.0",
                 "semver": "^7.3.7",
                 "tsutils": "^3.21.0"
             },
@@ -4219,14 +3487,14 @@
             }
         },
         "node_modules/@typescript-eslint/parser": {
-            "version": "5.54.1",
-            "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-5.54.1.tgz",
-            "integrity": "sha512-8zaIXJp/nG9Ff9vQNh7TI+C3nA6q6iIsGJ4B4L6MhZ7mHnTMR4YP5vp2xydmFXIy8rpyIVbNAG44871LMt6ujg==",
+            "version": "5.59.8",
+            "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-5.59.8.tgz",
+            "integrity": "sha512-AnR19RjJcpjoeGojmwZtCwBX/RidqDZtzcbG3xHrmz0aHHoOcbWnpDllenRDmDvsV0RQ6+tbb09/kyc+UT9Orw==",
             "dev": true,
             "dependencies": {
-                "@typescript-eslint/scope-manager": "5.54.1",
-                "@typescript-eslint/types": "5.54.1",
-                "@typescript-eslint/typescript-estree": "5.54.1",
+                "@typescript-eslint/scope-manager": "5.59.8",
+                "@typescript-eslint/types": "5.59.8",
+                "@typescript-eslint/typescript-estree": "5.59.8",
                 "debug": "^4.3.4"
             },
             "engines": {
@@ -4246,13 +3514,13 @@
             }
         },
         "node_modules/@typescript-eslint/scope-manager": {
-            "version": "5.54.1",
-            "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-5.54.1.tgz",
-            "integrity": "sha512-zWKuGliXxvuxyM71UA/EcPxaviw39dB2504LqAmFDjmkpO8qNLHcmzlh6pbHs1h/7YQ9bnsO8CCcYCSA8sykUg==",
+            "version": "5.59.8",
+            "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-5.59.8.tgz",
+            "integrity": "sha512-/w08ndCYI8gxGf+9zKf1vtx/16y8MHrZs5/tnjHhMLNSixuNcJavSX4wAiPf4aS5x41Es9YPCn44MIe4cxIlig==",
             "dev": true,
             "dependencies": {
-                "@typescript-eslint/types": "5.54.1",
-                "@typescript-eslint/visitor-keys": "5.54.1"
+                "@typescript-eslint/types": "5.59.8",
+                "@typescript-eslint/visitor-keys": "5.59.8"
             },
             "engines": {
                 "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
@@ -4263,13 +3531,13 @@
             }
         },
         "node_modules/@typescript-eslint/type-utils": {
-            "version": "5.54.1",
-            "resolved": "https://registry.npmjs.org/@typescript-eslint/type-utils/-/type-utils-5.54.1.tgz",
-            "integrity": "sha512-WREHsTz0GqVYLIbzIZYbmUUr95DKEKIXZNH57W3s+4bVnuF1TKe2jH8ZNH8rO1CeMY3U4j4UQeqPNkHMiGem3g==",
+            "version": "5.59.8",
+            "resolved": "https://registry.npmjs.org/@typescript-eslint/type-utils/-/type-utils-5.59.8.tgz",
+            "integrity": "sha512-+5M518uEIHFBy3FnyqZUF3BMP+AXnYn4oyH8RF012+e7/msMY98FhGL5SrN29NQ9xDgvqCgYnsOiKp1VjZ/fpA==",
             "dev": true,
             "dependencies": {
-                "@typescript-eslint/typescript-estree": "5.54.1",
-                "@typescript-eslint/utils": "5.54.1",
+                "@typescript-eslint/typescript-estree": "5.59.8",
+                "@typescript-eslint/utils": "5.59.8",
                 "debug": "^4.3.4",
                 "tsutils": "^3.21.0"
             },
@@ -4290,9 +3558,9 @@
             }
         },
         "node_modules/@typescript-eslint/types": {
-            "version": "5.54.1",
-            "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-5.54.1.tgz",
-            "integrity": "sha512-G9+1vVazrfAfbtmCapJX8jRo2E4MDXxgm/IMOF4oGh3kq7XuK3JRkOg6y2Qu1VsTRmWETyTkWt1wxy7X7/yLkw==",
+            "version": "5.59.8",
+            "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-5.59.8.tgz",
+            "integrity": "sha512-+uWuOhBTj/L6awoWIg0BlWy0u9TyFpCHrAuQ5bNfxDaZ1Ppb3mx6tUigc74LHcbHpOHuOTOJrBoAnhdHdaea1w==",
             "dev": true,
             "engines": {
                 "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
@@ -4303,13 +3571,13 @@
             }
         },
         "node_modules/@typescript-eslint/typescript-estree": {
-            "version": "5.54.1",
-            "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-5.54.1.tgz",
-            "integrity": "sha512-bjK5t+S6ffHnVwA0qRPTZrxKSaFYocwFIkZx5k7pvWfsB1I57pO/0M0Skatzzw1sCkjJ83AfGTL0oFIFiDX3bg==",
+            "version": "5.59.8",
+            "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-5.59.8.tgz",
+            "integrity": "sha512-Jy/lPSDJGNow14vYu6IrW790p7HIf/SOV1Bb6lZ7NUkLc2iB2Z9elESmsaUtLw8kVqogSbtLH9tut5GCX1RLDg==",
             "dev": true,
             "dependencies": {
-                "@typescript-eslint/types": "5.54.1",
-                "@typescript-eslint/visitor-keys": "5.54.1",
+                "@typescript-eslint/types": "5.59.8",
+                "@typescript-eslint/visitor-keys": "5.59.8",
                 "debug": "^4.3.4",
                 "globby": "^11.1.0",
                 "is-glob": "^4.0.3",
@@ -4330,18 +3598,18 @@
             }
         },
         "node_modules/@typescript-eslint/utils": {
-            "version": "5.54.1",
-            "resolved": "https://registry.npmjs.org/@typescript-eslint/utils/-/utils-5.54.1.tgz",
-            "integrity": "sha512-IY5dyQM8XD1zfDe5X8jegX6r2EVU5o/WJnLu/znLPWCBF7KNGC+adacXnt5jEYS9JixDcoccI6CvE4RCjHMzCQ==",
+            "version": "5.59.8",
+            "resolved": "https://registry.npmjs.org/@typescript-eslint/utils/-/utils-5.59.8.tgz",
+            "integrity": "sha512-Tr65630KysnNn9f9G7ROF3w1b5/7f6QVCJ+WK9nhIocWmx9F+TmCAcglF26Vm7z8KCTwoKcNEBZrhlklla3CKg==",
             "dev": true,
             "dependencies": {
+                "@eslint-community/eslint-utils": "^4.2.0",
                 "@types/json-schema": "^7.0.9",
                 "@types/semver": "^7.3.12",
-                "@typescript-eslint/scope-manager": "5.54.1",
-                "@typescript-eslint/types": "5.54.1",
-                "@typescript-eslint/typescript-estree": "5.54.1",
+                "@typescript-eslint/scope-manager": "5.59.8",
+                "@typescript-eslint/types": "5.59.8",
+                "@typescript-eslint/typescript-estree": "5.59.8",
                 "eslint-scope": "^5.1.1",
-                "eslint-utils": "^3.0.0",
                 "semver": "^7.3.7"
             },
             "engines": {
@@ -4356,12 +3624,12 @@
             }
         },
         "node_modules/@typescript-eslint/visitor-keys": {
-            "version": "5.54.1",
-            "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-5.54.1.tgz",
-            "integrity": "sha512-q8iSoHTgwCfgcRJ2l2x+xCbu8nBlRAlsQ33k24Adj8eoVBE0f8dUeI+bAa8F84Mv05UGbAx57g2zrRsYIooqQg==",
+            "version": "5.59.8",
+            "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-5.59.8.tgz",
+            "integrity": "sha512-pJhi2ms0x0xgloT7xYabil3SGGlojNNKjK/q6dB3Ey0uJLMjK2UDGJvHieiyJVW/7C3KI+Z4Q3pEHkm4ejA+xQ==",
             "dev": true,
             "dependencies": {
-                "@typescript-eslint/types": "5.54.1",
+                "@typescript-eslint/types": "5.59.8",
                 "eslint-visitor-keys": "^3.3.0"
             },
             "engines": {
@@ -6526,6 +5794,7 @@
             "resolved": "https://registry.npmjs.org/eslint-utils/-/eslint-utils-3.0.0.tgz",
             "integrity": "sha512-uuQC43IGctw68pJA1RgbQS8/NP7rch6Cwd4j3ZBtgo4/8Flj4eGE7ZYSZRN3iq5pVUv6GPdW5Z1RFleo84uLDA==",
             "dev": true,
+            "peer": true,
             "dependencies": {
                 "eslint-visitor-keys": "^2.0.0"
             },
@@ -6544,6 +5813,7 @@
             "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-2.1.0.tgz",
             "integrity": "sha512-0rSmRBzXgDzIsD6mGdJgevzgezI534Cer5L/vyMX0kHzT/jiB43jRhd9YUlMGYLQy2zprNmoT8qasCGtY+QaKw==",
             "dev": true,
+            "peer": true,
             "engines": {
                 "node": ">=10"
             }
@@ -6692,9 +5962,9 @@
             }
         },
         "node_modules/eventemitter3": {
-            "version": "5.0.0",
-            "resolved": "https://registry.npmjs.org/eventemitter3/-/eventemitter3-5.0.0.tgz",
-            "integrity": "sha512-riuVbElZZNXLeLEoprfNYoDSwTBRR44X3mnhdI1YcnENpWTCsTTVZ2zFuqQcpoyqPQIUXdiPEU0ECAq0KQRaHg=="
+            "version": "5.0.1",
+            "resolved": "https://registry.npmjs.org/eventemitter3/-/eventemitter3-5.0.1.tgz",
+            "integrity": "sha512-GWkBvjiSZK87ELrYOSESUYeVIc9mvLLf/nXalMOS5dYrgZq9o5OVkbZAVM06CVxYsCwH9BDZFPlQTlPA1j4ahA=="
         },
         "node_modules/events": {
             "version": "3.3.0",
@@ -10417,15 +9687,6 @@
                 "path-to-regexp": "^1.7.0"
             }
         },
-        "node_modules/nise/node_modules/@sinonjs/fake-timers": {
-            "version": "10.0.2",
-            "resolved": "https://registry.npmjs.org/@sinonjs/fake-timers/-/fake-timers-10.0.2.tgz",
-            "integrity": "sha512-SwUDyjWnah1AaNl7kxsa7cfLhlTYoiyhDAIgyh+El30YvXs/o7OLXpYH88Zdhyx9JExKrmHDJ+10bwIcY80Jmw==",
-            "dev": true,
-            "dependencies": {
-                "@sinonjs/commons": "^2.0.0"
-            }
-        },
         "node_modules/no-case": {
             "version": "3.0.4",
             "resolved": "https://registry.npmjs.org/no-case/-/no-case-3.0.4.tgz",
@@ -11155,9 +10416,9 @@
             }
         },
         "node_modules/prettier": {
-            "version": "2.8.4",
-            "resolved": "https://registry.npmjs.org/prettier/-/prettier-2.8.4.tgz",
-            "integrity": "sha512-vIS4Rlc2FNh0BySk3Wkd6xmwxB0FpOndW5fisM5H8hsZSxU2VWVB5CWIkIjWvrHjIhxk2g3bfMKM87zNTrZddw==",
+            "version": "2.8.8",
+            "resolved": "https://registry.npmjs.org/prettier/-/prettier-2.8.8.tgz",
+            "integrity": "sha512-tdN8qQGvNjw4CHbY+XXk0JgCXn9QiF21a55rBe5LJAU+kDyC4WQn4+awm2Xfk2lQMk5fKup9XgzTZtGkjBdP9Q==",
             "dev": true,
             "bin": {
                 "prettier": "bin-prettier.js"
@@ -11618,16 +10879,12 @@
                 "ms": "^2.1.1"
             }
         },
-        "node_modules/regenerator-runtime": {
-            "version": "0.13.11",
-            "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.13.11.tgz",
-            "integrity": "sha512-kY1AZVr2Ra+t+piVaJ4gxaFaReZVH40AKNo7UCX6W+dEwBo/2oZJzqfuN1qLq1oL45o56cPaTXELwrTh8Fpggg=="
-        },
         "node_modules/regexpp": {
             "version": "3.2.0",
             "resolved": "https://registry.npmjs.org/regexpp/-/regexpp-3.2.0.tgz",
             "integrity": "sha512-pq2bWo9mVD43nbts2wGv17XLiNLya+GklZ8kaDLV2Z08gDCsGpnKn9BFMepvWuHCbyVvY7J5o5+BVvoQbmlJLg==",
             "dev": true,
+            "peer": true,
             "engines": {
                 "node": ">=8"
             },
@@ -11836,9 +11093,9 @@
             }
         },
         "node_modules/rxjs": {
-            "version": "7.8.0",
-            "resolved": "https://registry.npmjs.org/rxjs/-/rxjs-7.8.0.tgz",
-            "integrity": "sha512-F2+gxDshqmIub1KdvZkaEfGDwLNpPvk9Fs6LD/MyQxNgMds/WH9OdDDXOmxUZpME+iSK3rQCctkL0DYyytUqMg==",
+            "version": "7.8.1",
+            "resolved": "https://registry.npmjs.org/rxjs/-/rxjs-7.8.1.tgz",
+            "integrity": "sha512-AA3TVj+0A2iuIoQkWEK/tqFjBq2j+6PO6Y0zJcvzLAFhEFIO3HL0vls9hWLncZbAAbK0mar7oZ4V079I/qPMxg==",
             "dependencies": {
                 "tslib": "^2.1.0"
             }
@@ -12017,21 +11274,39 @@
             }
         },
         "node_modules/sinon": {
-            "version": "14.0.2",
-            "resolved": "https://registry.npmjs.org/sinon/-/sinon-14.0.2.tgz",
-            "integrity": "sha512-PDpV0ZI3ZCS3pEqx0vpNp6kzPhHrLx72wA0G+ZLaaJjLIYeE0n8INlgaohKuGy7hP0as5tbUd23QWu5U233t+w==",
+            "version": "15.1.0",
+            "resolved": "https://registry.npmjs.org/sinon/-/sinon-15.1.0.tgz",
+            "integrity": "sha512-cS5FgpDdE9/zx7no8bxROHymSlPLZzq0ChbbLk1DrxBfc+eTeBK3y8nIL+nu/0QeYydhhbLIr7ecHJpywjQaoQ==",
             "dev": true,
             "dependencies": {
-                "@sinonjs/commons": "^2.0.0",
-                "@sinonjs/fake-timers": "^9.1.2",
-                "@sinonjs/samsam": "^7.0.1",
-                "diff": "^5.0.0",
-                "nise": "^5.1.2",
+                "@sinonjs/commons": "^3.0.0",
+                "@sinonjs/fake-timers": "^10.2.0",
+                "@sinonjs/samsam": "^8.0.0",
+                "diff": "^5.1.0",
+                "nise": "^5.1.4",
                 "supports-color": "^7.2.0"
             },
             "funding": {
                 "type": "opencollective",
                 "url": "https://opencollective.com/sinon"
+            }
+        },
+        "node_modules/sinon/node_modules/@sinonjs/commons": {
+            "version": "3.0.0",
+            "resolved": "https://registry.npmjs.org/@sinonjs/commons/-/commons-3.0.0.tgz",
+            "integrity": "sha512-jXBtWAF4vmdNmZgD5FoKsVLv3rPgDnLgPbU84LIJ3otV44vJlDRokVng5v8NFJdCf/da9legHcKaRuZs4L7faA==",
+            "dev": true,
+            "dependencies": {
+                "type-detect": "4.0.8"
+            }
+        },
+        "node_modules/sinon/node_modules/diff": {
+            "version": "5.1.0",
+            "resolved": "https://registry.npmjs.org/diff/-/diff-5.1.0.tgz",
+            "integrity": "sha512-D+mk+qE8VC/PAUrlAU34N+VfXev0ghe5ywmpqrawphmVZc1bEfn56uo9qpyGp1p4xpzOHkSW4ztBd6L7Xx4ACw==",
+            "dev": true,
+            "engines": {
+                "node": ">=0.3.1"
             }
         },
         "node_modules/slash": {
@@ -12044,9 +11319,9 @@
             }
         },
         "node_modules/smoldot": {
-            "version": "1.0.2",
-            "resolved": "https://registry.npmjs.org/smoldot/-/smoldot-1.0.2.tgz",
-            "integrity": "sha512-IHhMzvXwyl6I5GA4JvfzM2OOp9wBO06AmjqT4nCoNms5PiLe74f/A+jIZIJKyY6eBhMpmECizyfeTneHO2wMFQ==",
+            "version": "1.0.4",
+            "resolved": "https://registry.npmjs.org/smoldot/-/smoldot-1.0.4.tgz",
+            "integrity": "sha512-N3TazI1C4GGrseFH/piWyZCCCRJTRx2QhDfrUKRT4SzILlW5m8ayZ3QTKICcz1C/536T9cbHHJyP7afxI6Mi1A==",
             "optional": true,
             "dependencies": {
                 "pako": "^2.0.4",
@@ -12536,9 +11811,9 @@
             }
         },
         "node_modules/tslib": {
-            "version": "2.5.0",
-            "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.5.0.tgz",
-            "integrity": "sha512-336iVw3rtn2BUK7ORdIAHTyxHGRIHVReokCR3XjbckJMK7ms8FysBfhLR8IXnAgy7T0PTPNBWKiH514FOW/WSg=="
+            "version": "2.5.2",
+            "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.5.2.tgz",
+            "integrity": "sha512-5svOrSA2w3iGFDs1HibEVBGbDrAY82bFQ3HZ3ixB+88nsbsWQoKqDRb5UBYAUPEzbBn6dAp5gRNXglySbx1MlA=="
         },
         "node_modules/tsutils": {
             "version": "3.21.0",
@@ -12623,16 +11898,16 @@
             }
         },
         "node_modules/typescript": {
-            "version": "4.9.5",
-            "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.9.5.tgz",
-            "integrity": "sha512-1FXk9E2Hm+QzZQ7z+McJiHL4NW1F2EzMu9Nq9i3zAaGqibafqYwCVU6WyWAuyQRRzOlxou8xZSyXLEN8oKj24g==",
+            "version": "5.1.3",
+            "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.1.3.tgz",
+            "integrity": "sha512-XH627E9vkeqhlZFQuL+UsyAXEnibT0kWR2FWONlr4sTjvxyJYnyefgrkyECLzM5NenmKzRAy2rR/OlYLA1HkZw==",
             "dev": true,
             "bin": {
                 "tsc": "bin/tsc",
                 "tsserver": "bin/tsserver"
             },
             "engines": {
-                "node": ">=4.2.0"
+                "node": ">=14.17"
             }
         },
         "node_modules/uglify-js": {
@@ -13131,9 +12406,9 @@
             "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A=="
         },
         "node_modules/yargs": {
-            "version": "17.7.1",
-            "resolved": "https://registry.npmjs.org/yargs/-/yargs-17.7.1.tgz",
-            "integrity": "sha512-cwiTb08Xuv5fqF4AovYacTFNxk62th7LKJ6BL9IGUpTJrWoU7/7WdQGTP2SjKf1dUNBGzDd28p/Yfs/GI6JrLw==",
+            "version": "17.7.2",
+            "resolved": "https://registry.npmjs.org/yargs/-/yargs-17.7.2.tgz",
+            "integrity": "sha512-7dSzzRQ++CKnNI/krKnYRV7JKKPUXMEh61soaHKg9mrWEhzFWhFnxPxGl+69cD1Ou63C13NUPCnmIcrvqCuM6w==",
             "dependencies": {
                 "cliui": "^8.0.1",
                 "escalade": "^3.1.1",

--- a/integration-tests/package.json
+++ b/integration-tests/package.json
@@ -17,22 +17,22 @@
     "license": "Apache-2.0",
     "dependencies": {
         "@frequency-chain/api-augment": "file:../js/api-augment/dist/frequency-chain-api-augment-0.0.0.tgz",
-        "@polkadot/api": "10.4.1",
-        "@polkadot/types": "10.4.1",
-        "@polkadot/util": "10.4.1",
+        "@polkadot/api": "10.7.3",
+        "@polkadot/types": "10.7.3",
+        "@polkadot/util": "12.2.1",
         "ipfs": "^0.66.0",
-        "multiformats": "^11.0.1",
-        "rxjs": "^7.8.0"
+        "multiformats": "^11.0.2",
+        "rxjs": "^7.8.1"
     },
     "devDependencies": {
-        "@polkadot/typegen": "10.4.1",
-        "@types/mocha": "^10.0.0",
-        "@typescript-eslint/eslint-plugin": "^5.48.1",
-        "@typescript-eslint/parser": "^5.48.1",
-        "mocha": "^10.1.0",
-        "prettier": "^2.7.1",
-        "sinon": "^14.0.2",
+        "@polkadot/typegen": "10.7.3",
+        "@types/mocha": "^10.0.1",
+        "@typescript-eslint/eslint-plugin": "^5.59.8",
+        "@typescript-eslint/parser": "^5.59.8",
+        "mocha": "^10.2.0",
+        "prettier": "^2.8.8",
+        "sinon": "^15.1.0",
         "ts-node": "^10.9.1",
-        "typescript": "^4.9.5"
+        "typescript": "^5.1.3"
     }
 }

--- a/integration-tests/tsconfig.json
+++ b/integration-tests/tsconfig.json
@@ -14,7 +14,6 @@
         "strict": true,
         "skipLibCheck": true,
         "target": "es2022",
-        "watch": false,
         "typeRoots": [
             "node_modules/@types"
         ]

--- a/js/api-augment/package-lock.json
+++ b/js/api-augment/package-lock.json
@@ -9,16 +9,16 @@
       "version": "0.0.0",
       "license": "Apache-2.0",
       "dependencies": {
-        "@polkadot/api": "10.4.1",
-        "@polkadot/rpc-provider": "10.4.1",
-        "@polkadot/types": "10.4.1"
+        "@polkadot/api": "^10.7.3",
+        "@polkadot/rpc-provider": "^10.7.3",
+        "@polkadot/types": "^10.7.3"
       },
       "devDependencies": {
-        "@polkadot/typegen": "10.4.1",
+        "@polkadot/typegen": "^10.7.3",
         "@types/mocha": "^10.0.1",
-        "@typescript-eslint/eslint-plugin": "^5.59.1",
-        "@typescript-eslint/parser": "^5.59.1",
-        "eslint": "^8.39.0",
+        "@typescript-eslint/eslint-plugin": "^5.59.8",
+        "@typescript-eslint/parser": "^5.59.8",
+        "eslint": "^8.41.0",
         "eslint-config-prettier": "^8.8.0",
         "eslint-plugin-import": "^2.27.5",
         "eslint-plugin-mocha": "^10.1.0",
@@ -26,7 +26,7 @@
         "mocha": "10.2.0",
         "prettier": "2.8.8",
         "ts-node": "^10.9.1",
-        "typescript": "^5.0.4"
+        "typescript": "^5.1.3"
       }
     },
     "node_modules/@cspotcode/source-map-support": {
@@ -65,14 +65,14 @@
       }
     },
     "node_modules/@eslint/eslintrc": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/@eslint/eslintrc/-/eslintrc-2.0.2.tgz",
-      "integrity": "sha512-3W4f5tDUra+pA+FzgugqL2pRimUTDJWKr7BINqOpkZrC0uYI0NIc0/JFgBROCU07HR6GieA5m3/rsPIhDmCXTQ==",
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/@eslint/eslintrc/-/eslintrc-2.0.3.tgz",
+      "integrity": "sha512-+5gy6OQfk+xx3q0d6jGZZC3f3KzAkXc/IanVxd1is/VIIziRqqt3ongQz0FiTUXqTk0c7aDB3OaFuKnuSoJicQ==",
       "dev": true,
       "dependencies": {
         "ajv": "^6.12.4",
         "debug": "^4.3.2",
-        "espree": "^9.5.1",
+        "espree": "^9.5.2",
         "globals": "^13.19.0",
         "ignore": "^5.2.0",
         "import-fresh": "^3.2.1",
@@ -88,9 +88,9 @@
       }
     },
     "node_modules/@eslint/js": {
-      "version": "8.39.0",
-      "resolved": "https://registry.npmjs.org/@eslint/js/-/js-8.39.0.tgz",
-      "integrity": "sha512-kf9RB0Fg7NZfap83B3QOqOGg9QmD9yBudqQXzzOtn3i4y7ZUXe5ONeW34Gwi+TxhH4mvj72R1Zc300KUMa9Bng==",
+      "version": "8.41.0",
+      "resolved": "https://registry.npmjs.org/@eslint/js/-/js-8.41.0.tgz",
+      "integrity": "sha512-LxcyMGxwmTh2lY9FwHPGWOHmYFCZvbrFCBZL4FzSSsxsRPuhrYUg/49/0KDfW8tnIEaEHtfmn6+NPN+1DqaNmA==",
       "dev": true,
       "engines": {
         "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
@@ -214,138 +214,133 @@
       }
     },
     "node_modules/@polkadot/api": {
-      "version": "10.4.1",
-      "resolved": "https://registry.npmjs.org/@polkadot/api/-/api-10.4.1.tgz",
-      "integrity": "sha512-MFIhykqvU4l5oyLxEnMhtF07VWLXwBS02gVd9Q+Gh2RxXtskQnXlos00hZFdLaCQ7g8BNggoq0Woc2BGZQEG2A==",
+      "version": "10.7.3",
+      "resolved": "https://registry.npmjs.org/@polkadot/api/-/api-10.7.3.tgz",
+      "integrity": "sha512-SqgjA5QihxSBGGtazgH5y+bYg3mYg4GQPoK7gJkz3E9avQ8glaCOAZJsm4Wmj1l87VvdCQffyew+Q9lTwrQ+JA==",
       "dependencies": {
-        "@polkadot/api-augment": "10.4.1",
-        "@polkadot/api-base": "10.4.1",
-        "@polkadot/api-derive": "10.4.1",
-        "@polkadot/keyring": "^12.0.1",
-        "@polkadot/rpc-augment": "10.4.1",
-        "@polkadot/rpc-core": "10.4.1",
-        "@polkadot/rpc-provider": "10.4.1",
-        "@polkadot/types": "10.4.1",
-        "@polkadot/types-augment": "10.4.1",
-        "@polkadot/types-codec": "10.4.1",
-        "@polkadot/types-create": "10.4.1",
-        "@polkadot/types-known": "10.4.1",
-        "@polkadot/util": "^12.0.1",
-        "@polkadot/util-crypto": "^12.0.1",
-        "eventemitter3": "^5.0.0",
-        "rxjs": "^7.8.0",
-        "tslib": "^2.5.0"
+        "@polkadot/api-augment": "10.7.3",
+        "@polkadot/api-base": "10.7.3",
+        "@polkadot/api-derive": "10.7.3",
+        "@polkadot/keyring": "^12.2.1",
+        "@polkadot/rpc-augment": "10.7.3",
+        "@polkadot/rpc-core": "10.7.3",
+        "@polkadot/rpc-provider": "10.7.3",
+        "@polkadot/types": "10.7.3",
+        "@polkadot/types-augment": "10.7.3",
+        "@polkadot/types-codec": "10.7.3",
+        "@polkadot/types-create": "10.7.3",
+        "@polkadot/types-known": "10.7.3",
+        "@polkadot/util": "^12.2.1",
+        "@polkadot/util-crypto": "^12.2.1",
+        "eventemitter3": "^5.0.1",
+        "rxjs": "^7.8.1",
+        "tslib": "^2.5.2"
       },
       "engines": {
         "node": ">=16"
       }
     },
     "node_modules/@polkadot/api-augment": {
-      "version": "10.4.1",
-      "resolved": "https://registry.npmjs.org/@polkadot/api-augment/-/api-augment-10.4.1.tgz",
-      "integrity": "sha512-7TUFHiOsaAKwRCDXEwwYHIBi07Nd0+4vMDgP+/eKVrX5XkYCnEA+PdkE8uEpFY3LMoVVr08mPiYPn59gN0b5jw==",
+      "version": "10.7.3",
+      "resolved": "https://registry.npmjs.org/@polkadot/api-augment/-/api-augment-10.7.3.tgz",
+      "integrity": "sha512-qdMELIV/PrSmOMFXnebNHlsiYiOebeTrMqNWB+lWPiGLKHBu4PnXzuvQK/H2FcMHJXXoocYjm10teJ6uZuSS/A==",
       "dependencies": {
-        "@polkadot/api-base": "10.4.1",
-        "@polkadot/rpc-augment": "10.4.1",
-        "@polkadot/types": "10.4.1",
-        "@polkadot/types-augment": "10.4.1",
-        "@polkadot/types-codec": "10.4.1",
-        "@polkadot/util": "^12.0.1",
-        "tslib": "^2.5.0"
+        "@polkadot/api-base": "10.7.3",
+        "@polkadot/rpc-augment": "10.7.3",
+        "@polkadot/types": "10.7.3",
+        "@polkadot/types-augment": "10.7.3",
+        "@polkadot/types-codec": "10.7.3",
+        "@polkadot/util": "^12.2.1",
+        "tslib": "^2.5.2"
       },
       "engines": {
         "node": ">=16"
       }
     },
     "node_modules/@polkadot/api-augment/node_modules/tslib": {
-      "version": "2.5.0",
-      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.5.0.tgz",
-      "integrity": "sha512-336iVw3rtn2BUK7ORdIAHTyxHGRIHVReokCR3XjbckJMK7ms8FysBfhLR8IXnAgy7T0PTPNBWKiH514FOW/WSg=="
+      "version": "2.5.2",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.5.2.tgz",
+      "integrity": "sha512-5svOrSA2w3iGFDs1HibEVBGbDrAY82bFQ3HZ3ixB+88nsbsWQoKqDRb5UBYAUPEzbBn6dAp5gRNXglySbx1MlA=="
     },
     "node_modules/@polkadot/api-base": {
-      "version": "10.4.1",
-      "resolved": "https://registry.npmjs.org/@polkadot/api-base/-/api-base-10.4.1.tgz",
-      "integrity": "sha512-4uItv9NeZDu60qN8dhPN8Q7HBOYZ0Ylf7+/lAnEMldoCx0RxNP2h1T2JwdW3C5ElTsztYzYVLKg0Iz5zJpbffQ==",
+      "version": "10.7.3",
+      "resolved": "https://registry.npmjs.org/@polkadot/api-base/-/api-base-10.7.3.tgz",
+      "integrity": "sha512-FYqG4HYWji1QCFZcPSJ5k87K2NNxbxl4JNhNPHcZTtfXdOnhKXze3Wkbv68S3Az6plIEkq6+aMbmkNsq5cNaWg==",
       "dependencies": {
-        "@polkadot/rpc-core": "10.4.1",
-        "@polkadot/types": "10.4.1",
-        "@polkadot/util": "^12.0.1",
-        "rxjs": "^7.8.0",
-        "tslib": "^2.5.0"
+        "@polkadot/rpc-core": "10.7.3",
+        "@polkadot/types": "10.7.3",
+        "@polkadot/util": "^12.2.1",
+        "rxjs": "^7.8.1",
+        "tslib": "^2.5.2"
       },
       "engines": {
         "node": ">=16"
       }
     },
     "node_modules/@polkadot/api-base/node_modules/tslib": {
-      "version": "2.5.0",
-      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.5.0.tgz",
-      "integrity": "sha512-336iVw3rtn2BUK7ORdIAHTyxHGRIHVReokCR3XjbckJMK7ms8FysBfhLR8IXnAgy7T0PTPNBWKiH514FOW/WSg=="
+      "version": "2.5.2",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.5.2.tgz",
+      "integrity": "sha512-5svOrSA2w3iGFDs1HibEVBGbDrAY82bFQ3HZ3ixB+88nsbsWQoKqDRb5UBYAUPEzbBn6dAp5gRNXglySbx1MlA=="
     },
     "node_modules/@polkadot/api-derive": {
-      "version": "10.4.1",
-      "resolved": "https://registry.npmjs.org/@polkadot/api-derive/-/api-derive-10.4.1.tgz",
-      "integrity": "sha512-SR/L4H8oiYMyLaLzmm9Z3kb4tNLAOAIR2uBZshCo917CqMuvrkNVW+Wfh2dAtVsnoSc1FaSPfDwmKash6pqNUQ==",
+      "version": "10.7.3",
+      "resolved": "https://registry.npmjs.org/@polkadot/api-derive/-/api-derive-10.7.3.tgz",
+      "integrity": "sha512-++C+nMn6BgFdlkEVJrDez/6ILDxYe7CdCfNLKr5kOuTJu8VtmYS6kbmpCxZ0kYD5Omwe4UJ6az9hDHR5MUn94A==",
       "dependencies": {
-        "@polkadot/api": "10.4.1",
-        "@polkadot/api-augment": "10.4.1",
-        "@polkadot/api-base": "10.4.1",
-        "@polkadot/rpc-core": "10.4.1",
-        "@polkadot/types": "10.4.1",
-        "@polkadot/types-codec": "10.4.1",
-        "@polkadot/util": "^12.0.1",
-        "@polkadot/util-crypto": "^12.0.1",
-        "rxjs": "^7.8.0",
-        "tslib": "^2.5.0"
+        "@polkadot/api": "10.7.3",
+        "@polkadot/api-augment": "10.7.3",
+        "@polkadot/api-base": "10.7.3",
+        "@polkadot/rpc-core": "10.7.3",
+        "@polkadot/types": "10.7.3",
+        "@polkadot/types-codec": "10.7.3",
+        "@polkadot/util": "^12.2.1",
+        "@polkadot/util-crypto": "^12.2.1",
+        "rxjs": "^7.8.1",
+        "tslib": "^2.5.2"
       },
       "engines": {
         "node": ">=16"
       }
     },
     "node_modules/@polkadot/api-derive/node_modules/tslib": {
-      "version": "2.5.0",
-      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.5.0.tgz",
-      "integrity": "sha512-336iVw3rtn2BUK7ORdIAHTyxHGRIHVReokCR3XjbckJMK7ms8FysBfhLR8IXnAgy7T0PTPNBWKiH514FOW/WSg=="
-    },
-    "node_modules/@polkadot/api/node_modules/eventemitter3": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/eventemitter3/-/eventemitter3-5.0.0.tgz",
-      "integrity": "sha512-riuVbElZZNXLeLEoprfNYoDSwTBRR44X3mnhdI1YcnENpWTCsTTVZ2zFuqQcpoyqPQIUXdiPEU0ECAq0KQRaHg=="
+      "version": "2.5.2",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.5.2.tgz",
+      "integrity": "sha512-5svOrSA2w3iGFDs1HibEVBGbDrAY82bFQ3HZ3ixB+88nsbsWQoKqDRb5UBYAUPEzbBn6dAp5gRNXglySbx1MlA=="
     },
     "node_modules/@polkadot/api/node_modules/tslib": {
-      "version": "2.5.0",
-      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.5.0.tgz",
-      "integrity": "sha512-336iVw3rtn2BUK7ORdIAHTyxHGRIHVReokCR3XjbckJMK7ms8FysBfhLR8IXnAgy7T0PTPNBWKiH514FOW/WSg=="
+      "version": "2.5.2",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.5.2.tgz",
+      "integrity": "sha512-5svOrSA2w3iGFDs1HibEVBGbDrAY82bFQ3HZ3ixB+88nsbsWQoKqDRb5UBYAUPEzbBn6dAp5gRNXglySbx1MlA=="
     },
     "node_modules/@polkadot/keyring": {
-      "version": "12.0.1",
-      "resolved": "https://registry.npmjs.org/@polkadot/keyring/-/keyring-12.0.1.tgz",
-      "integrity": "sha512-dq/2FKXVzET9qBmba9xOQyOW8UjcMvS9H7ZZbcxFgP/rJ6amLByOYLXXDARp6ZXL3zrsQ6D6iRx82mnYWnxhjg==",
+      "version": "12.2.1",
+      "resolved": "https://registry.npmjs.org/@polkadot/keyring/-/keyring-12.2.1.tgz",
+      "integrity": "sha512-YqgpU+97OZgnSUL56DEMib937Dpb1bTTDPYHhBiN1yNCKod7UboWXIe4xPh+1Kzugum+dEyPpdV+fHH10rtDzw==",
       "dependencies": {
-        "@polkadot/util": "12.0.1",
-        "@polkadot/util-crypto": "12.0.1",
+        "@polkadot/util": "12.2.1",
+        "@polkadot/util-crypto": "12.2.1",
         "tslib": "^2.5.0"
       },
       "engines": {
         "node": ">=16"
       },
       "peerDependencies": {
-        "@polkadot/util": "12.0.1",
-        "@polkadot/util-crypto": "12.0.1"
+        "@polkadot/util": "12.2.1",
+        "@polkadot/util-crypto": "12.2.1"
       }
     },
     "node_modules/@polkadot/keyring/node_modules/tslib": {
-      "version": "2.5.0",
-      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.5.0.tgz",
-      "integrity": "sha512-336iVw3rtn2BUK7ORdIAHTyxHGRIHVReokCR3XjbckJMK7ms8FysBfhLR8IXnAgy7T0PTPNBWKiH514FOW/WSg=="
+      "version": "2.5.2",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.5.2.tgz",
+      "integrity": "sha512-5svOrSA2w3iGFDs1HibEVBGbDrAY82bFQ3HZ3ixB+88nsbsWQoKqDRb5UBYAUPEzbBn6dAp5gRNXglySbx1MlA=="
     },
     "node_modules/@polkadot/networks": {
-      "version": "12.0.1",
-      "resolved": "https://registry.npmjs.org/@polkadot/networks/-/networks-12.0.1.tgz",
-      "integrity": "sha512-VJkrLzIVr8B6iHm/yH7lmNwsu/ullNhiTWalxX8Ayxd+yfKwm3dL6IzggFp1uyjykOYlMvlI28keZP32OlMfdg==",
+      "version": "12.2.1",
+      "resolved": "https://registry.npmjs.org/@polkadot/networks/-/networks-12.2.1.tgz",
+      "integrity": "sha512-lYLvFv6iQ2UzkP66zJfsiTo2goeaNeKuwiaGoRoFrDwdwVeZK/+rCsz1uAyvbwmpZIaK8K+dTlSBVWlFoAkgcA==",
       "dependencies": {
-        "@polkadot/util": "12.0.1",
-        "@substrate/ss58-registry": "^1.39.0",
+        "@polkadot/util": "12.2.1",
+        "@substrate/ss58-registry": "^1.40.0",
         "tslib": "^2.5.0"
       },
       "engines": {
@@ -353,107 +348,102 @@
       }
     },
     "node_modules/@polkadot/networks/node_modules/tslib": {
-      "version": "2.5.0",
-      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.5.0.tgz",
-      "integrity": "sha512-336iVw3rtn2BUK7ORdIAHTyxHGRIHVReokCR3XjbckJMK7ms8FysBfhLR8IXnAgy7T0PTPNBWKiH514FOW/WSg=="
+      "version": "2.5.2",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.5.2.tgz",
+      "integrity": "sha512-5svOrSA2w3iGFDs1HibEVBGbDrAY82bFQ3HZ3ixB+88nsbsWQoKqDRb5UBYAUPEzbBn6dAp5gRNXglySbx1MlA=="
     },
     "node_modules/@polkadot/rpc-augment": {
-      "version": "10.4.1",
-      "resolved": "https://registry.npmjs.org/@polkadot/rpc-augment/-/rpc-augment-10.4.1.tgz",
-      "integrity": "sha512-lwwSjyboTTDzrfmBxFgBq4ZcD8mhMKkofmVqS/ntvuJePrCnBPGQG9d+tfntizIO5OpCqFGk0lgYBwae+oQ+vw==",
+      "version": "10.7.3",
+      "resolved": "https://registry.npmjs.org/@polkadot/rpc-augment/-/rpc-augment-10.7.3.tgz",
+      "integrity": "sha512-Y5bfzot3NT1QM0QDnFHG0NsZyBSV69+yOSh635q1gpZureykVnn5o36xQtLDHUKmTkiBjqgmjmYqoXByfHZ+Sg==",
       "dependencies": {
-        "@polkadot/rpc-core": "10.4.1",
-        "@polkadot/types": "10.4.1",
-        "@polkadot/types-codec": "10.4.1",
-        "@polkadot/util": "^12.0.1",
-        "tslib": "^2.5.0"
+        "@polkadot/rpc-core": "10.7.3",
+        "@polkadot/types": "10.7.3",
+        "@polkadot/types-codec": "10.7.3",
+        "@polkadot/util": "^12.2.1",
+        "tslib": "^2.5.2"
       },
       "engines": {
         "node": ">=16"
       }
     },
     "node_modules/@polkadot/rpc-augment/node_modules/tslib": {
-      "version": "2.5.0",
-      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.5.0.tgz",
-      "integrity": "sha512-336iVw3rtn2BUK7ORdIAHTyxHGRIHVReokCR3XjbckJMK7ms8FysBfhLR8IXnAgy7T0PTPNBWKiH514FOW/WSg=="
+      "version": "2.5.2",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.5.2.tgz",
+      "integrity": "sha512-5svOrSA2w3iGFDs1HibEVBGbDrAY82bFQ3HZ3ixB+88nsbsWQoKqDRb5UBYAUPEzbBn6dAp5gRNXglySbx1MlA=="
     },
     "node_modules/@polkadot/rpc-core": {
-      "version": "10.4.1",
-      "resolved": "https://registry.npmjs.org/@polkadot/rpc-core/-/rpc-core-10.4.1.tgz",
-      "integrity": "sha512-jE3dBzfOFkiROMsiXpge/njvwPDCXF990VPFtlFqVWpr9ypXY7eZT1gduanN6YkXRjzcBVVPHaPfWLejie6hZA==",
+      "version": "10.7.3",
+      "resolved": "https://registry.npmjs.org/@polkadot/rpc-core/-/rpc-core-10.7.3.tgz",
+      "integrity": "sha512-SL8PDfuYEwDx+g1KBq7DVFqP/dSEromhDfQHWs/mlxh+YSD4sOJBVvd1HN0PIsG/Xi6qJwzWoj0sLNy4wymhcA==",
       "dependencies": {
-        "@polkadot/rpc-augment": "10.4.1",
-        "@polkadot/rpc-provider": "10.4.1",
-        "@polkadot/types": "10.4.1",
-        "@polkadot/util": "^12.0.1",
-        "rxjs": "^7.8.0",
-        "tslib": "^2.5.0"
+        "@polkadot/rpc-augment": "10.7.3",
+        "@polkadot/rpc-provider": "10.7.3",
+        "@polkadot/types": "10.7.3",
+        "@polkadot/util": "^12.2.1",
+        "rxjs": "^7.8.1",
+        "tslib": "^2.5.2"
       },
       "engines": {
         "node": ">=16"
       }
     },
     "node_modules/@polkadot/rpc-core/node_modules/tslib": {
-      "version": "2.5.0",
-      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.5.0.tgz",
-      "integrity": "sha512-336iVw3rtn2BUK7ORdIAHTyxHGRIHVReokCR3XjbckJMK7ms8FysBfhLR8IXnAgy7T0PTPNBWKiH514FOW/WSg=="
+      "version": "2.5.2",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.5.2.tgz",
+      "integrity": "sha512-5svOrSA2w3iGFDs1HibEVBGbDrAY82bFQ3HZ3ixB+88nsbsWQoKqDRb5UBYAUPEzbBn6dAp5gRNXglySbx1MlA=="
     },
     "node_modules/@polkadot/rpc-provider": {
-      "version": "10.4.1",
-      "resolved": "https://registry.npmjs.org/@polkadot/rpc-provider/-/rpc-provider-10.4.1.tgz",
-      "integrity": "sha512-DwXs5dB1hp0P17I/Aqg+BnILQRMWlmMlABfSwwPprOh+16BBDw4P7bEuvaYw3gl/Zrxt4UhDcPl48jD+4j5OrQ==",
+      "version": "10.7.3",
+      "resolved": "https://registry.npmjs.org/@polkadot/rpc-provider/-/rpc-provider-10.7.3.tgz",
+      "integrity": "sha512-A87O8UH3erxV8G8LFxDVYvWy9DPx30sPPPaPoDju2vtd7b9yyGMIdazJwhx1rXwD2PYsu7gEMdUNo8oVtDQf4A==",
       "dependencies": {
-        "@polkadot/keyring": "^12.0.1",
-        "@polkadot/types": "10.4.1",
-        "@polkadot/types-support": "10.4.1",
-        "@polkadot/util": "^12.0.1",
-        "@polkadot/util-crypto": "^12.0.1",
-        "@polkadot/x-fetch": "^12.0.1",
-        "@polkadot/x-global": "^12.0.1",
-        "@polkadot/x-ws": "^12.0.1",
-        "eventemitter3": "^5.0.0",
+        "@polkadot/keyring": "^12.2.1",
+        "@polkadot/types": "10.7.3",
+        "@polkadot/types-support": "10.7.3",
+        "@polkadot/util": "^12.2.1",
+        "@polkadot/util-crypto": "^12.2.1",
+        "@polkadot/x-fetch": "^12.2.1",
+        "@polkadot/x-global": "^12.2.1",
+        "@polkadot/x-ws": "^12.2.1",
+        "eventemitter3": "^5.0.1",
         "mock-socket": "^9.2.1",
-        "nock": "^13.3.0",
-        "tslib": "^2.5.0"
+        "nock": "^13.3.1",
+        "tslib": "^2.5.2"
       },
       "engines": {
         "node": ">=16"
       },
       "optionalDependencies": {
-        "@substrate/connect": "0.7.24"
+        "@substrate/connect": "0.7.26"
       }
     },
-    "node_modules/@polkadot/rpc-provider/node_modules/eventemitter3": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/eventemitter3/-/eventemitter3-5.0.0.tgz",
-      "integrity": "sha512-riuVbElZZNXLeLEoprfNYoDSwTBRR44X3mnhdI1YcnENpWTCsTTVZ2zFuqQcpoyqPQIUXdiPEU0ECAq0KQRaHg=="
-    },
     "node_modules/@polkadot/rpc-provider/node_modules/tslib": {
-      "version": "2.5.0",
-      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.5.0.tgz",
-      "integrity": "sha512-336iVw3rtn2BUK7ORdIAHTyxHGRIHVReokCR3XjbckJMK7ms8FysBfhLR8IXnAgy7T0PTPNBWKiH514FOW/WSg=="
+      "version": "2.5.2",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.5.2.tgz",
+      "integrity": "sha512-5svOrSA2w3iGFDs1HibEVBGbDrAY82bFQ3HZ3ixB+88nsbsWQoKqDRb5UBYAUPEzbBn6dAp5gRNXglySbx1MlA=="
     },
     "node_modules/@polkadot/typegen": {
-      "version": "10.4.1",
-      "resolved": "https://registry.npmjs.org/@polkadot/typegen/-/typegen-10.4.1.tgz",
-      "integrity": "sha512-M2DwurCqX4n7IAXWRK/T9yLERC6y+rKzg3YpIiQ6RdOz5Hmr0vimU/1KVunW/0I8gOI+dCvHR6ybXftRrLhabg==",
+      "version": "10.7.3",
+      "resolved": "https://registry.npmjs.org/@polkadot/typegen/-/typegen-10.7.3.tgz",
+      "integrity": "sha512-BtaUs1SOW58ilbrvDom6t5J8P0uT4pBYQxJtts+8df6lkggr/UiXWP7xPMIRWXs2U0sHp6TZnYOE9TE2/qjdRw==",
       "dev": true,
       "dependencies": {
-        "@polkadot/api": "10.4.1",
-        "@polkadot/api-augment": "10.4.1",
-        "@polkadot/rpc-augment": "10.4.1",
-        "@polkadot/rpc-provider": "10.4.1",
-        "@polkadot/types": "10.4.1",
-        "@polkadot/types-augment": "10.4.1",
-        "@polkadot/types-codec": "10.4.1",
-        "@polkadot/types-create": "10.4.1",
-        "@polkadot/types-support": "10.4.1",
-        "@polkadot/util": "^12.0.1",
-        "@polkadot/util-crypto": "^12.0.1",
-        "@polkadot/x-ws": "^12.0.1",
+        "@polkadot/api": "10.7.3",
+        "@polkadot/api-augment": "10.7.3",
+        "@polkadot/rpc-augment": "10.7.3",
+        "@polkadot/rpc-provider": "10.7.3",
+        "@polkadot/types": "10.7.3",
+        "@polkadot/types-augment": "10.7.3",
+        "@polkadot/types-codec": "10.7.3",
+        "@polkadot/types-create": "10.7.3",
+        "@polkadot/types-support": "10.7.3",
+        "@polkadot/util": "^12.2.1",
+        "@polkadot/util-crypto": "^12.2.1",
+        "@polkadot/x-ws": "^12.2.1",
         "handlebars": "^4.7.7",
-        "tslib": "^2.5.0",
-        "yargs": "^17.7.1"
+        "tslib": "^2.5.2",
+        "yargs": "^17.7.2"
       },
       "bin": {
         "polkadot-types-chain-info": "scripts/polkadot-types-chain-info.mjs",
@@ -481,15 +471,15 @@
       }
     },
     "node_modules/@polkadot/typegen/node_modules/tslib": {
-      "version": "2.5.0",
-      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.5.0.tgz",
-      "integrity": "sha512-336iVw3rtn2BUK7ORdIAHTyxHGRIHVReokCR3XjbckJMK7ms8FysBfhLR8IXnAgy7T0PTPNBWKiH514FOW/WSg==",
+      "version": "2.5.2",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.5.2.tgz",
+      "integrity": "sha512-5svOrSA2w3iGFDs1HibEVBGbDrAY82bFQ3HZ3ixB+88nsbsWQoKqDRb5UBYAUPEzbBn6dAp5gRNXglySbx1MlA==",
       "dev": true
     },
     "node_modules/@polkadot/typegen/node_modules/yargs": {
-      "version": "17.7.1",
-      "resolved": "https://registry.npmjs.org/yargs/-/yargs-17.7.1.tgz",
-      "integrity": "sha512-cwiTb08Xuv5fqF4AovYacTFNxk62th7LKJ6BL9IGUpTJrWoU7/7WdQGTP2SjKf1dUNBGzDd28p/Yfs/GI6JrLw==",
+      "version": "17.7.2",
+      "resolved": "https://registry.npmjs.org/yargs/-/yargs-17.7.2.tgz",
+      "integrity": "sha512-7dSzzRQ++CKnNI/krKnYRV7JKKPUXMEh61soaHKg9mrWEhzFWhFnxPxGl+69cD1Ou63C13NUPCnmIcrvqCuM6w==",
       "dev": true,
       "dependencies": {
         "cliui": "^8.0.1",
@@ -514,130 +504,130 @@
       }
     },
     "node_modules/@polkadot/types": {
-      "version": "10.4.1",
-      "resolved": "https://registry.npmjs.org/@polkadot/types/-/types-10.4.1.tgz",
-      "integrity": "sha512-w4spUa4CMLoPuIHOANR8X5F/Hfs4b4OnxsofA9SOl2aaQNRgu77Qu0y60rReu8HxBKD/FUBJJmRpZeY/2WQAAQ==",
+      "version": "10.7.3",
+      "resolved": "https://registry.npmjs.org/@polkadot/types/-/types-10.7.3.tgz",
+      "integrity": "sha512-F+h8tvlvMgwF+oVLu/bTV1WtsqMoosoGKL96a/6LY1a1ykKhK1HiB11Lodu3VkRTQa3oie5ftjg/iCQ2pilgDA==",
       "dependencies": {
-        "@polkadot/keyring": "^12.0.1",
-        "@polkadot/types-augment": "10.4.1",
-        "@polkadot/types-codec": "10.4.1",
-        "@polkadot/types-create": "10.4.1",
-        "@polkadot/util": "^12.0.1",
-        "@polkadot/util-crypto": "^12.0.1",
-        "rxjs": "^7.8.0",
-        "tslib": "^2.5.0"
+        "@polkadot/keyring": "^12.2.1",
+        "@polkadot/types-augment": "10.7.3",
+        "@polkadot/types-codec": "10.7.3",
+        "@polkadot/types-create": "10.7.3",
+        "@polkadot/util": "^12.2.1",
+        "@polkadot/util-crypto": "^12.2.1",
+        "rxjs": "^7.8.1",
+        "tslib": "^2.5.2"
       },
       "engines": {
         "node": ">=16"
       }
     },
     "node_modules/@polkadot/types-augment": {
-      "version": "10.4.1",
-      "resolved": "https://registry.npmjs.org/@polkadot/types-augment/-/types-augment-10.4.1.tgz",
-      "integrity": "sha512-4QWfxf6nA+sBf2X88S454N5Wpc4yTL+9uwdCP5PiqyDuCv96l+G0jQWurolywADJcKMKcnu8zHdQdv4rcgUyxQ==",
+      "version": "10.7.3",
+      "resolved": "https://registry.npmjs.org/@polkadot/types-augment/-/types-augment-10.7.3.tgz",
+      "integrity": "sha512-iWw0Qfqko/D2XDKKjI3syPMZol24k0BEJWsk8HX4waqFDNa+DIGz729J5cj1NopHg7re6BkGhYloMAaH0r2Q7g==",
       "dependencies": {
-        "@polkadot/types": "10.4.1",
-        "@polkadot/types-codec": "10.4.1",
-        "@polkadot/util": "^12.0.1",
-        "tslib": "^2.5.0"
+        "@polkadot/types": "10.7.3",
+        "@polkadot/types-codec": "10.7.3",
+        "@polkadot/util": "^12.2.1",
+        "tslib": "^2.5.2"
       },
       "engines": {
         "node": ">=16"
       }
     },
     "node_modules/@polkadot/types-augment/node_modules/tslib": {
-      "version": "2.5.0",
-      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.5.0.tgz",
-      "integrity": "sha512-336iVw3rtn2BUK7ORdIAHTyxHGRIHVReokCR3XjbckJMK7ms8FysBfhLR8IXnAgy7T0PTPNBWKiH514FOW/WSg=="
+      "version": "2.5.2",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.5.2.tgz",
+      "integrity": "sha512-5svOrSA2w3iGFDs1HibEVBGbDrAY82bFQ3HZ3ixB+88nsbsWQoKqDRb5UBYAUPEzbBn6dAp5gRNXglySbx1MlA=="
     },
     "node_modules/@polkadot/types-codec": {
-      "version": "10.4.1",
-      "resolved": "https://registry.npmjs.org/@polkadot/types-codec/-/types-codec-10.4.1.tgz",
-      "integrity": "sha512-h6OCSF6i0b/Q4uCOEEiibMkGefhb7daaDGwoxjTEOeSqDE9gMIkhkyXVjqcOGbsHsFaYqYhuJakRQe/LICykTw==",
+      "version": "10.7.3",
+      "resolved": "https://registry.npmjs.org/@polkadot/types-codec/-/types-codec-10.7.3.tgz",
+      "integrity": "sha512-/9C50FZFSL4qGIOXYUDkNUt1YJSsEGbo2aSxJLMwki7U3UuBdbBqolsbKQRM4g6dtAS0FSM8lFYaKXFiz4VxNw==",
       "dependencies": {
-        "@polkadot/util": "^12.0.1",
-        "@polkadot/x-bigint": "^12.0.1",
-        "tslib": "^2.5.0"
+        "@polkadot/util": "^12.2.1",
+        "@polkadot/x-bigint": "^12.2.1",
+        "tslib": "^2.5.2"
       },
       "engines": {
         "node": ">=16"
       }
     },
     "node_modules/@polkadot/types-codec/node_modules/tslib": {
-      "version": "2.5.0",
-      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.5.0.tgz",
-      "integrity": "sha512-336iVw3rtn2BUK7ORdIAHTyxHGRIHVReokCR3XjbckJMK7ms8FysBfhLR8IXnAgy7T0PTPNBWKiH514FOW/WSg=="
+      "version": "2.5.2",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.5.2.tgz",
+      "integrity": "sha512-5svOrSA2w3iGFDs1HibEVBGbDrAY82bFQ3HZ3ixB+88nsbsWQoKqDRb5UBYAUPEzbBn6dAp5gRNXglySbx1MlA=="
     },
     "node_modules/@polkadot/types-create": {
-      "version": "10.4.1",
-      "resolved": "https://registry.npmjs.org/@polkadot/types-create/-/types-create-10.4.1.tgz",
-      "integrity": "sha512-E15P4ZQSAIq90Gnc+ZVK7XmEWRIF9qbCAQvJQ6nxikb6u5A9AzePAZ4XwxjJ3JXC5/t0Wxnij+pddtfxOkUi2w==",
+      "version": "10.7.3",
+      "resolved": "https://registry.npmjs.org/@polkadot/types-create/-/types-create-10.7.3.tgz",
+      "integrity": "sha512-xFJqssVGICLoclc3nTBhoZG74Z/yltMUYQmmiqm0ByE5W6451rf76IMNcWpoNe7EuWmA4Ccjy0jG1yEhOTtRuQ==",
       "dependencies": {
-        "@polkadot/types-codec": "10.4.1",
-        "@polkadot/util": "^12.0.1",
-        "tslib": "^2.5.0"
+        "@polkadot/types-codec": "10.7.3",
+        "@polkadot/util": "^12.2.1",
+        "tslib": "^2.5.2"
       },
       "engines": {
         "node": ">=16"
       }
     },
     "node_modules/@polkadot/types-create/node_modules/tslib": {
-      "version": "2.5.0",
-      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.5.0.tgz",
-      "integrity": "sha512-336iVw3rtn2BUK7ORdIAHTyxHGRIHVReokCR3XjbckJMK7ms8FysBfhLR8IXnAgy7T0PTPNBWKiH514FOW/WSg=="
+      "version": "2.5.2",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.5.2.tgz",
+      "integrity": "sha512-5svOrSA2w3iGFDs1HibEVBGbDrAY82bFQ3HZ3ixB+88nsbsWQoKqDRb5UBYAUPEzbBn6dAp5gRNXglySbx1MlA=="
     },
     "node_modules/@polkadot/types-known": {
-      "version": "10.4.1",
-      "resolved": "https://registry.npmjs.org/@polkadot/types-known/-/types-known-10.4.1.tgz",
-      "integrity": "sha512-vgxsJeZTdbNJ55CCICRcSeOJD6Qy4D2NaMhR2j24xxHRY1lL8uBfCE/ReIEY2Bxa8cCIjCtw5fXJiCWPjnQQoQ==",
+      "version": "10.7.3",
+      "resolved": "https://registry.npmjs.org/@polkadot/types-known/-/types-known-10.7.3.tgz",
+      "integrity": "sha512-sS8zK/3wds/NmosMupg2TJ/p+dW40jcgzFn42WYSxA1kOP0vtxVMeqM81Xrsig0ENl4Y0Fb+8EDlrmxo9DWdOw==",
       "dependencies": {
-        "@polkadot/networks": "^12.0.1",
-        "@polkadot/types": "10.4.1",
-        "@polkadot/types-codec": "10.4.1",
-        "@polkadot/types-create": "10.4.1",
-        "@polkadot/util": "^12.0.1",
-        "tslib": "^2.5.0"
+        "@polkadot/networks": "^12.2.1",
+        "@polkadot/types": "10.7.3",
+        "@polkadot/types-codec": "10.7.3",
+        "@polkadot/types-create": "10.7.3",
+        "@polkadot/util": "^12.2.1",
+        "tslib": "^2.5.2"
       },
       "engines": {
         "node": ">=16"
       }
     },
     "node_modules/@polkadot/types-known/node_modules/tslib": {
-      "version": "2.5.0",
-      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.5.0.tgz",
-      "integrity": "sha512-336iVw3rtn2BUK7ORdIAHTyxHGRIHVReokCR3XjbckJMK7ms8FysBfhLR8IXnAgy7T0PTPNBWKiH514FOW/WSg=="
+      "version": "2.5.2",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.5.2.tgz",
+      "integrity": "sha512-5svOrSA2w3iGFDs1HibEVBGbDrAY82bFQ3HZ3ixB+88nsbsWQoKqDRb5UBYAUPEzbBn6dAp5gRNXglySbx1MlA=="
     },
     "node_modules/@polkadot/types-support": {
-      "version": "10.4.1",
-      "resolved": "https://registry.npmjs.org/@polkadot/types-support/-/types-support-10.4.1.tgz",
-      "integrity": "sha512-kt/TGVAGaGD76eM/kye8qdYxQDZtpc6GS58xYvgnsk59KkCvaOzOE+hHFDXx0UDy4pPgXKquk1EHxwiFTKSb4g==",
+      "version": "10.7.3",
+      "resolved": "https://registry.npmjs.org/@polkadot/types-support/-/types-support-10.7.3.tgz",
+      "integrity": "sha512-3RYIveHUyIysC21YR0XEuTL0ijQQQjFHUbmI3bdjbKgIaQKmgEkRGhFCutkvr9HgB/jUDOpmdxW0t0OJe1etmg==",
       "dependencies": {
-        "@polkadot/util": "^12.0.1",
-        "tslib": "^2.5.0"
+        "@polkadot/util": "^12.2.1",
+        "tslib": "^2.5.2"
       },
       "engines": {
         "node": ">=16"
       }
     },
     "node_modules/@polkadot/types-support/node_modules/tslib": {
-      "version": "2.5.0",
-      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.5.0.tgz",
-      "integrity": "sha512-336iVw3rtn2BUK7ORdIAHTyxHGRIHVReokCR3XjbckJMK7ms8FysBfhLR8IXnAgy7T0PTPNBWKiH514FOW/WSg=="
+      "version": "2.5.2",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.5.2.tgz",
+      "integrity": "sha512-5svOrSA2w3iGFDs1HibEVBGbDrAY82bFQ3HZ3ixB+88nsbsWQoKqDRb5UBYAUPEzbBn6dAp5gRNXglySbx1MlA=="
     },
     "node_modules/@polkadot/types/node_modules/tslib": {
-      "version": "2.5.0",
-      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.5.0.tgz",
-      "integrity": "sha512-336iVw3rtn2BUK7ORdIAHTyxHGRIHVReokCR3XjbckJMK7ms8FysBfhLR8IXnAgy7T0PTPNBWKiH514FOW/WSg=="
+      "version": "2.5.2",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.5.2.tgz",
+      "integrity": "sha512-5svOrSA2w3iGFDs1HibEVBGbDrAY82bFQ3HZ3ixB+88nsbsWQoKqDRb5UBYAUPEzbBn6dAp5gRNXglySbx1MlA=="
     },
     "node_modules/@polkadot/util": {
-      "version": "12.0.1",
-      "resolved": "https://registry.npmjs.org/@polkadot/util/-/util-12.0.1.tgz",
-      "integrity": "sha512-yG4VcZ9wWvgCOg9+tUoTk6s4lphhsniuQVmQ/dRRKry983QlIj5eUgu1PfSRCKX+qUMR8IWI6oENZjmWdg0n6w==",
+      "version": "12.2.1",
+      "resolved": "https://registry.npmjs.org/@polkadot/util/-/util-12.2.1.tgz",
+      "integrity": "sha512-MQmPx9aCX4GTpDY/USUQywXRyaDbaibg4V1+c/CoRTsoDu+XHNM8G3lpabdNAYKZrtxg+3/1bTS0ojm6ANSQRw==",
       "dependencies": {
-        "@polkadot/x-bigint": "12.0.1",
-        "@polkadot/x-global": "12.0.1",
-        "@polkadot/x-textdecoder": "12.0.1",
-        "@polkadot/x-textencoder": "12.0.1",
+        "@polkadot/x-bigint": "12.2.1",
+        "@polkadot/x-global": "12.2.1",
+        "@polkadot/x-textdecoder": "12.2.1",
+        "@polkadot/x-textencoder": "12.2.1",
         "@types/bn.js": "^5.1.1",
         "bn.js": "^5.2.1",
         "tslib": "^2.5.0"
@@ -647,18 +637,18 @@
       }
     },
     "node_modules/@polkadot/util-crypto": {
-      "version": "12.0.1",
-      "resolved": "https://registry.npmjs.org/@polkadot/util-crypto/-/util-crypto-12.0.1.tgz",
-      "integrity": "sha512-9zkxoAHUaGFcerMxKZu2rbBSB48YBx3dGzFMGnu/nTf3gL65a7r0wMy3R5iPhWF4AZ8RUjjcS/1a22mSB+PXTg==",
+      "version": "12.2.1",
+      "resolved": "https://registry.npmjs.org/@polkadot/util-crypto/-/util-crypto-12.2.1.tgz",
+      "integrity": "sha512-MFh7Sdm7/G9ot5eIBZGuQXTYP/EbOCh1+ODyygp9/TjWAmJZMq1J73Uqk4KmzkwpDBpNZO8TGjiYwL8lR6BnGg==",
       "dependencies": {
         "@noble/curves": "1.0.0",
         "@noble/hashes": "1.3.0",
-        "@polkadot/networks": "12.0.1",
-        "@polkadot/util": "12.0.1",
-        "@polkadot/wasm-crypto": "^7.1.1",
-        "@polkadot/wasm-util": "^7.1.1",
-        "@polkadot/x-bigint": "12.0.1",
-        "@polkadot/x-randomvalues": "12.0.1",
+        "@polkadot/networks": "12.2.1",
+        "@polkadot/util": "12.2.1",
+        "@polkadot/wasm-crypto": "^7.2.1",
+        "@polkadot/wasm-util": "^7.2.1",
+        "@polkadot/x-bigint": "12.2.1",
+        "@polkadot/x-randomvalues": "12.2.1",
         "@scure/base": "1.1.1",
         "tslib": "^2.5.0"
       },
@@ -666,25 +656,25 @@
         "node": ">=16"
       },
       "peerDependencies": {
-        "@polkadot/util": "12.0.1"
+        "@polkadot/util": "12.2.1"
       }
     },
     "node_modules/@polkadot/util-crypto/node_modules/tslib": {
-      "version": "2.5.0",
-      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.5.0.tgz",
-      "integrity": "sha512-336iVw3rtn2BUK7ORdIAHTyxHGRIHVReokCR3XjbckJMK7ms8FysBfhLR8IXnAgy7T0PTPNBWKiH514FOW/WSg=="
+      "version": "2.5.2",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.5.2.tgz",
+      "integrity": "sha512-5svOrSA2w3iGFDs1HibEVBGbDrAY82bFQ3HZ3ixB+88nsbsWQoKqDRb5UBYAUPEzbBn6dAp5gRNXglySbx1MlA=="
     },
     "node_modules/@polkadot/util/node_modules/tslib": {
-      "version": "2.5.0",
-      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.5.0.tgz",
-      "integrity": "sha512-336iVw3rtn2BUK7ORdIAHTyxHGRIHVReokCR3XjbckJMK7ms8FysBfhLR8IXnAgy7T0PTPNBWKiH514FOW/WSg=="
+      "version": "2.5.2",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.5.2.tgz",
+      "integrity": "sha512-5svOrSA2w3iGFDs1HibEVBGbDrAY82bFQ3HZ3ixB+88nsbsWQoKqDRb5UBYAUPEzbBn6dAp5gRNXglySbx1MlA=="
     },
     "node_modules/@polkadot/wasm-bridge": {
-      "version": "7.1.1",
-      "resolved": "https://registry.npmjs.org/@polkadot/wasm-bridge/-/wasm-bridge-7.1.1.tgz",
-      "integrity": "sha512-2YKaqrGaN+e+OjKxs1sAS822Jil6GJE8xhNTs8an7BtgEKtfBjQ/j2ZIe41ijRs4O05iI+OkxHpLEHhIm+wq0A==",
+      "version": "7.2.1",
+      "resolved": "https://registry.npmjs.org/@polkadot/wasm-bridge/-/wasm-bridge-7.2.1.tgz",
+      "integrity": "sha512-uV/LHREDBGBbHrrv7HTki+Klw0PYZzFomagFWII4lp6Toj/VCvRh5WMzooVC+g/XsBGosAwrvBhoModabyHx+A==",
       "dependencies": {
-        "@polkadot/wasm-util": "7.1.1",
+        "@polkadot/wasm-util": "7.2.1",
         "tslib": "^2.5.0"
       },
       "engines": {
@@ -696,20 +686,20 @@
       }
     },
     "node_modules/@polkadot/wasm-bridge/node_modules/tslib": {
-      "version": "2.5.0",
-      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.5.0.tgz",
-      "integrity": "sha512-336iVw3rtn2BUK7ORdIAHTyxHGRIHVReokCR3XjbckJMK7ms8FysBfhLR8IXnAgy7T0PTPNBWKiH514FOW/WSg=="
+      "version": "2.5.2",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.5.2.tgz",
+      "integrity": "sha512-5svOrSA2w3iGFDs1HibEVBGbDrAY82bFQ3HZ3ixB+88nsbsWQoKqDRb5UBYAUPEzbBn6dAp5gRNXglySbx1MlA=="
     },
     "node_modules/@polkadot/wasm-crypto": {
-      "version": "7.1.1",
-      "resolved": "https://registry.npmjs.org/@polkadot/wasm-crypto/-/wasm-crypto-7.1.1.tgz",
-      "integrity": "sha512-qaYScOVR7gUr41bP7O7OzOVJFfb9gh6KBk9xVy7gl5U9XYAqq0xqp88g528hEUa7IjFW3QVg7EeI8KsRmm0zpA==",
+      "version": "7.2.1",
+      "resolved": "https://registry.npmjs.org/@polkadot/wasm-crypto/-/wasm-crypto-7.2.1.tgz",
+      "integrity": "sha512-SA2+33S9TAwGhniKgztVN6pxUKpGfN4Tre/eUZGUfpgRkT92wIUT2GpGWQE+fCCqGQgADrNiBcwt6XwdPqMQ4Q==",
       "dependencies": {
-        "@polkadot/wasm-bridge": "7.1.1",
-        "@polkadot/wasm-crypto-asmjs": "7.1.1",
-        "@polkadot/wasm-crypto-init": "7.1.1",
-        "@polkadot/wasm-crypto-wasm": "7.1.1",
-        "@polkadot/wasm-util": "7.1.1",
+        "@polkadot/wasm-bridge": "7.2.1",
+        "@polkadot/wasm-crypto-asmjs": "7.2.1",
+        "@polkadot/wasm-crypto-init": "7.2.1",
+        "@polkadot/wasm-crypto-wasm": "7.2.1",
+        "@polkadot/wasm-util": "7.2.1",
         "tslib": "^2.5.0"
       },
       "engines": {
@@ -721,9 +711,9 @@
       }
     },
     "node_modules/@polkadot/wasm-crypto-asmjs": {
-      "version": "7.1.1",
-      "resolved": "https://registry.npmjs.org/@polkadot/wasm-crypto-asmjs/-/wasm-crypto-asmjs-7.1.1.tgz",
-      "integrity": "sha512-LOKdussHjRx+bwT85iuL6huiKwWZ0x3XLvo0En2U16fT/g9mx74Nmp/YpIwkDRXJ0PUgHpuPYGNMH3x2vEVgBQ==",
+      "version": "7.2.1",
+      "resolved": "https://registry.npmjs.org/@polkadot/wasm-crypto-asmjs/-/wasm-crypto-asmjs-7.2.1.tgz",
+      "integrity": "sha512-z/d21bmxyVfkzGsKef/FWswKX02x5lK97f4NPBZ9XBeiFkmzlXhdSnu58/+b1sKsRAGdW/Rn/rTNRDhW0GqCAg==",
       "dependencies": {
         "tslib": "^2.5.0"
       },
@@ -735,19 +725,19 @@
       }
     },
     "node_modules/@polkadot/wasm-crypto-asmjs/node_modules/tslib": {
-      "version": "2.5.0",
-      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.5.0.tgz",
-      "integrity": "sha512-336iVw3rtn2BUK7ORdIAHTyxHGRIHVReokCR3XjbckJMK7ms8FysBfhLR8IXnAgy7T0PTPNBWKiH514FOW/WSg=="
+      "version": "2.5.2",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.5.2.tgz",
+      "integrity": "sha512-5svOrSA2w3iGFDs1HibEVBGbDrAY82bFQ3HZ3ixB+88nsbsWQoKqDRb5UBYAUPEzbBn6dAp5gRNXglySbx1MlA=="
     },
     "node_modules/@polkadot/wasm-crypto-init": {
-      "version": "7.1.1",
-      "resolved": "https://registry.npmjs.org/@polkadot/wasm-crypto-init/-/wasm-crypto-init-7.1.1.tgz",
-      "integrity": "sha512-EgbnXCPNvqfXElhsipI1XqLdVnvk46MCr0cgNE9g1sQHfOh5N9Bsjv7J4bnbv5bIb7JlpXBc9MnTas70PasaCw==",
+      "version": "7.2.1",
+      "resolved": "https://registry.npmjs.org/@polkadot/wasm-crypto-init/-/wasm-crypto-init-7.2.1.tgz",
+      "integrity": "sha512-GcEXtwN9LcSf32V9zSaYjHImFw16hCyo2Xzg4GLLDPPeaAAfbFr2oQMgwyDbvBrBjLKHVHjsPZyGhXae831amw==",
       "dependencies": {
-        "@polkadot/wasm-bridge": "7.1.1",
-        "@polkadot/wasm-crypto-asmjs": "7.1.1",
-        "@polkadot/wasm-crypto-wasm": "7.1.1",
-        "@polkadot/wasm-util": "7.1.1",
+        "@polkadot/wasm-bridge": "7.2.1",
+        "@polkadot/wasm-crypto-asmjs": "7.2.1",
+        "@polkadot/wasm-crypto-wasm": "7.2.1",
+        "@polkadot/wasm-util": "7.2.1",
         "tslib": "^2.5.0"
       },
       "engines": {
@@ -759,16 +749,16 @@
       }
     },
     "node_modules/@polkadot/wasm-crypto-init/node_modules/tslib": {
-      "version": "2.5.0",
-      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.5.0.tgz",
-      "integrity": "sha512-336iVw3rtn2BUK7ORdIAHTyxHGRIHVReokCR3XjbckJMK7ms8FysBfhLR8IXnAgy7T0PTPNBWKiH514FOW/WSg=="
+      "version": "2.5.2",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.5.2.tgz",
+      "integrity": "sha512-5svOrSA2w3iGFDs1HibEVBGbDrAY82bFQ3HZ3ixB+88nsbsWQoKqDRb5UBYAUPEzbBn6dAp5gRNXglySbx1MlA=="
     },
     "node_modules/@polkadot/wasm-crypto-wasm": {
-      "version": "7.1.1",
-      "resolved": "https://registry.npmjs.org/@polkadot/wasm-crypto-wasm/-/wasm-crypto-wasm-7.1.1.tgz",
-      "integrity": "sha512-mbo6CEt/11Wh2NDGDhVzQFpOZLE/+Hl8tUf8Y38ddRo20xAHvs09KK+cNTFRurY0P2Tq5LnF9+VzuC0bZPyRqQ==",
+      "version": "7.2.1",
+      "resolved": "https://registry.npmjs.org/@polkadot/wasm-crypto-wasm/-/wasm-crypto-wasm-7.2.1.tgz",
+      "integrity": "sha512-DqyXE4rSD0CVlLIw88B58+HHNyrvm+JAnYyuEDYZwCvzUWOCNos/DDg9wi/K39VAIsCCKDmwKqkkfIofuOj/lA==",
       "dependencies": {
-        "@polkadot/wasm-util": "7.1.1",
+        "@polkadot/wasm-util": "7.2.1",
         "tslib": "^2.5.0"
       },
       "engines": {
@@ -779,19 +769,19 @@
       }
     },
     "node_modules/@polkadot/wasm-crypto-wasm/node_modules/tslib": {
-      "version": "2.5.0",
-      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.5.0.tgz",
-      "integrity": "sha512-336iVw3rtn2BUK7ORdIAHTyxHGRIHVReokCR3XjbckJMK7ms8FysBfhLR8IXnAgy7T0PTPNBWKiH514FOW/WSg=="
+      "version": "2.5.2",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.5.2.tgz",
+      "integrity": "sha512-5svOrSA2w3iGFDs1HibEVBGbDrAY82bFQ3HZ3ixB+88nsbsWQoKqDRb5UBYAUPEzbBn6dAp5gRNXglySbx1MlA=="
     },
     "node_modules/@polkadot/wasm-crypto/node_modules/tslib": {
-      "version": "2.5.0",
-      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.5.0.tgz",
-      "integrity": "sha512-336iVw3rtn2BUK7ORdIAHTyxHGRIHVReokCR3XjbckJMK7ms8FysBfhLR8IXnAgy7T0PTPNBWKiH514FOW/WSg=="
+      "version": "2.5.2",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.5.2.tgz",
+      "integrity": "sha512-5svOrSA2w3iGFDs1HibEVBGbDrAY82bFQ3HZ3ixB+88nsbsWQoKqDRb5UBYAUPEzbBn6dAp5gRNXglySbx1MlA=="
     },
     "node_modules/@polkadot/wasm-util": {
-      "version": "7.1.1",
-      "resolved": "https://registry.npmjs.org/@polkadot/wasm-util/-/wasm-util-7.1.1.tgz",
-      "integrity": "sha512-FOflVMo4sXTsXhXoY9rQKfPPCiTfE+dEsuGcm6Aecau0NL24Ze/guxX6vOSDN2E2I6kf60biQU016O2RKHqtwg==",
+      "version": "7.2.1",
+      "resolved": "https://registry.npmjs.org/@polkadot/wasm-util/-/wasm-util-7.2.1.tgz",
+      "integrity": "sha512-FBSn/3aYJzhN0sYAYhHB8y9JL8mVgxLy4M1kUXYbyo+8GLRQEN5rns8Vcb8TAlIzBWgVTOOptYBvxo0oj0h7Og==",
       "dependencies": {
         "tslib": "^2.5.0"
       },
@@ -803,16 +793,16 @@
       }
     },
     "node_modules/@polkadot/wasm-util/node_modules/tslib": {
-      "version": "2.5.0",
-      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.5.0.tgz",
-      "integrity": "sha512-336iVw3rtn2BUK7ORdIAHTyxHGRIHVReokCR3XjbckJMK7ms8FysBfhLR8IXnAgy7T0PTPNBWKiH514FOW/WSg=="
+      "version": "2.5.2",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.5.2.tgz",
+      "integrity": "sha512-5svOrSA2w3iGFDs1HibEVBGbDrAY82bFQ3HZ3ixB+88nsbsWQoKqDRb5UBYAUPEzbBn6dAp5gRNXglySbx1MlA=="
     },
     "node_modules/@polkadot/x-bigint": {
-      "version": "12.0.1",
-      "resolved": "https://registry.npmjs.org/@polkadot/x-bigint/-/x-bigint-12.0.1.tgz",
-      "integrity": "sha512-i93iVkK/PHsh1XDtYqdvUhuom6W80dYPCEA0WcZl0yuxuZGWk3Az+mXRL/mZkK/uDp8RGC0wYQiUm0kkheeoqg==",
+      "version": "12.2.1",
+      "resolved": "https://registry.npmjs.org/@polkadot/x-bigint/-/x-bigint-12.2.1.tgz",
+      "integrity": "sha512-3cZLsV8kU1MFOTcyloeg61CF+qdBkbZxWZJkSjh4AGlPXy+2tKwwoBPExxfCWXK61+Lo/q3/U1+lln8DSBCI2A==",
       "dependencies": {
-        "@polkadot/x-global": "12.0.1",
+        "@polkadot/x-global": "12.2.1",
         "tslib": "^2.5.0"
       },
       "engines": {
@@ -820,16 +810,16 @@
       }
     },
     "node_modules/@polkadot/x-bigint/node_modules/tslib": {
-      "version": "2.5.0",
-      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.5.0.tgz",
-      "integrity": "sha512-336iVw3rtn2BUK7ORdIAHTyxHGRIHVReokCR3XjbckJMK7ms8FysBfhLR8IXnAgy7T0PTPNBWKiH514FOW/WSg=="
+      "version": "2.5.2",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.5.2.tgz",
+      "integrity": "sha512-5svOrSA2w3iGFDs1HibEVBGbDrAY82bFQ3HZ3ixB+88nsbsWQoKqDRb5UBYAUPEzbBn6dAp5gRNXglySbx1MlA=="
     },
     "node_modules/@polkadot/x-fetch": {
-      "version": "12.0.1",
-      "resolved": "https://registry.npmjs.org/@polkadot/x-fetch/-/x-fetch-12.0.1.tgz",
-      "integrity": "sha512-JCCN1Q2mEenBXymLGC3f7F+L7Arp+36jPB7iGs6AZVmFBW8tX3uozVpETt4O4GMC56qZX5RHCPaemY4PVXcnlg==",
+      "version": "12.2.1",
+      "resolved": "https://registry.npmjs.org/@polkadot/x-fetch/-/x-fetch-12.2.1.tgz",
+      "integrity": "sha512-N2MIcn1g7LVZLZNDEkRkDD/LRY680PFqxziRoqb11SV52kRe6oVsdMIfaWH77UheniRR3br8YiQMUdvBVkak9Q==",
       "dependencies": {
-        "@polkadot/x-global": "12.0.1",
+        "@polkadot/x-global": "12.2.1",
         "node-fetch": "^3.3.1",
         "tslib": "^2.5.0"
       },
@@ -838,14 +828,14 @@
       }
     },
     "node_modules/@polkadot/x-fetch/node_modules/tslib": {
-      "version": "2.5.0",
-      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.5.0.tgz",
-      "integrity": "sha512-336iVw3rtn2BUK7ORdIAHTyxHGRIHVReokCR3XjbckJMK7ms8FysBfhLR8IXnAgy7T0PTPNBWKiH514FOW/WSg=="
+      "version": "2.5.2",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.5.2.tgz",
+      "integrity": "sha512-5svOrSA2w3iGFDs1HibEVBGbDrAY82bFQ3HZ3ixB+88nsbsWQoKqDRb5UBYAUPEzbBn6dAp5gRNXglySbx1MlA=="
     },
     "node_modules/@polkadot/x-global": {
-      "version": "12.0.1",
-      "resolved": "https://registry.npmjs.org/@polkadot/x-global/-/x-global-12.0.1.tgz",
-      "integrity": "sha512-kj/mMv7UPKIq5SnnnzICVOjhhYgUZzE8bT/az1D7z6OXV3SEH+4dmRsDEavwYinGMO7fi5fCvDayRu8r7ne2ZA==",
+      "version": "12.2.1",
+      "resolved": "https://registry.npmjs.org/@polkadot/x-global/-/x-global-12.2.1.tgz",
+      "integrity": "sha512-JNMziAZjvfzMrXASuBPCvSzEqlhsgw0x95SOBtqJWsxmbCMAiZbYAC51vI1B9Z9wiKuzPtSh9Sk7YHsUOGCrIQ==",
       "dependencies": {
         "tslib": "^2.5.0"
       },
@@ -854,37 +844,37 @@
       }
     },
     "node_modules/@polkadot/x-global/node_modules/tslib": {
-      "version": "2.5.0",
-      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.5.0.tgz",
-      "integrity": "sha512-336iVw3rtn2BUK7ORdIAHTyxHGRIHVReokCR3XjbckJMK7ms8FysBfhLR8IXnAgy7T0PTPNBWKiH514FOW/WSg=="
+      "version": "2.5.2",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.5.2.tgz",
+      "integrity": "sha512-5svOrSA2w3iGFDs1HibEVBGbDrAY82bFQ3HZ3ixB+88nsbsWQoKqDRb5UBYAUPEzbBn6dAp5gRNXglySbx1MlA=="
     },
     "node_modules/@polkadot/x-randomvalues": {
-      "version": "12.0.1",
-      "resolved": "https://registry.npmjs.org/@polkadot/x-randomvalues/-/x-randomvalues-12.0.1.tgz",
-      "integrity": "sha512-5ZMRbVJNhlKpwYgfcjVynH0jRwiXXn1k2I/xCjr+F6MwBTcIsbNXtgMczJB2PBAJpJvBV9GVpJoZW4Gq6nXdEg==",
+      "version": "12.2.1",
+      "resolved": "https://registry.npmjs.org/@polkadot/x-randomvalues/-/x-randomvalues-12.2.1.tgz",
+      "integrity": "sha512-NwSDLcLjgHa0C7Un54Yhg2/E3Y/PcVfW5QNB9TDyzDbkmod3ziaVhh0iWG0sOmm26K6Q3phY+0uYt0etq0Gu3w==",
       "dependencies": {
-        "@polkadot/x-global": "12.0.1",
+        "@polkadot/x-global": "12.2.1",
         "tslib": "^2.5.0"
       },
       "engines": {
         "node": ">=16"
       },
       "peerDependencies": {
-        "@polkadot/util": "12.0.1",
+        "@polkadot/util": "12.2.1",
         "@polkadot/wasm-util": "*"
       }
     },
     "node_modules/@polkadot/x-randomvalues/node_modules/tslib": {
-      "version": "2.5.0",
-      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.5.0.tgz",
-      "integrity": "sha512-336iVw3rtn2BUK7ORdIAHTyxHGRIHVReokCR3XjbckJMK7ms8FysBfhLR8IXnAgy7T0PTPNBWKiH514FOW/WSg=="
+      "version": "2.5.2",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.5.2.tgz",
+      "integrity": "sha512-5svOrSA2w3iGFDs1HibEVBGbDrAY82bFQ3HZ3ixB+88nsbsWQoKqDRb5UBYAUPEzbBn6dAp5gRNXglySbx1MlA=="
     },
     "node_modules/@polkadot/x-textdecoder": {
-      "version": "12.0.1",
-      "resolved": "https://registry.npmjs.org/@polkadot/x-textdecoder/-/x-textdecoder-12.0.1.tgz",
-      "integrity": "sha512-CJkJid9UVpJB5TmT4GdnMdm9SsINg5zElTcVMV4F/rS7+SnkIE9X/M91DgvGzq+d+qvU84UNjOgs/ZN3aOKbuA==",
+      "version": "12.2.1",
+      "resolved": "https://registry.npmjs.org/@polkadot/x-textdecoder/-/x-textdecoder-12.2.1.tgz",
+      "integrity": "sha512-5nQCIwyaGS0fXU2cbtMOSjFo0yTw1Z94m/UC+Gu5lm3ZU+kK4DpKFxhfLQORWAbvQkn12chRj3LI5Gm944hcrQ==",
       "dependencies": {
-        "@polkadot/x-global": "12.0.1",
+        "@polkadot/x-global": "12.2.1",
         "tslib": "^2.5.0"
       },
       "engines": {
@@ -892,16 +882,16 @@
       }
     },
     "node_modules/@polkadot/x-textdecoder/node_modules/tslib": {
-      "version": "2.5.0",
-      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.5.0.tgz",
-      "integrity": "sha512-336iVw3rtn2BUK7ORdIAHTyxHGRIHVReokCR3XjbckJMK7ms8FysBfhLR8IXnAgy7T0PTPNBWKiH514FOW/WSg=="
+      "version": "2.5.2",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.5.2.tgz",
+      "integrity": "sha512-5svOrSA2w3iGFDs1HibEVBGbDrAY82bFQ3HZ3ixB+88nsbsWQoKqDRb5UBYAUPEzbBn6dAp5gRNXglySbx1MlA=="
     },
     "node_modules/@polkadot/x-textencoder": {
-      "version": "12.0.1",
-      "resolved": "https://registry.npmjs.org/@polkadot/x-textencoder/-/x-textencoder-12.0.1.tgz",
-      "integrity": "sha512-nmS2tN36P4sc4WYiR9HHkgCBZcXksZF3dBsGTppWF6/ssgRmc2TZYoHBMUmdSq0OHg11kCKys94HXrWjPA/GCg==",
+      "version": "12.2.1",
+      "resolved": "https://registry.npmjs.org/@polkadot/x-textencoder/-/x-textencoder-12.2.1.tgz",
+      "integrity": "sha512-Ou6OXypRsJloK5a7Kn7re3ImqcL26h22fVw1cNv4fsTgkRFUdJDgPux2TpCZ3N+cyrfGVv42xKYFbdKMQCczjg==",
       "dependencies": {
-        "@polkadot/x-global": "12.0.1",
+        "@polkadot/x-global": "12.2.1",
         "tslib": "^2.5.0"
       },
       "engines": {
@@ -909,16 +899,16 @@
       }
     },
     "node_modules/@polkadot/x-textencoder/node_modules/tslib": {
-      "version": "2.5.0",
-      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.5.0.tgz",
-      "integrity": "sha512-336iVw3rtn2BUK7ORdIAHTyxHGRIHVReokCR3XjbckJMK7ms8FysBfhLR8IXnAgy7T0PTPNBWKiH514FOW/WSg=="
+      "version": "2.5.2",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.5.2.tgz",
+      "integrity": "sha512-5svOrSA2w3iGFDs1HibEVBGbDrAY82bFQ3HZ3ixB+88nsbsWQoKqDRb5UBYAUPEzbBn6dAp5gRNXglySbx1MlA=="
     },
     "node_modules/@polkadot/x-ws": {
-      "version": "12.0.1",
-      "resolved": "https://registry.npmjs.org/@polkadot/x-ws/-/x-ws-12.0.1.tgz",
-      "integrity": "sha512-hRFNlgBRz549hXJNKykEG4kKgEGHxLRHLyS/+qAOdBefiXWoB7it9D6JgcFqoJpOHyHw3Y8b/kSxwmx+Ub1rTA==",
+      "version": "12.2.1",
+      "resolved": "https://registry.npmjs.org/@polkadot/x-ws/-/x-ws-12.2.1.tgz",
+      "integrity": "sha512-jPfNR/QFwPmXCk9hGEAyCo50xBNHm3s+XavmpHEKQSulnLn5des5X/pKn+g8ttaO9nqrXYnUFO6VEmILgUa/IQ==",
       "dependencies": {
-        "@polkadot/x-global": "12.0.1",
+        "@polkadot/x-global": "12.2.1",
         "tslib": "^2.5.0",
         "ws": "^8.13.0"
       },
@@ -927,9 +917,9 @@
       }
     },
     "node_modules/@polkadot/x-ws/node_modules/tslib": {
-      "version": "2.5.0",
-      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.5.0.tgz",
-      "integrity": "sha512-336iVw3rtn2BUK7ORdIAHTyxHGRIHVReokCR3XjbckJMK7ms8FysBfhLR8IXnAgy7T0PTPNBWKiH514FOW/WSg=="
+      "version": "2.5.2",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.5.2.tgz",
+      "integrity": "sha512-5svOrSA2w3iGFDs1HibEVBGbDrAY82bFQ3HZ3ixB+88nsbsWQoKqDRb5UBYAUPEzbBn6dAp5gRNXglySbx1MlA=="
     },
     "node_modules/@scure/base": {
       "version": "1.1.1",
@@ -943,14 +933,14 @@
       ]
     },
     "node_modules/@substrate/connect": {
-      "version": "0.7.24",
-      "resolved": "https://registry.npmjs.org/@substrate/connect/-/connect-0.7.24.tgz",
-      "integrity": "sha512-vF82taiM0yME+ibiJgEv0xn/NZd9TQ4atXk1AQCe2z82SEKzw0Lwx9ZLFEOvlgnh+Nc2EtQi7y4cXJ+48rOqxw==",
+      "version": "0.7.26",
+      "resolved": "https://registry.npmjs.org/@substrate/connect/-/connect-0.7.26.tgz",
+      "integrity": "sha512-uuGSiroGuKWj1+38n1kY5HReer5iL9bRwPCzuoLtqAOmI1fGI0hsSI2LlNQMAbfRgr7VRHXOk5MTuQf5ulsFRw==",
       "optional": true,
       "dependencies": {
         "@substrate/connect-extension-protocol": "^1.0.1",
         "eventemitter3": "^4.0.7",
-        "smoldot": "1.0.2"
+        "smoldot": "1.0.4"
       }
     },
     "node_modules/@substrate/connect-extension-protocol": {
@@ -959,10 +949,16 @@
       "integrity": "sha512-161JhCC1csjH3GE5mPLEd7HbWtwNSPJBg3p1Ksz9SFlTzj/bgEwudiRN2y5i0MoLGCIJRYKyKGMxVnd29PzNjg==",
       "optional": true
     },
+    "node_modules/@substrate/connect/node_modules/eventemitter3": {
+      "version": "4.0.7",
+      "resolved": "https://registry.npmjs.org/eventemitter3/-/eventemitter3-4.0.7.tgz",
+      "integrity": "sha512-8guHBZCwKnFhYdHr2ysuRWErTwhoN2X8XELRlrRwpmfeY2jjuUN4taQMsULKUVo1K4DvZl+0pgfyoysHxvmvEw==",
+      "optional": true
+    },
     "node_modules/@substrate/ss58-registry": {
-      "version": "1.39.0",
-      "resolved": "https://registry.npmjs.org/@substrate/ss58-registry/-/ss58-registry-1.39.0.tgz",
-      "integrity": "sha512-qZYpuE6n+mwew+X71dOur/CbMXj6rNW27o63JeJwdQH/GvcSKm3JLNhd+bGzwUKg0D/zD30Qc6p4JykArzM+tA=="
+      "version": "1.40.0",
+      "resolved": "https://registry.npmjs.org/@substrate/ss58-registry/-/ss58-registry-1.40.0.tgz",
+      "integrity": "sha512-QuU2nBql3J4KCnOWtWDw4n1K4JU0T79j54ZZvm/9nhsX6AIar13FyhsaBfs6QkJ2ixTQAnd7TocJIoJRWbqMZA=="
     },
     "node_modules/@tsconfig/node10": {
       "version": "1.0.9",
@@ -993,9 +989,9 @@
       }
     },
     "node_modules/@types/json-schema": {
-      "version": "7.0.11",
-      "resolved": "https://registry.npmjs.org/@types/json-schema/-/json-schema-7.0.11.tgz",
-      "integrity": "sha512-wOuvG1SN4Us4rez+tylwwwCV1psiNVOkJeM3AUWUNWg/jDQY2+HE/444y5gc+jBmRqASOm2Oeh5c1axHobwRKQ==",
+      "version": "7.0.12",
+      "resolved": "https://registry.npmjs.org/@types/json-schema/-/json-schema-7.0.12.tgz",
+      "integrity": "sha512-Hr5Jfhc9eYOQNPYO5WLDq/n4jqijdHNlDXjuAQkkt+mWdQR+XJToOHrsD4cPaMXpn6KO7y2+wM8AZEs8VpBLVA==",
       "dev": true
     },
     "node_modules/@types/json5": {
@@ -1014,21 +1010,21 @@
       "license": "MIT"
     },
     "node_modules/@types/semver": {
-      "version": "7.3.13",
-      "resolved": "https://registry.npmjs.org/@types/semver/-/semver-7.3.13.tgz",
-      "integrity": "sha512-21cFJr9z3g5dW8B0CVI9g2O9beqaThGQ6ZFBqHfwhzLDKUxaqTIy3vnfah/UPkfOiF2pLq+tGz+W8RyCskuslw==",
+      "version": "7.5.0",
+      "resolved": "https://registry.npmjs.org/@types/semver/-/semver-7.5.0.tgz",
+      "integrity": "sha512-G8hZ6XJiHnuhQKR7ZmysCeJWE08o8T0AXtk5darsCaTVsYZhhgUrq53jizaR2FvsoeCwJhlmwTjkXBY5Pn/ZHw==",
       "dev": true
     },
     "node_modules/@typescript-eslint/eslint-plugin": {
-      "version": "5.59.1",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-5.59.1.tgz",
-      "integrity": "sha512-AVi0uazY5quFB9hlp2Xv+ogpfpk77xzsgsIEWyVS7uK/c7MZ5tw7ZPbapa0SbfkqE0fsAMkz5UwtgMLVk2BQAg==",
+      "version": "5.59.8",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-5.59.8.tgz",
+      "integrity": "sha512-JDMOmhXteJ4WVKOiHXGCoB96ADWg9q7efPWHRViT/f09bA8XOMLAVHHju3l0MkZnG1izaWXYmgvQcUjTRcpShQ==",
       "dev": true,
       "dependencies": {
         "@eslint-community/regexpp": "^4.4.0",
-        "@typescript-eslint/scope-manager": "5.59.1",
-        "@typescript-eslint/type-utils": "5.59.1",
-        "@typescript-eslint/utils": "5.59.1",
+        "@typescript-eslint/scope-manager": "5.59.8",
+        "@typescript-eslint/type-utils": "5.59.8",
+        "@typescript-eslint/utils": "5.59.8",
         "debug": "^4.3.4",
         "grapheme-splitter": "^1.0.4",
         "ignore": "^5.2.0",
@@ -1054,14 +1050,14 @@
       }
     },
     "node_modules/@typescript-eslint/parser": {
-      "version": "5.59.1",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-5.59.1.tgz",
-      "integrity": "sha512-nzjFAN8WEu6yPRDizIFyzAfgK7nybPodMNFGNH0M9tei2gYnYszRDqVA0xlnRjkl7Hkx2vYrEdb6fP2a21cG1g==",
+      "version": "5.59.8",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-5.59.8.tgz",
+      "integrity": "sha512-AnR19RjJcpjoeGojmwZtCwBX/RidqDZtzcbG3xHrmz0aHHoOcbWnpDllenRDmDvsV0RQ6+tbb09/kyc+UT9Orw==",
       "dev": true,
       "dependencies": {
-        "@typescript-eslint/scope-manager": "5.59.1",
-        "@typescript-eslint/types": "5.59.1",
-        "@typescript-eslint/typescript-estree": "5.59.1",
+        "@typescript-eslint/scope-manager": "5.59.8",
+        "@typescript-eslint/types": "5.59.8",
+        "@typescript-eslint/typescript-estree": "5.59.8",
         "debug": "^4.3.4"
       },
       "engines": {
@@ -1081,13 +1077,13 @@
       }
     },
     "node_modules/@typescript-eslint/scope-manager": {
-      "version": "5.59.1",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-5.59.1.tgz",
-      "integrity": "sha512-mau0waO5frJctPuAzcxiNWqJR5Z8V0190FTSqRw1Q4Euop6+zTwHAf8YIXNwDOT29tyUDrQ65jSg9aTU/H0omA==",
+      "version": "5.59.8",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-5.59.8.tgz",
+      "integrity": "sha512-/w08ndCYI8gxGf+9zKf1vtx/16y8MHrZs5/tnjHhMLNSixuNcJavSX4wAiPf4aS5x41Es9YPCn44MIe4cxIlig==",
       "dev": true,
       "dependencies": {
-        "@typescript-eslint/types": "5.59.1",
-        "@typescript-eslint/visitor-keys": "5.59.1"
+        "@typescript-eslint/types": "5.59.8",
+        "@typescript-eslint/visitor-keys": "5.59.8"
       },
       "engines": {
         "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
@@ -1098,13 +1094,13 @@
       }
     },
     "node_modules/@typescript-eslint/type-utils": {
-      "version": "5.59.1",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/type-utils/-/type-utils-5.59.1.tgz",
-      "integrity": "sha512-ZMWQ+Oh82jWqWzvM3xU+9y5U7MEMVv6GLioM3R5NJk6uvP47kZ7YvlgSHJ7ERD6bOY7Q4uxWm25c76HKEwIjZw==",
+      "version": "5.59.8",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/type-utils/-/type-utils-5.59.8.tgz",
+      "integrity": "sha512-+5M518uEIHFBy3FnyqZUF3BMP+AXnYn4oyH8RF012+e7/msMY98FhGL5SrN29NQ9xDgvqCgYnsOiKp1VjZ/fpA==",
       "dev": true,
       "dependencies": {
-        "@typescript-eslint/typescript-estree": "5.59.1",
-        "@typescript-eslint/utils": "5.59.1",
+        "@typescript-eslint/typescript-estree": "5.59.8",
+        "@typescript-eslint/utils": "5.59.8",
         "debug": "^4.3.4",
         "tsutils": "^3.21.0"
       },
@@ -1125,9 +1121,9 @@
       }
     },
     "node_modules/@typescript-eslint/types": {
-      "version": "5.59.1",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-5.59.1.tgz",
-      "integrity": "sha512-dg0ICB+RZwHlysIy/Dh1SP+gnXNzwd/KS0JprD3Lmgmdq+dJAJnUPe1gNG34p0U19HvRlGX733d/KqscrGC1Pg==",
+      "version": "5.59.8",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-5.59.8.tgz",
+      "integrity": "sha512-+uWuOhBTj/L6awoWIg0BlWy0u9TyFpCHrAuQ5bNfxDaZ1Ppb3mx6tUigc74LHcbHpOHuOTOJrBoAnhdHdaea1w==",
       "dev": true,
       "engines": {
         "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
@@ -1138,13 +1134,13 @@
       }
     },
     "node_modules/@typescript-eslint/typescript-estree": {
-      "version": "5.59.1",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-5.59.1.tgz",
-      "integrity": "sha512-lYLBBOCsFltFy7XVqzX0Ju+Lh3WPIAWxYpmH/Q7ZoqzbscLiCW00LeYCdsUnnfnj29/s1WovXKh2gwCoinHNGA==",
+      "version": "5.59.8",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-5.59.8.tgz",
+      "integrity": "sha512-Jy/lPSDJGNow14vYu6IrW790p7HIf/SOV1Bb6lZ7NUkLc2iB2Z9elESmsaUtLw8kVqogSbtLH9tut5GCX1RLDg==",
       "dev": true,
       "dependencies": {
-        "@typescript-eslint/types": "5.59.1",
-        "@typescript-eslint/visitor-keys": "5.59.1",
+        "@typescript-eslint/types": "5.59.8",
+        "@typescript-eslint/visitor-keys": "5.59.8",
         "debug": "^4.3.4",
         "globby": "^11.1.0",
         "is-glob": "^4.0.3",
@@ -1165,17 +1161,17 @@
       }
     },
     "node_modules/@typescript-eslint/utils": {
-      "version": "5.59.1",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/utils/-/utils-5.59.1.tgz",
-      "integrity": "sha512-MkTe7FE+K1/GxZkP5gRj3rCztg45bEhsd8HYjczBuYm+qFHP5vtZmjx3B0yUCDotceQ4sHgTyz60Ycl225njmA==",
+      "version": "5.59.8",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/utils/-/utils-5.59.8.tgz",
+      "integrity": "sha512-Tr65630KysnNn9f9G7ROF3w1b5/7f6QVCJ+WK9nhIocWmx9F+TmCAcglF26Vm7z8KCTwoKcNEBZrhlklla3CKg==",
       "dev": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.2.0",
         "@types/json-schema": "^7.0.9",
         "@types/semver": "^7.3.12",
-        "@typescript-eslint/scope-manager": "5.59.1",
-        "@typescript-eslint/types": "5.59.1",
-        "@typescript-eslint/typescript-estree": "5.59.1",
+        "@typescript-eslint/scope-manager": "5.59.8",
+        "@typescript-eslint/types": "5.59.8",
+        "@typescript-eslint/typescript-estree": "5.59.8",
         "eslint-scope": "^5.1.1",
         "semver": "^7.3.7"
       },
@@ -1191,12 +1187,12 @@
       }
     },
     "node_modules/@typescript-eslint/visitor-keys": {
-      "version": "5.59.1",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-5.59.1.tgz",
-      "integrity": "sha512-6waEYwBTCWryx0VJmP7JaM4FpipLsFl9CvYf2foAE8Qh/Y0s+bxWysciwOs0LTBED4JCaNxTZ5rGadB14M6dwA==",
+      "version": "5.59.8",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-5.59.8.tgz",
+      "integrity": "sha512-pJhi2ms0x0xgloT7xYabil3SGGlojNNKjK/q6dB3Ey0uJLMjK2UDGJvHieiyJVW/7C3KI+Z4Q3pEHkm4ejA+xQ==",
       "dev": true,
       "dependencies": {
-        "@typescript-eslint/types": "5.59.1",
+        "@typescript-eslint/types": "5.59.8",
         "eslint-visitor-keys": "^3.3.0"
       },
       "engines": {
@@ -1772,15 +1768,15 @@
       }
     },
     "node_modules/eslint": {
-      "version": "8.39.0",
-      "resolved": "https://registry.npmjs.org/eslint/-/eslint-8.39.0.tgz",
-      "integrity": "sha512-mwiok6cy7KTW7rBpo05k6+p4YVZByLNjAZ/ACB9DRCu4YDRwjXI01tWHp6KAUWelsBetTxKK/2sHB0vdS8Z2Og==",
+      "version": "8.41.0",
+      "resolved": "https://registry.npmjs.org/eslint/-/eslint-8.41.0.tgz",
+      "integrity": "sha512-WQDQpzGBOP5IrXPo4Hc0814r4/v2rrIsB0rhT7jtunIalgg6gYXWhRMOejVO8yH21T/FGaxjmFjBMNqcIlmH1Q==",
       "dev": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.2.0",
         "@eslint-community/regexpp": "^4.4.0",
-        "@eslint/eslintrc": "^2.0.2",
-        "@eslint/js": "8.39.0",
+        "@eslint/eslintrc": "^2.0.3",
+        "@eslint/js": "8.41.0",
         "@humanwhocodes/config-array": "^0.11.8",
         "@humanwhocodes/module-importer": "^1.0.1",
         "@nodelib/fs.walk": "^1.2.8",
@@ -1791,8 +1787,8 @@
         "doctrine": "^3.0.0",
         "escape-string-regexp": "^4.0.0",
         "eslint-scope": "^7.2.0",
-        "eslint-visitor-keys": "^3.4.0",
-        "espree": "^9.5.1",
+        "eslint-visitor-keys": "^3.4.1",
+        "espree": "^9.5.2",
         "esquery": "^1.4.2",
         "esutils": "^2.0.2",
         "fast-deep-equal": "^3.1.3",
@@ -1800,13 +1796,12 @@
         "find-up": "^5.0.0",
         "glob-parent": "^6.0.2",
         "globals": "^13.19.0",
-        "grapheme-splitter": "^1.0.4",
+        "graphemer": "^1.4.0",
         "ignore": "^5.2.0",
         "import-fresh": "^3.0.0",
         "imurmurhash": "^0.1.4",
         "is-glob": "^4.0.0",
         "is-path-inside": "^3.0.3",
-        "js-sdsl": "^4.1.4",
         "js-yaml": "^4.1.0",
         "json-stable-stringify-without-jsonify": "^1.0.1",
         "levn": "^0.4.1",
@@ -2008,9 +2003,9 @@
       }
     },
     "node_modules/eslint-visitor-keys": {
-      "version": "3.4.0",
-      "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-3.4.0.tgz",
-      "integrity": "sha512-HPpKPUBQcAsZOsHAFwTtIKcYlCje62XB7SEAcxjtmW6TD1WVpkS6i6/hOVtTZIl4zGj/mBqpFVGvaDneik+VoQ==",
+      "version": "3.4.1",
+      "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-3.4.1.tgz",
+      "integrity": "sha512-pZnmmLwYzf+kWaM/Qgrvpen51upAktaaiI01nsJD/Yr3lMOdNtq0cxkrrg16w64VtisN6okbs7Q8AfGqj4c9fA==",
       "dev": true,
       "engines": {
         "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
@@ -2067,14 +2062,14 @@
       }
     },
     "node_modules/espree": {
-      "version": "9.5.1",
-      "resolved": "https://registry.npmjs.org/espree/-/espree-9.5.1.tgz",
-      "integrity": "sha512-5yxtHSZXRSW5pvv3hAlXM5+/Oswi1AUFqBmbibKb5s6bp3rGIDkyXU6xCoyuuLhijr4SFwPrXRoZjz0AZDN9tg==",
+      "version": "9.5.2",
+      "resolved": "https://registry.npmjs.org/espree/-/espree-9.5.2.tgz",
+      "integrity": "sha512-7OASN1Wma5fum5SrNhFMAMJxOUAbhyfQ8dQ//PJaJbNw0URTPWqIghHWt1MmAANKhHZIYOHruW4Kw4ruUWOdGw==",
       "dev": true,
       "dependencies": {
         "acorn": "^8.8.0",
         "acorn-jsx": "^5.3.2",
-        "eslint-visitor-keys": "^3.4.0"
+        "eslint-visitor-keys": "^3.4.1"
       },
       "engines": {
         "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
@@ -2143,10 +2138,9 @@
       }
     },
     "node_modules/eventemitter3": {
-      "version": "4.0.7",
-      "resolved": "https://registry.npmjs.org/eventemitter3/-/eventemitter3-4.0.7.tgz",
-      "integrity": "sha512-8guHBZCwKnFhYdHr2ysuRWErTwhoN2X8XELRlrRwpmfeY2jjuUN4taQMsULKUVo1K4DvZl+0pgfyoysHxvmvEw==",
-      "optional": true
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/eventemitter3/-/eventemitter3-5.0.1.tgz",
+      "integrity": "sha512-GWkBvjiSZK87ELrYOSESUYeVIc9mvLLf/nXalMOS5dYrgZq9o5OVkbZAVM06CVxYsCwH9BDZFPlQTlPA1j4ahA=="
     },
     "node_modules/fast-deep-equal": {
       "version": "3.1.3",
@@ -2494,6 +2488,12 @@
       "version": "1.0.4",
       "resolved": "https://registry.npmjs.org/grapheme-splitter/-/grapheme-splitter-1.0.4.tgz",
       "integrity": "sha512-bzh50DW9kTPM00T8y4o8vQg89Di9oLJVLW/KaOGIXJWP/iqCN6WKYkbNOF04vFLJhwcpYUh9ydh/+5vpOqV4YQ==",
+      "dev": true
+    },
+    "node_modules/graphemer": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/graphemer/-/graphemer-1.4.0.tgz",
+      "integrity": "sha512-EtKwoO6kxCL9WO5xipiHTZlSzBm7WLT627TqC/uVRd0HKmq8NXyebnNYxDoBi7wt8eTWrUrKXCOVaFq9x1kgag==",
       "dev": true
     },
     "node_modules/handlebars": {
@@ -2941,12 +2941,6 @@
       "dev": true,
       "license": "ISC"
     },
-    "node_modules/js-sdsl": {
-      "version": "4.1.5",
-      "resolved": "https://registry.npmjs.org/js-sdsl/-/js-sdsl-4.1.5.tgz",
-      "integrity": "sha512-08bOAKweV2NUC1wqTtf3qZlnpOX/R2DU9ikpjOHs0H+ibQv3zpncVQg6um4uYtRtrwIX8M4Nh3ytK4HGlYAq7Q==",
-      "dev": true
-    },
     "node_modules/js-yaml": {
       "version": "4.1.0",
       "dev": true,
@@ -3198,9 +3192,9 @@
       "license": "MIT"
     },
     "node_modules/nock": {
-      "version": "13.3.0",
-      "resolved": "https://registry.npmjs.org/nock/-/nock-13.3.0.tgz",
-      "integrity": "sha512-HHqYQ6mBeiMc+N038w8LkMpDCRquCHWeNmN3v6645P3NhN2+qXOBqvPqo7Rt1VyCMzKhJ733wZqw5B7cQVFNPg==",
+      "version": "13.3.1",
+      "resolved": "https://registry.npmjs.org/nock/-/nock-13.3.1.tgz",
+      "integrity": "sha512-vHnopocZuI93p2ccivFyGuUfzjq2fxNyNurp7816mlT5V5HF4SzXu8lvLrVzBbNqzs+ODooZ6OksuSUNM7Njkw==",
       "dependencies": {
         "debug": "^4.1.0",
         "json-stringify-safe": "^5.0.1",
@@ -3615,17 +3609,17 @@
       }
     },
     "node_modules/rxjs": {
-      "version": "7.8.0",
-      "resolved": "https://registry.npmjs.org/rxjs/-/rxjs-7.8.0.tgz",
-      "integrity": "sha512-F2+gxDshqmIub1KdvZkaEfGDwLNpPvk9Fs6LD/MyQxNgMds/WH9OdDDXOmxUZpME+iSK3rQCctkL0DYyytUqMg==",
+      "version": "7.8.1",
+      "resolved": "https://registry.npmjs.org/rxjs/-/rxjs-7.8.1.tgz",
+      "integrity": "sha512-AA3TVj+0A2iuIoQkWEK/tqFjBq2j+6PO6Y0zJcvzLAFhEFIO3HL0vls9hWLncZbAAbK0mar7oZ4V079I/qPMxg==",
       "dependencies": {
         "tslib": "^2.1.0"
       }
     },
     "node_modules/rxjs/node_modules/tslib": {
-      "version": "2.5.0",
-      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.5.0.tgz",
-      "integrity": "sha512-336iVw3rtn2BUK7ORdIAHTyxHGRIHVReokCR3XjbckJMK7ms8FysBfhLR8IXnAgy7T0PTPNBWKiH514FOW/WSg=="
+      "version": "2.5.2",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.5.2.tgz",
+      "integrity": "sha512-5svOrSA2w3iGFDs1HibEVBGbDrAY82bFQ3HZ3ixB+88nsbsWQoKqDRb5UBYAUPEzbBn6dAp5gRNXglySbx1MlA=="
     },
     "node_modules/safe-buffer": {
       "version": "5.1.2",
@@ -3713,9 +3707,9 @@
       }
     },
     "node_modules/smoldot": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/smoldot/-/smoldot-1.0.2.tgz",
-      "integrity": "sha512-IHhMzvXwyl6I5GA4JvfzM2OOp9wBO06AmjqT4nCoNms5PiLe74f/A+jIZIJKyY6eBhMpmECizyfeTneHO2wMFQ==",
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/smoldot/-/smoldot-1.0.4.tgz",
+      "integrity": "sha512-N3TazI1C4GGrseFH/piWyZCCCRJTRx2QhDfrUKRT4SzILlW5m8ayZ3QTKICcz1C/536T9cbHHJyP7afxI6Mi1A==",
       "optional": true,
       "dependencies": {
         "pako": "^2.0.4",
@@ -3979,16 +3973,16 @@
       }
     },
     "node_modules/typescript": {
-      "version": "5.0.4",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.0.4.tgz",
-      "integrity": "sha512-cW9T5W9xY37cc+jfEnaUvX91foxtHkza3Nw3wkoF4sSlKn0MONdkdEndig/qPBWXNkmplh3NzayQzCiHM4/hqw==",
+      "version": "5.1.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.1.3.tgz",
+      "integrity": "sha512-XH627E9vkeqhlZFQuL+UsyAXEnibT0kWR2FWONlr4sTjvxyJYnyefgrkyECLzM5NenmKzRAy2rR/OlYLA1HkZw==",
       "dev": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
       },
       "engines": {
-        "node": ">=12.20"
+        "node": ">=14.17"
       }
     },
     "node_modules/uglify-js": {

--- a/js/api-augment/package.json
+++ b/js/api-augment/package.json
@@ -33,16 +33,16 @@
   "author": "LibertyDSNP",
   "license": "Apache-2.0",
   "dependencies": {
-    "@polkadot/api": "10.4.1",
-    "@polkadot/rpc-provider": "10.4.1",
-    "@polkadot/types": "10.4.1"
+    "@polkadot/api": "^10.7.3",
+    "@polkadot/rpc-provider": "^10.7.3",
+    "@polkadot/types": "^10.7.3"
   },
   "devDependencies": {
-    "@polkadot/typegen": "10.4.1",
+    "@polkadot/typegen": "^10.7.3",
     "@types/mocha": "^10.0.1",
-    "@typescript-eslint/eslint-plugin": "^5.59.1",
-    "@typescript-eslint/parser": "^5.59.1",
-    "eslint": "^8.39.0",
+    "@typescript-eslint/eslint-plugin": "^5.59.8",
+    "@typescript-eslint/parser": "^5.59.8",
+    "eslint": "^8.41.0",
     "eslint-config-prettier": "^8.8.0",
     "eslint-plugin-import": "^2.27.5",
     "eslint-plugin-mocha": "^10.1.0",
@@ -50,6 +50,6 @@
     "mocha": "10.2.0",
     "prettier": "2.8.8",
     "ts-node": "^10.9.1",
-    "typescript": "^5.0.4"
+    "typescript": "^5.1.3"
   }
 }

--- a/js/api-augment/tsconfig.json
+++ b/js/api-augment/tsconfig.json
@@ -13,7 +13,6 @@
         "strict": true,
         "skipLibCheck": true,
         "target": "es2022",
-        "watch": false,
         "typeRoots": [
             "node_modules/@types"
         ],


### PR DESCRIPTION
# Goal
The goal of this PR is to update everything to the latest `@polkadotjs/api` package.

Closes #1461 

# Discussion
- All the issues with the initial `@polkadotjs/api` 10.0.0 release have been corrected
- Removed unused tsconfig`watch` option which was unused and causing issues with the esm version of ts-node.

# Checklist
- [x] Integration tests run locally
- [x] `make js` and then used it in another npm project that uses latest `@polkadotjs/api` without errors, warnings, or issues.