### PR TITLE
Fix Incorrect weight on `set_epoch_length`

### DIFF
--- a/pallets/capacity/src/lib.rs
+++ b/pallets/capacity/src/lib.rs
@@ -402,7 +402,7 @@ pub mod pallet {
 		/// ### Errors
 		/// - Returns `Error::MaxEpochLengthExceeded` if `length` is greater than T::MaxEpochLength.
 		#[pallet::call_index(3)]
-		#[pallet::weight(T::WeightInfo::unstake())]
+		#[pallet::weight(T::WeightInfo::set_epoch_length())]
 		pub fn set_epoch_length(origin: OriginFor<T>, length: T::BlockNumber) -> DispatchResult {
 			ensure_root(origin)?;
 			ensure!(length <= T::MaxEpochLength::get(), Error::<T>::MaxEpochLengthExceeded);

--- a/pallets/frequency-tx-payment/src/capacity_stable_weights.rs
+++ b/pallets/frequency-tx-payment/src/capacity_stable_weights.rs
@@ -40,7 +40,6 @@ pub trait WeightInfo {
 	fn create_sponsored_account_with_delegation(s: u32) -> Weight;
 	fn add_public_key_to_msa() -> Weight;
 	fn grant_delegation(s: u32) -> Weight;
-	fn grant_schema_permissions(s: u32) -> Weight;
 	// Messages
 	fn add_onchain_message(n: u32) -> Weight;
 	fn add_ipfs_message() -> Weight;
@@ -131,16 +130,6 @@ impl<T: frame_system::Config> WeightInfo for SubstrateWeight<T> {
 			.saturating_add(Weight::from_parts(192_710, 0).saturating_mul(s.into()))
 			.saturating_add(T::DbWeight::get().reads(8_u64))
 			.saturating_add(T::DbWeight::get().writes(4_u64))
-	}
-	// Storage: Msa PublicKeyToMsaId (r:1 w:0)
-	// Storage: Msa DelegatorAndProviderToDelegation (r:1 w:1)
-	// Storage: Schemas CurrentSchemaIdentifierMaximum (r:1 w:0)
-	fn grant_schema_permissions(s: u32) -> Weight {
-		Weight::from_parts(26_682_873 as u64, 0)
-			// Standard Error: 7_236
-			.saturating_add(Weight::from_parts(63_887 as u64, 0).saturating_mul(s as u64))
-			.saturating_add(T::DbWeight::get().reads(3 as u64))
-			.saturating_add(T::DbWeight::get().writes(1 as u64))
 	}
 	/// Storage: Schemas Schemas (r:1 w:0)
 	/// Proof Skipped: Schemas Schemas (max_values: None, max_size: None, mode: Measured)

--- a/pallets/frequency-tx-payment/src/tests/stable_weights_tests.rs
+++ b/pallets/frequency-tx-payment/src/tests/stable_weights_tests.rs
@@ -21,12 +21,6 @@ fn test_weights_are_stable() {
 			),
 			("grant_delegation", SubstrateWeight::<Test>::grant_delegation(100), 135218313, 14946),
 			(
-				"grant_schema_permissions",
-				SubstrateWeight::<Test>::grant_schema_permissions(100),
-				33071573,
-				0,
-			),
-			(
 				"add_onchain_message",
 				SubstrateWeight::<Test>::add_onchain_message(100),
 				174216930,


### PR DESCRIPTION
# Goal
The goal of this PR is to fix `set_epoch_length`'s weight function

Closes #1624

# Discussion
- Also removes unused static weight function call `grant_schema_permissions` as it was removed.