### PR TITLE
Add file permissions for generated docs

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -355,6 +355,13 @@ jobs:
           rustup install nightly-2023-06-01
           rustup target add wasm32-unknown-unknown --toolchain nightly-2023-06-01
           RUSTDOCFLAGS="--enable-index-page --check -Zunstable-options" cargo +nightly-2023-06-01 doc --no-deps --features frequency
+      - name: Fix file permissions
+        shell: sh
+        run: |
+          chmod -c -R +rX "target/doc" |
+          while read line; do
+              echo "::warning title=Invalid file permissions automatically fixed::$line"
+          done
       - name: Upload Docs
         uses: actions/upload-pages-artifact@v1
         with:


### PR DESCRIPTION
# Goal
The goal of this PR is to fix file permissions that might be causing the issue with rust docs

