### PR TITLE
fix: disconnect additional ApiPromise connection after tests run

### DIFF
--- a/integration-tests/scaffolding/rootHooks.ts
+++ b/integration-tests/scaffolding/rootHooks.ts
@@ -34,5 +34,6 @@ exports.mochaHooks = {
     },
     async afterAll() {
         await ExtrinsicHelper.api.disconnect();
+        await ExtrinsicHelper.apiPromise.disconnect();
     }
 }


### PR DESCRIPTION
# Goal
The goal of this PR is to make sure all Frequency node connections get closed after integration tests run.

Closes #1620 

# Checklist
- [ ] Chain spec updated
- [ ] Custom RPC OR Runtime API added/changed? Updated js/api-augment.
- [ ] Design doc(s) updated
- [ ] Tests added
- [ ] Benchmarks added
- [ ] Weights updated
