### PR TITLE
Fix failing staking end to end tests for relay chain execution

### DIFF
--- a/integration-tests/.relay-chain.mocharc.json
+++ b/integration-tests/.relay-chain.mocharc.json
@@ -12,5 +12,5 @@
     "spec": [
         "./{,!(node_modules|load-tests)/**}/{createMsa,addIPFSMessage,staking,transactions}.test.ts"
     ],
-    "timeout": 200000
+    "timeout": 250000
 }


### PR DESCRIPTION
# Goal
The goal of this PR is to fix failing end to end tests against Rococo

# Discussion
- Tracking frozen balance in `staking.test.ts`
- Increased the relay chain timeout; they were being exceeded in the test runners
