### PR TITLE
fix: specify workspace resolver for edition=2021

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,6 +7,7 @@ members = [
   "runtime/*",
   "common/helpers",
 ]
+resolver = "2"
 
 [profile.release]
 panic = "unwind"


### PR DESCRIPTION
# Goal
The goal of this PR is to fix warnings about the workspace.resolver.

  
# Discussion
Specify the workspace.resolver in root/Cargo.toml to eliminate ambiguity with crate dependencies.

# Checklist
- [ ] Chain spec updated
- [ ] Custom RPC OR Runtime API added/changed? Updated js/api-augment.
- [ ] Design doc(s) updated
- [ ] Tests added
- [ ] Benchmarks added
- [ ] Weights updated
