### PR TITLE
fix Rustup not found error

### DIFF
--- a/.github/workflows/verify-pr-commit.yml
+++ b/.github/workflows/verify-pr-commit.yml
@@ -213,7 +213,6 @@ jobs:
         # When the toolchain is updated to ^nightly-2023-06-01, this can be removed
       - name: Install Rust Nightly-2023-06-01 and Build Docs
         run: |
-          export HOME="/root"
           rustup install nightly-2023-06-01
           rustup target add wasm32-unknown-unknown --toolchain nightly-2023-06-01
           RUSTDOCFLAGS="--enable-index-page --check -Zunstable-options" cargo +nightly-2023-06-01 doc --no-deps --features frequency

--- a/tools/ci/docker/ci-base-image.dockerfile
+++ b/tools/ci/docker/ci-base-image.dockerfile
@@ -13,5 +13,7 @@ RUN apt-get update && \
 # Install Rust
 RUN curl https://sh.rustup.rs -sSf | bash -s -- -y
 ENV PATH="/home/runner/.cargo/bin:/root/.cargo/bin:${PATH}"
+ENV RUSTUP_HOME="/root/.cargo"
+ENV CARGO_HOME="/root/.cargo"
 
 RUN git config --system --add safe.directory /__w/frequency/frequency


### PR DESCRIPTION
# Goal
The goal of this PR is to fix `rustup` not found error in verify Rust developer docs CI job.

Part of #1118