### PR TITLE
Support German letter ß in handles

### DIFF
--- a/pallets/handles/src/handles-utils/constants.rs
+++ b/pallets/handles/src/handles-utils/constants.rs
@@ -3,7 +3,7 @@
 use core::ops::RangeInclusive;
 
 /// Character that are allowed.
-pub const ALLOWED_UNICODE_CHARACTER_RANGES: [RangeInclusive<u16>; 20] = [
+pub const ALLOWED_UNICODE_CHARACTER_RANGES: [RangeInclusive<u16>; 21] = [
 	0x0020..=0x007F, // Basic Latin
 	0x0080..=0x00FF, // Latin-1 Supplement
 	0x0100..=0x017F, // Latin Extended-A
@@ -16,6 +16,7 @@ pub const ALLOWED_UNICODE_CHARACTER_RANGES: [RangeInclusive<u16>; 20] = [
 	0x0980..=0x09FF, // Bengali
 	0x0E00..=0x0E7F, // Thai
 	0x1100..=0x11FF, // Hangul Jamo
+	0x1E00..=0x1EFF, // Latin Extended Additional
 	0x1F00..=0x1FFF, // Greek Extended
 	0x3040..=0x309F, // Hiragana
 	0x30A0..=0x30FF, // Katakana

--- a/pallets/handles/src/handles-utils/src/tests/validator_tests.rs
+++ b/pallets/handles/src/handles-utils/src/tests/validator_tests.rs
@@ -41,23 +41,30 @@ fn test_contains_blocked_characters_negative() {
 #[test]
 fn test_consists_of_supported_unicode_character_sets_happy_path() {
 	let strings_containing_characters_in_supported_unicode_character_sets = Vec::from([
-		"John",                  // Basic Latin
-		"Álvaro",               // Latin-1 Supplement
-		"가영",                // Hangul Syllables
-		"가나다",             // Hangul Syllables
-		"アキラ",             // Katakana
-		"あいこ",             // Hiragana
-		"李明",                // CJK Unified Ideographs
-		"严勇",                // CJK Unified Ideographs
-		"龍",                   // CJK Unified Ideographs
-		"অমিত",          // Bengali
-		"आरव",             // Devanagari
-		"Александр",    // Cyrillic
-		"Αλέξανδρος",  // Greek and Coptic
-		"Ἀναξαγόρας", // Greek Extended
-		"กัญญา",       // Thai
-		"عمر",                // Arabic
-		"דָּנִיֵּאל",  // Hewbrew
+		"John",                                                             // Basic Latin
+		"Álvaro",                                                          // Latin-1 Supplement
+		"가영",                                                           // Hangul Syllables
+		"가나다",                                                        // Hangul Syllables
+		"アキラ",                                                        // Katakana
+		"あいこ",                                                        // Hiragana
+		"李明",                                                           // CJK Unified Ideographs
+		"严勇",                                                           // CJK Unified Ideographs
+		"龍",                                                              // CJK Unified Ideographs
+		"অমিত",                                                     // Bengali
+		"आरव",                                                        // Devanagari
+		"Александр",                                               // Cyrillic
+		"Αλέξανδρος",                                             // Greek and Coptic
+		"Ἀναξαγόρας",                                            // Greek Extended
+		"กัญญา",                                                  // Thai
+		"ابجدهوزحطيكلمنسعفصقرشتثخذضظغءعمر", // Arabic
+		"דָּנִיֵּאלאבּבגּגדּדהווּוֹזחטי ִיכּךּכךלמםנןסעפּףּפףצץקרשׁשׂתּת", // Hewbrew
+		"AaĄąBbCcĆćDdEeĘęFfGgHhIiJjKkLlŁłMmNnŃńOoÓóRrSsŚśYyZzŹźŻż", // Polish
+		"ÄäÖöÜüẞß",                                                // German
+		"AÁBCČDĎEÉĚFGHChIÍJKLMNŇOÓPQRŘSŠTŤUÚŮVWXYÝZŽaábcčdďeéěfghchiíjklmnňoópqrřsštťuúůvwxyýzž", // Czech
+		"αιαιαιᾳειειηιῃοιοιυιυιωιῳαυαυᾹυᾱυευευηυηυουουωυωυγγγγγκγκγξγξγχγχμπμπντντΖζΤΖτζ", // Greek
+		"ÅåÄäÖö",                                                     // Swedish
+		"ÅåÄäÖöŠšŽž",                                             // Finnish
+		"ÆæØøÅå",                                                     // Danish
 	]);
 
 	for string in strings_containing_characters_in_supported_unicode_character_sets {


### PR DESCRIPTION
# Goal
The goal of this PR is to add support in handles for the German letter `ß`

Closes #1646

# Discussion
- Adds 4 lines to the confusables.rs

# Checklist
- [x] Tests added
