### PR TITLE
Enable Warp Sync

### DIFF
--- a/node/cli/src/cli.rs
+++ b/node/cli/src/cli.rs
@@ -1,4 +1,7 @@
 //! Frequency CLI library.
+
+// File originally from https://github.com/paritytech/cumulus/blob/master/parachain-template/node/src/cli.rs
+
 use crate::{ExportMetadataCmd, ExportRuntimeVersionCmd};
 use std::path::PathBuf;
 

--- a/node/cli/src/command.rs
+++ b/node/cli/src/command.rs
@@ -1,3 +1,5 @@
+// File originally from https://github.com/paritytech/cumulus/blob/master/parachain-template/node/src/command.rs
+
 use crate::{
 	benchmarking::{inherent_benchmark_data, RemarkBuilder},
 	cli::{Cli, RelayChainCli, Subcommand},

--- a/node/service/src/service.rs
+++ b/node/service/src/service.rs
@@ -1,6 +1,8 @@
 #![allow(unused_imports)]
 //! Service and ServiceFactory implementation. Specialized wrapper over substrate service.
 
+// Originally from https://github.com/paritytech/cumulus/blob/master/parachain-template/node/src/service.rs
+
 // std
 use std::{sync::Arc, time::Duration};
 
@@ -18,14 +20,15 @@ use cumulus_client_consensus_common::{
 };
 use cumulus_client_network::BlockAnnounceValidator;
 use cumulus_client_service::{
-	build_relay_chain_interface, prepare_node_config, start_collator, start_full_node,
-	StartCollatorParams, StartFullNodeParams,
+	build_network, build_relay_chain_interface, prepare_node_config, start_collator,
+	start_full_node, BuildNetworkParams, StartCollatorParams, StartFullNodeParams,
 };
 use cumulus_primitives_core::ParaId;
 use cumulus_primitives_parachain_inherent::MockValidationDataInherentDataProvider;
 use cumulus_relay_chain_interface::{RelayChainError, RelayChainInterface};
 
 // Substrate Imports
+use frame_benchmarking_cli::SUBSTRATE_REFERENCE_HARDWARE;
 use sc_consensus::{ImportQueue, LongestChain};
 use sc_executor::NativeElseWasmExecutor;
 use sc_network::{NetworkBlock, NetworkService};
@@ -196,7 +199,7 @@ async fn start_node_impl(
 	parachain_config: Configuration,
 	polkadot_config: Configuration,
 	collator_options: CollatorOptions,
-	id: ParaId,
+	para_id: ParaId,
 	hwbench: Option<sc_sysinfo::HwBench>,
 ) -> sc_service::error::Result<(TaskManager, Arc<ParachainClient>)> {
 	let parachain_config = prepare_node_config(parachain_config);
@@ -219,28 +222,27 @@ async fn start_node_impl(
 	.await
 	.map_err(|e| sc_service::Error::Application(Box::new(e) as Box<_>))?;
 
-	let block_announce_validator = BlockAnnounceValidator::new(relay_chain_interface.clone(), id);
-
 	let force_authoring = parachain_config.force_authoring;
 	let validator = parachain_config.role.is_authority();
 	let prometheus_registry = parachain_config.prometheus_registry().cloned();
 	let transaction_pool = params.transaction_pool.clone();
 	let import_queue_service = params.import_queue.service();
+
 	let net_config: sc_network::config::FullNetworkConfiguration =
 		sc_network::config::FullNetworkConfiguration::new(&parachain_config.network);
+
 	let (network, system_rpc_tx, tx_handler_controller, start_network, sync_service) =
-		sc_service::build_network(sc_service::BuildNetworkParams {
-			config: &parachain_config,
+		build_network(BuildNetworkParams {
+			parachain_config: &parachain_config,
 			net_config,
 			client: client.clone(),
 			transaction_pool: transaction_pool.clone(),
+			para_id,
 			spawn_handle: task_manager.spawn_handle(),
+			relay_chain_interface: relay_chain_interface.clone(),
 			import_queue: params.import_queue,
-			block_announce_validator_builder: Some(Box::new(|_| {
-				Box::new(block_announce_validator)
-			})),
-			warp_sync_params: None,
-		})?;
+		})
+		.await?;
 
 	let rpc_builder = {
 		let client = client.clone();
@@ -275,6 +277,14 @@ async fn start_node_impl(
 
 	if let Some(hwbench) = hwbench {
 		sc_sysinfo::print_hwbench(&hwbench);
+		// Here you can check whether the hardware meets your chains' requirements. Putting a link
+		// in there and swapping out the requirements for your own are probably a good idea. The
+		// requirements for a para-chain are dictated by its relay-chain.
+		if !SUBSTRATE_REFERENCE_HARDWARE.check_hardware(&hwbench) && validator {
+			log::warn!(
+				"⚠️  The hardware does not meet the minimal requirements for role 'Authority'."
+			);
+		}
 
 		if let Some(ref mut telemetry) = telemetry {
 			let telemetry_handle = telemetry.handle();
@@ -309,13 +319,13 @@ async fn start_node_impl(
 			sync_service.clone(),
 			params.keystore_container.keystore(),
 			force_authoring,
-			id,
+			para_id,
 		)?;
 
 		let spawner = task_manager.spawn_handle();
 
 		let params = StartCollatorParams {
-			para_id: id,
+			para_id,
 			block_status: client.clone(),
 			announce_block,
 			client: client.clone(),
@@ -336,7 +346,7 @@ async fn start_node_impl(
 			client: client.clone(),
 			announce_block,
 			task_manager: &mut task_manager,
-			para_id: id,
+			para_id,
 			relay_chain_interface,
 			relay_chain_slot_duration,
 			import_queue: import_queue_service,


### PR DESCRIPTION
# Goal
The goal of this PR is to enable Warp sync for Frequency

Closes #1585 

# Discussion
- There are some additional updates possible to `node/service/src/service.rs` that are possible once #1639 is complete
- Mostly this swaps out for the standard setup from cumulus

# Testing

1. `make build-mainnet-release`
2. `./target/release/frequency --base-path=/tmp/chain-warp --sync warp -- --sync warp`
3. Look for `[Parachain] ⏩ Waiting for pending target block`
4. Wait until `[Parachain] ⏩ Block history`
5. Finally `[Parachain] ✨ Imported` (aka warp complete)
