### PR TITLE
Bug Fix Enum ParquetBaseType should be FIXED_LEN_BYTE_ARRAY

### DIFF
--- a/common/primitives/src/parquet/base.rs
+++ b/common/primitives/src/parquet/base.rs
@@ -18,5 +18,5 @@ pub enum ParquetBaseType {
 	/// Encapsulates arrays
 	ByteArray,
 	/// Encapsulates fixed length arrays
-	FixedLengthByteArray,
+	FixedLenByteArray,
 }


### PR DESCRIPTION
Per: https://github.com/apache/parquet-format/blob/c766945d90935ebcd4e03fee13aad2b6efcadce3/Encodings.md?plain=1#L41
