### PR TITLE
Re-factor balances.transfer() to transferAllowDeath()

### DIFF
--- a/integration-tests/miscellaneous/utilityBatch.test.ts
+++ b/integration-tests/miscellaneous/utilityBatch.test.ts
@@ -16,7 +16,7 @@ describe("Utility Batch Filtering", function () {
     it("should successfully execute ✅ batch with allowed calls", async function () {
         // good batch: with only allowed calls
         const goodBatch: SubmittableExtrinsic<ApiTypes>[] = [];
-        goodBatch.push(ExtrinsicHelper.api.tx.balances.transfer(recipient.address, 1000))
+        goodBatch.push(ExtrinsicHelper.api.tx.balances.transferAllowDeath(recipient.address, 1000))
         goodBatch.push(ExtrinsicHelper.api.tx.system.remark("Hello From Batch"))
         goodBatch.push(ExtrinsicHelper.api.tx.msa.create())
         const batch = ExtrinsicHelper.executeUtilityBatchAll(sender, goodBatch);
@@ -29,7 +29,7 @@ describe("Utility Batch Filtering", function () {
         // bad batch: with a mix of allowed and disallowed calls
         const badBatch: SubmittableExtrinsic<ApiTypes>[] = [];
         //allowed
-        badBatch.push(ExtrinsicHelper.api.tx.balances.transfer(recipient.address, 1000))
+        badBatch.push(ExtrinsicHelper.api.tx.balances.transferAllowDeath(recipient.address, 1000))
         badBatch.push(ExtrinsicHelper.api.tx.system.remark("Hello From Batch"))
         // not allowed
         badBatch.push(ExtrinsicHelper.api.tx.handles.retireHandle())
@@ -50,7 +50,7 @@ describe("Utility Batch Filtering", function () {
     it("should fail to execute ❌ batch with disallowed calls", async function () {
         // bad batch: with a mix of allowed and disallowed calls
         const badBatch: SubmittableExtrinsic<ApiTypes>[] = [];
-        badBatch.push(ExtrinsicHelper.api.tx.balances.transfer(recipient.address, 1000))
+        badBatch.push(ExtrinsicHelper.api.tx.balances.transferAllowDeath(recipient.address, 1000))
         badBatch.push(ExtrinsicHelper.api.tx.system.remark("Hello From Batch"))
         badBatch.push(ExtrinsicHelper.api.tx.handles.retireHandle())
         badBatch.push(ExtrinsicHelper.api.tx.msa.retireMsa())
@@ -66,7 +66,7 @@ describe("Utility Batch Filtering", function () {
     it("should fail to execute ❌ forceBatch with disallowed calls", async function () {
         // bad batch: with a mix of allowed and disallowed calls
         const badBatch: SubmittableExtrinsic<ApiTypes>[] = [];
-        badBatch.push(ExtrinsicHelper.api.tx.balances.transfer(recipient.address, 1000))
+        badBatch.push(ExtrinsicHelper.api.tx.balances.transferAllowDeath(recipient.address, 1000))
         badBatch.push(ExtrinsicHelper.api.tx.system.remark("Hello From Batch"))
         badBatch.push(ExtrinsicHelper.api.tx.handles.retireHandle())
         badBatch.push(ExtrinsicHelper.api.tx.msa.retireMsa())
@@ -91,7 +91,7 @@ describe("Utility Batch Filtering", function () {
             error = err;
             assert.notEqual(error, undefined, "should return an error");
         }
-        assert.notEqual(error, undefined, "should return an error");    
+        assert.notEqual(error, undefined, "should return an error");
     });
 
     it("should fail to execute ❌ batch with `Pays::Yes` `create_provider`call blocked by Frequency", async function () {
@@ -128,7 +128,7 @@ describe("Utility Batch Filtering", function () {
         // batch with nested batch
         const nestedBatch: SubmittableExtrinsic<ApiTypes>[] = [];
         const innerBatch: SubmittableExtrinsic<ApiTypes>[] = [];
-        innerBatch.push(ExtrinsicHelper.api.tx.balances.transfer(recipient.address, 1000))
+        innerBatch.push(ExtrinsicHelper.api.tx.balances.transferAllowDeath(recipient.address, 1000))
         innerBatch.push(ExtrinsicHelper.api.tx.system.remark("Hello From Batch"))
         nestedBatch.push(ExtrinsicHelper.api.tx.utility.batch(innerBatch))
         const batch = ExtrinsicHelper.executeUtilityBatchAll(sender, nestedBatch);

--- a/integration-tests/scaffolding/extrinsicHelpers.ts
+++ b/integration-tests/scaffolding/extrinsicHelpers.ts
@@ -231,7 +231,7 @@ export class ExtrinsicHelper {
 
     /** Balance Extrinsics */
     public static transferFunds(keys: KeyringPair, dest: KeyringPair, amount: Compact<u128> | AnyNumber): Extrinsic {
-        return new Extrinsic(() => ExtrinsicHelper.api.tx.balances.transfer(dest.address, amount), keys, ExtrinsicHelper.api.events.balances.Transfer);
+        return new Extrinsic(() => ExtrinsicHelper.api.tx.balances.transferAllowDeath(dest.address, amount), keys, ExtrinsicHelper.api.events.balances.Transfer);
     }
 
     /** Schema Extrinsics */


### PR DESCRIPTION
# Goal
The goal of this PR is to update use the new transferAllowDeath() instead of balances.transfer()

Closes #1607 
