### PR TITLE
Update stable weights for Weights 2.0

### DIFF
--- a/pallets/frequency-tx-payment/src/capacity_stable_weights.rs
+++ b/pallets/frequency-tx-payment/src/capacity_stable_weights.rs
@@ -80,42 +80,74 @@ pub trait WeightInfo {
 /// Weights for pallet_msa using the Substrate node and recommended hardware.
 pub struct SubstrateWeight<T>(PhantomData<T>);
 impl<T: frame_system::Config> WeightInfo for SubstrateWeight<T> {
-	// Storage: Msa PayloadSignatureBucketCount (r:1 w:1)
-	// Storage: Msa PayloadSignatureRegistry (r:1 w:1)
-	// Storage: Msa PublicKeyToMsaId (r:2 w:1)
-	// Storage: Msa ProviderToRegistryEntry (r:1 w:0)
-	// Storage: Msa CurrentMsaIdentifierMaximum (r:1 w:1)
-	// Storage: Msa PublicKeyCountForMsaId (r:1 w:1)
-	// Storage: Msa DelegatorAndProviderToDelegation (r:1 w:1)
-	// Storage: Schemas CurrentSchemaIdentifierMaximum (r:1 w:0)
+	/// Storage: Msa PayloadSignatureRegistryList (r:2 w:2)
+	/// Proof: Msa PayloadSignatureRegistryList (max_values: Some(50000), max_size: Some(144), added: 2124, mode: MaxEncodedLen)
+	/// Storage: Msa PayloadSignatureRegistryPointer (r:1 w:1)
+	/// Proof: Msa PayloadSignatureRegistryPointer (max_values: Some(1), max_size: Some(140), added: 635, mode: MaxEncodedLen)
+	/// Storage: Msa PublicKeyToMsaId (r:2 w:1)
+	/// Proof: Msa PublicKeyToMsaId (max_values: None, max_size: Some(48), added: 2523, mode: MaxEncodedLen)
+	/// Storage: Msa ProviderToRegistryEntry (r:1 w:0)
+	/// Proof: Msa ProviderToRegistryEntry (max_values: None, max_size: Some(33), added: 2508, mode: MaxEncodedLen)
+	/// Storage: Msa CurrentMsaIdentifierMaximum (r:1 w:1)
+	/// Proof: Msa CurrentMsaIdentifierMaximum (max_values: Some(1), max_size: Some(8), added: 503, mode: MaxEncodedLen)
+	/// Storage: Msa PublicKeyCountForMsaId (r:1 w:1)
+	/// Proof: Msa PublicKeyCountForMsaId (max_values: None, max_size: Some(17), added: 2492, mode: MaxEncodedLen)
+	/// Storage: Msa DelegatorAndProviderToDelegation (r:1 w:1)
+	/// Proof: Msa DelegatorAndProviderToDelegation (max_values: None, max_size: Some(217), added: 2692, mode: MaxEncodedLen)
+	/// Storage: Schemas CurrentSchemaIdentifierMaximum (r:1 w:0)
+	/// Proof Skipped: Schemas CurrentSchemaIdentifierMaximum (max_values: Some(1), max_size: None, mode: Measured)
+	/// The range of component `s` is `[0, 30]`.
 	fn create_sponsored_account_with_delegation(s: u32) -> Weight {
-		Weight::from_parts(100_556_500 as u64, 0)
-			// Standard Error: 19_778
-			.saturating_add(Weight::from_parts(120_447 as u64, 0).saturating_mul(s as u64))
-			.saturating_add(T::DbWeight::get().reads(9 as u64))
-			.saturating_add(T::DbWeight::get().writes(6 as u64))
+		// Proof Size summary in bytes:
+		//  Measured:  `1393`
+		//  Estimated: `14946`
+		// Minimum execution time: 119_554_000 picoseconds.
+		Weight::from_parts(124_216_637, 14946)
+			// Standard Error: 26_556
+			.saturating_add(Weight::from_parts(129_688, 0).saturating_mul(s.into()))
+			.saturating_add(T::DbWeight::get().reads(10_u64))
+			.saturating_add(T::DbWeight::get().writes(7_u64))
 	}
-	// Storage: Msa PayloadSignatureBucketCount (r:1 w:1)
-	// Storage: Msa PayloadSignatureRegistry (r:2 w:2)
-	// Storage: Msa PublicKeyToMsaId (r:2 w:1)
-	// Storage: Msa PublicKeyCountForMsaId (r:1 w:1)
+	/// Storage: Msa PayloadSignatureRegistryList (r:4 w:4)
+	/// Proof: Msa PayloadSignatureRegistryList (max_values: Some(50000), max_size: Some(144), added: 2124, mode: MaxEncodedLen)
+	/// Storage: Msa PayloadSignatureRegistryPointer (r:1 w:1)
+	/// Proof: Msa PayloadSignatureRegistryPointer (max_values: Some(1), max_size: Some(140), added: 635, mode: MaxEncodedLen)
+	/// Storage: Msa PublicKeyToMsaId (r:2 w:1)
+	/// Proof: Msa PublicKeyToMsaId (max_values: None, max_size: Some(48), added: 2523, mode: MaxEncodedLen)
+	/// Storage: Msa PublicKeyCountForMsaId (r:1 w:1)
+	/// Proof: Msa PublicKeyCountForMsaId (max_values: None, max_size: Some(17), added: 2492, mode: MaxEncodedLen)
 	fn add_public_key_to_msa() -> Weight {
-		Weight::from_parts(147_786_000 as u64, 0)
-			.saturating_add(T::DbWeight::get().reads(6 as u64))
-			.saturating_add(T::DbWeight::get().writes(5 as u64))
+		// Proof Size summary in bytes:
+		//  Measured:  `1654`
+		//  Estimated: `18396`
+		// Minimum execution time: 184_446_000 picoseconds.
+		Weight::from_parts(188_662_000, 18396)
+			.saturating_add(T::DbWeight::get().reads(8_u64))
+			.saturating_add(T::DbWeight::get().writes(7_u64))
 	}
-	// Storage: Msa PayloadSignatureBucketCount (r:1 w:1)
-	// Storage: Msa PayloadSignatureRegistry (r:1 w:1)
-	// Storage: Msa PublicKeyToMsaId (r:2 w:0)
-	// Storage: Msa ProviderToRegistryEntry (r:1 w:0)
-	// Storage: Msa DelegatorAndProviderToDelegation (r:1 w:1)
-	// Storage: Schemas CurrentSchemaIdentifierMaximum (r:1 w:0)
+	/// Storage: Msa PayloadSignatureRegistryList (r:2 w:2)
+	/// Proof: Msa PayloadSignatureRegistryList (max_values: Some(50000), max_size: Some(144), added: 2124, mode: MaxEncodedLen)
+	/// Storage: Msa PayloadSignatureRegistryPointer (r:1 w:1)
+	/// Proof: Msa PayloadSignatureRegistryPointer (max_values: Some(1), max_size: Some(140), added: 635, mode: MaxEncodedLen)
+	/// Storage: Msa PublicKeyToMsaId (r:2 w:0)
+	/// Proof: Msa PublicKeyToMsaId (max_values: None, max_size: Some(48), added: 2523, mode: MaxEncodedLen)
+	/// Storage: Msa ProviderToRegistryEntry (r:1 w:0)
+	/// Proof: Msa ProviderToRegistryEntry (max_values: None, max_size: Some(33), added: 2508, mode: MaxEncodedLen)
+	/// Storage: Msa DelegatorAndProviderToDelegation (r:1 w:1)
+	/// Proof: Msa DelegatorAndProviderToDelegation (max_values: None, max_size: Some(217), added: 2692, mode: MaxEncodedLen)
+	/// Storage: Schemas CurrentSchemaIdentifierMaximum (r:1 w:0)
+	/// Proof Skipped: Schemas CurrentSchemaIdentifierMaximum (max_values: Some(1), max_size: None, mode: Measured)
+	/// The range of component `s` is `[0, 30]`.
 	fn grant_delegation(s: u32) -> Weight {
-		Weight::from_parts(94_743_045 as u64, 0)
-			// Standard Error: 19_748
-			.saturating_add(Weight::from_parts(125_241 as u64, 0).saturating_mul(s as u64))
-			.saturating_add(T::DbWeight::get().reads(7 as u64))
-			.saturating_add(T::DbWeight::get().writes(3 as u64))
+		// Proof Size summary in bytes:
+		//  Measured:  `1447`
+		//  Estimated: `14946`
+		// Minimum execution time: 115_100_000 picoseconds.
+		Weight::from_parts(120_342_076, 14946)
+			// Standard Error: 35_029
+			.saturating_add(Weight::from_parts(34_990, 0).saturating_mul(s.into()))
+			.saturating_add(T::DbWeight::get().reads(8_u64))
+			.saturating_add(T::DbWeight::get().writes(4_u64))
 	}
 	// Storage: Msa PublicKeyToMsaId (r:1 w:0)
 	// Storage: Msa DelegatorAndProviderToDelegation (r:1 w:1)
@@ -127,94 +159,168 @@ impl<T: frame_system::Config> WeightInfo for SubstrateWeight<T> {
 			.saturating_add(T::DbWeight::get().reads(3 as u64))
 			.saturating_add(T::DbWeight::get().writes(1 as u64))
 	}
-	// Storage: Schemas Schemas (r:1 w:0)
-	// Storage: Msa PublicKeyToMsaId (r:1 w:0)
-	// Storage: Msa DelegatorAndProviderToDelegation (r:1 w:0)
-	// Storage: Messages Messages (r:1 w:1)
+	/// Storage: Schemas Schemas (r:1 w:0)
+	/// Proof Skipped: Schemas Schemas (max_values: None, max_size: None, mode: Measured)
+	/// Storage: Msa PublicKeyToMsaId (r:1 w:0)
+	/// Proof: Msa PublicKeyToMsaId (max_values: None, max_size: Some(48), added: 2523, mode: MaxEncodedLen)
+	/// Storage: Msa DelegatorAndProviderToDelegation (r:1 w:0)
+	/// Proof: Msa DelegatorAndProviderToDelegation (max_values: None, max_size: Some(217), added: 2692, mode: MaxEncodedLen)
+	/// Storage: Messages Messages (r:1 w:1)
+	/// Proof Skipped: Messages Messages (max_values: None, max_size: None, mode: Measured)
+	/// The range of component `n` is `[0, 51199]`.
 	fn add_onchain_message(n: u32) -> Weight {
-		Weight::from_parts(139_432_286 as u64, 0)
-			// Standard Error: 43
-			.saturating_add(Weight::from_parts(1_441 as u64, 0).saturating_mul(n as u64))
-			.saturating_add(T::DbWeight::get().reads(4 as u64))
-			.saturating_add(T::DbWeight::get().writes(1 as u64))
+		// Proof Size summary in bytes:
+		//  Measured:  `46773`
+		//  Estimated: `59148`
+		// Minimum execution time: 180_329_000 picoseconds.
+		Weight::from_parts(179_112_822, 59148)
+			// Standard Error: 52
+			.saturating_add(Weight::from_parts(1_852, 0).saturating_mul(n.into()))
+			.saturating_add(T::DbWeight::get().reads(4_u64))
+			.saturating_add(T::DbWeight::get().writes(1_u64))
 	}
-	// Storage: Schemas Schemas (r:1 w:0)
-	// Storage: Msa PublicKeyToMsaId (r:1 w:0)
-	// Storage: Messages Messages (r:1 w:1)
+	/// Storage: Schemas Schemas (r:1 w:0)
+	/// Proof Skipped: Schemas Schemas (max_values: None, max_size: None, mode: Measured)
+	/// Storage: Msa PublicKeyToMsaId (r:1 w:0)
+	/// Proof: Msa PublicKeyToMsaId (max_values: None, max_size: Some(48), added: 2523, mode: MaxEncodedLen)
+	/// Storage: Messages Messages (r:1 w:1)
+	/// Proof Skipped: Messages Messages (max_values: None, max_size: None, mode: Measured)
 	fn add_ipfs_message() -> Weight {
-		Weight::from_parts(131_669_000 as u64, 0)
-			.saturating_add(T::DbWeight::get().reads(3 as u64))
-			.saturating_add(T::DbWeight::get().writes(1 as u64))
+		// Proof Size summary in bytes:
+		//  Measured:  `36289`
+		//  Estimated: `48664`
+		// Minimum execution time: 169_213_000 picoseconds.
+		Weight::from_parts(174_485_000, 48664)
+			.saturating_add(T::DbWeight::get().reads(3_u64))
+			.saturating_add(T::DbWeight::get().writes(1_u64))
 	}
-	// Storage: Schemas Schemas (r:1 w:0)
-	// Storage: Msa PublicKeyToMsaId (r:1 w:0)
-	// Storage: Msa DelegatorAndProviderToDelegation (r:1 w:0)
-	// Storage: unknown [0xbd1557c8db6bd8599a811a7175fbc2fc6400] (r:1 w:1)
+	/// Storage: Schemas Schemas (r:1 w:0)
+	/// Proof Skipped: Schemas Schemas (max_values: None, max_size: None, mode: Measured)
+	/// Storage: Msa PublicKeyToMsaId (r:1 w:0)
+	/// Proof: Msa PublicKeyToMsaId (max_values: None, max_size: Some(48), added: 2523, mode: MaxEncodedLen)
+	/// Storage: Msa DelegatorAndProviderToDelegation (r:1 w:0)
+	/// Proof: Msa DelegatorAndProviderToDelegation (max_values: None, max_size: Some(217), added: 2692, mode: MaxEncodedLen)
+	/// Storage: unknown `0xbd1557c8db6bd8599a811a7175fbc2fc6400` (r:1 w:1)
+	/// Proof Skipped: unknown `0xbd1557c8db6bd8599a811a7175fbc2fc6400` (r:1 w:1)
+	/// The range of component `s` is `[1, 5121]`.
 	fn apply_item_actions(s: u32) -> Weight {
-		Weight::from_parts(66_026_301 as u64, 0)
-			// Standard Error: 161
-			.saturating_add(Weight::from_parts(2_145 as u64, 0).saturating_mul(s as u64))
-			.saturating_add(T::DbWeight::get().reads(4 as u64))
-			.saturating_add(T::DbWeight::get().writes(1 as u64))
+		// Proof Size summary in bytes:
+		//  Measured:  `33370`
+		//  Estimated: `45745`
+		// Minimum execution time: 107_769_000 picoseconds.
+		Weight::from_parts(105_222_871, 45745)
+			// Standard Error: 361
+			.saturating_add(Weight::from_parts(8_115, 0).saturating_mul(s.into()))
+			.saturating_add(T::DbWeight::get().reads(4_u64))
+			.saturating_add(T::DbWeight::get().writes(1_u64))
 	}
-	// Storage: Schemas Schemas (r:1 w:0)
-	// Storage: Msa PublicKeyToMsaId (r:1 w:0)
-	// Storage: Msa DelegatorAndProviderToDelegation (r:1 w:0)
-	// Storage: unknown [0x0763c98381dc89abe38627fe2f98cb7af1577fbf1d628fdddb4ebfc6e8d95fb1] (r:1 w:1)
+	/// Storage: Schemas Schemas (r:1 w:0)
+	/// Proof Skipped: Schemas Schemas (max_values: None, max_size: None, mode: Measured)
+	/// Storage: Msa PublicKeyToMsaId (r:1 w:0)
+	/// Proof: Msa PublicKeyToMsaId (max_values: None, max_size: Some(48), added: 2523, mode: MaxEncodedLen)
+	/// Storage: Msa DelegatorAndProviderToDelegation (r:1 w:0)
+	/// Proof: Msa DelegatorAndProviderToDelegation (max_values: None, max_size: Some(217), added: 2692, mode: MaxEncodedLen)
+	/// Storage: unknown `0x0763c98381dc89abe38627fe2f98cb7af1577fbf1d628fdddb4ebfc6e8d95fb1` (r:1 w:1)
+	/// Proof Skipped: unknown `0x0763c98381dc89abe38627fe2f98cb7af1577fbf1d628fdddb4ebfc6e8d95fb1` (r:1 w:1)
+	/// The range of component `s` is `[1, 1024]`.
 	fn upsert_page(s: u32) -> Weight {
-		Weight::from_parts(23_029_186 as u64, 0)
-			// Standard Error: 53
-			.saturating_add(Weight::from_parts(339 as u64, 0).saturating_mul(s as u64))
-			.saturating_add(T::DbWeight::get().reads(4 as u64))
-			.saturating_add(T::DbWeight::get().writes(1 as u64))
+		// Proof Size summary in bytes:
+		//  Measured:  `416`
+		//  Estimated: `12791`
+		// Minimum execution time: 31_259_000 picoseconds.
+		Weight::from_parts(32_661_101, 12791)
+			// Standard Error: 203
+			.saturating_add(Weight::from_parts(786, 0).saturating_mul(s.into()))
+			.saturating_add(T::DbWeight::get().reads(4_u64))
+			.saturating_add(T::DbWeight::get().writes(1_u64))
 	}
-	// Storage: Schemas Schemas (r:1 w:0)
-	// Storage: Msa PublicKeyToMsaId (r:1 w:0)
-	// Storage: Msa DelegatorAndProviderToDelegation (r:1 w:0)
-	// Storage: unknown [0x0763c98381dc89abe38627fe2f98cb7af1577fbf1d628fdddb4ebfc6e8d95fb1] (r:1 w:1)
+	/// Storage: Schemas Schemas (r:1 w:0)
+	/// Proof Skipped: Schemas Schemas (max_values: None, max_size: None, mode: Measured)
+	/// Storage: Msa PublicKeyToMsaId (r:1 w:0)
+	/// Proof: Msa PublicKeyToMsaId (max_values: None, max_size: Some(48), added: 2523, mode: MaxEncodedLen)
+	/// Storage: Msa DelegatorAndProviderToDelegation (r:1 w:0)
+	/// Proof: Msa DelegatorAndProviderToDelegation (max_values: None, max_size: Some(217), added: 2692, mode: MaxEncodedLen)
+	/// Storage: unknown `0x0763c98381dc89abe38627fe2f98cb7af1577fbf1d628fdddb4ebfc6e8d95fb1` (r:1 w:1)
+	/// Proof Skipped: unknown `0x0763c98381dc89abe38627fe2f98cb7af1577fbf1d628fdddb4ebfc6e8d95fb1` (r:1 w:1)
 	fn delete_page() -> Weight {
-		Weight::from_parts(26_000_000 as u64, 0)
-			.saturating_add(T::DbWeight::get().reads(4 as u64))
-			.saturating_add(T::DbWeight::get().writes(1 as u64))
+		// Proof Size summary in bytes:
+		//  Measured:  `1575`
+		//  Estimated: `13950`
+		// Minimum execution time: 37_460_000 picoseconds.
+		Weight::from_parts(39_471_000, 13950)
+			.saturating_add(T::DbWeight::get().reads(4_u64))
+			.saturating_add(T::DbWeight::get().writes(1_u64))
 	}
-	// Storage: Msa PublicKeyToMsaId (r:1 w:0)
-	// Storage: Schemas Schemas (r:1 w:0)
-	// Storage: unknown [0xbd1557c8db6bd8599a811a7175fbc2fc6400] (r:1 w:1)
+	/// Storage: Msa PublicKeyToMsaId (r:1 w:0)
+	/// Proof: Msa PublicKeyToMsaId (max_values: None, max_size: Some(48), added: 2523, mode: MaxEncodedLen)
+	/// Storage: Schemas Schemas (r:1 w:0)
+	/// Proof Skipped: Schemas Schemas (max_values: None, max_size: None, mode: Measured)
+	/// Storage: unknown `0xbd1557c8db6bd8599a811a7175fbc2fc6400` (r:1 w:1)
+	/// Proof Skipped: unknown `0xbd1557c8db6bd8599a811a7175fbc2fc6400` (r:1 w:1)
+	/// The range of component `s` is `[1, 5121]`.
 	fn apply_item_actions_with_signature(s: u32) -> Weight {
-		Weight::from_parts(105_921_191 as u64, 0)
-			// Standard Error: 267
-			.saturating_add(Weight::from_parts(6_150 as u64, 0).saturating_mul(s as u64))
-			.saturating_add(T::DbWeight::get().reads(3 as u64))
-			.saturating_add(T::DbWeight::get().writes(1 as u64))
+		// Proof Size summary in bytes:
+		//  Measured:  `33377`
+		//  Estimated: `45752`
+		// Minimum execution time: 175_937_000 picoseconds.
+		Weight::from_parts(169_857_770, 45752)
+			// Standard Error: 561
+			.saturating_add(Weight::from_parts(15_494, 0).saturating_mul(s.into()))
+			.saturating_add(T::DbWeight::get().reads(3_u64))
+			.saturating_add(T::DbWeight::get().writes(1_u64))
 	}
-	// Storage: Msa PublicKeyToMsaId (r:1 w:0)
-	// Storage: Schemas Schemas (r:1 w:0)
-	// Storage: unknown [0x0763c98381dc89abe38627fe2f98cb7af1577fbf1d628fdddb4ebfc6e8d95fb1] (r:1 w:1)
+	/// Storage: Msa PublicKeyToMsaId (r:1 w:0)
+	/// Proof: Msa PublicKeyToMsaId (max_values: None, max_size: Some(48), added: 2523, mode: MaxEncodedLen)
+	/// Storage: Schemas Schemas (r:1 w:0)
+	/// Proof Skipped: Schemas Schemas (max_values: None, max_size: None, mode: Measured)
+	/// Storage: unknown `0x0763c98381dc89abe38627fe2f98cb7af1577fbf1d628fdddb4ebfc6e8d95fb1` (r:1 w:1)
+	/// Proof Skipped: unknown `0x0763c98381dc89abe38627fe2f98cb7af1577fbf1d628fdddb4ebfc6e8d95fb1` (r:1 w:1)
+	/// The range of component `s` is `[1, 1024]`.
 	fn upsert_page_with_signature(s: u32) -> Weight {
-		Weight::from_parts(61_324_707 as u64, 0)
-			// Standard Error: 249
-			.saturating_add(Weight::from_parts(4_406 as u64, 0).saturating_mul(s as u64))
-			.saturating_add(T::DbWeight::get().reads(3 as u64))
-			.saturating_add(T::DbWeight::get().writes(1 as u64))
+		// Proof Size summary in bytes:
+		//  Measured:  `349`
+		//  Estimated: `12724`
+		// Minimum execution time: 87_687_000 picoseconds.
+		Weight::from_parts(91_158_457, 12724)
+			// Standard Error: 668
+			.saturating_add(Weight::from_parts(7_009, 0).saturating_mul(s.into()))
+			.saturating_add(T::DbWeight::get().reads(3_u64))
+			.saturating_add(T::DbWeight::get().writes(1_u64))
 	}
-	// Storage: Msa PublicKeyToMsaId (r:1 w:0)
-	// Storage: Schemas Schemas (r:1 w:0)
-	// Storage: unknown [0x0763c98381dc89abe38627fe2f98cb7af1577fbf1d628fdddb4ebfc6e8d95fb1] (r:1 w:1)
+	/// Storage: Msa PublicKeyToMsaId (r:1 w:0)
+	/// Proof: Msa PublicKeyToMsaId (max_values: None, max_size: Some(48), added: 2523, mode: MaxEncodedLen)
+	/// Storage: Schemas Schemas (r:1 w:0)
+	/// Proof Skipped: Schemas Schemas (max_values: None, max_size: None, mode: Measured)
+	/// Storage: unknown `0x0763c98381dc89abe38627fe2f98cb7af1577fbf1d628fdddb4ebfc6e8d95fb1` (r:1 w:1)
+	/// Proof Skipped: unknown `0x0763c98381dc89abe38627fe2f98cb7af1577fbf1d628fdddb4ebfc6e8d95fb1` (r:1 w:1)
 	fn delete_page_with_signature() -> Weight {
-		Weight::from_parts(65_000_000 as u64, 0)
-			.saturating_add(T::DbWeight::get().reads(3 as u64))
-			.saturating_add(T::DbWeight::get().writes(1 as u64))
+		// Proof Size summary in bytes:
+		//  Measured:  `1508`
+		//  Estimated: `13883`
+		// Minimum execution time: 89_775_000 picoseconds.
+		Weight::from_parts(92_238_000, 13883)
+			.saturating_add(T::DbWeight::get().reads(3_u64))
+			.saturating_add(T::DbWeight::get().writes(1_u64))
 	}
-	// Storage: Msa PublicKeyToMsaId (r:1 w:0)
-	// Storage: Handles MSAIdToDisplayName (r:1 w:1)
-	// Storage: Handles CanonicalBaseHandleToSuffixIndex (r:1 w:1)
-	// Storage: Handles CanonicalBaseHandleAndSuffixToMSAId (r:0 w:1)
+	/// Storage: Msa PublicKeyToMsaId (r:1 w:0)
+	/// Proof: Msa PublicKeyToMsaId (max_values: None, max_size: Some(48), added: 2523, mode: MaxEncodedLen)
+	/// Storage: Handles MSAIdToDisplayName (r:1 w:1)
+	/// Proof: Handles MSAIdToDisplayName (max_values: None, max_size: Some(59), added: 2534, mode: MaxEncodedLen)
+	/// Storage: Handles CanonicalBaseHandleToSuffixIndex (r:1 w:1)
+	/// Proof: Handles CanonicalBaseHandleToSuffixIndex (max_values: None, max_size: Some(53), added: 2528, mode: MaxEncodedLen)
+	/// Storage: Handles CanonicalBaseHandleAndSuffixToMSAId (r:0 w:1)
+	/// Proof: Handles CanonicalBaseHandleAndSuffixToMSAId (max_values: None, max_size: Some(67), added: 2542, mode: MaxEncodedLen)
+	/// The range of component `b` is `[3, 30]`.
 	fn claim_handle(b: u32) -> Weight {
-		Weight::from_parts(90_537_753 as u64, 0)
-			// Standard Error: 27_078
-			.saturating_add(Weight::from_parts(104_522 as u64, 0).saturating_mul(b as u64))
-			.saturating_add(T::DbWeight::get().reads(3 as u64))
-			.saturating_add(T::DbWeight::get().writes(3 as u64))
+		// Proof Size summary in bytes:
+		//  Measured:  `191`
+		//  Estimated: `12434`
+		// Minimum execution time: 83_385_000 picoseconds.
+		Weight::from_parts(85_563_974, 12434)
+			// Standard Error: 14_428
+			.saturating_add(Weight::from_parts(105_821, 0).saturating_mul(b.into()))
+			.saturating_add(T::DbWeight::get().reads(3_u64))
+			.saturating_add(T::DbWeight::get().writes(3_u64))
 	}
 	/// Storage: Msa PublicKeyToMsaId (r:1 w:0)
 	/// Storage: Handles MSAIdToDisplayName (r:1 w:1)

--- a/pallets/frequency-tx-payment/src/capacity_stable_weights.rs
+++ b/pallets/frequency-tx-payment/src/capacity_stable_weights.rs
@@ -17,41 +17,22 @@ use sp_std::marker::PhantomData;
 /// Capacity needs the base fee to remain stable and not change when benchmarks are run.
 /// CAPACITY_EXTRINSIC_BASE_WEIGHT is a snapshot of the ExtrinsicBaseWeight
 /// taken from: runtime/common/src/weights/extrinsic_weights.rs
-///   THIS FILE WAS AUTO-GENERATED USING THE SUBSTRATE BENCHMARK CLI VERSION 4.0.0-dev
-///   DATE: 2023-04-05 (Y/M/D)
-///   HOSTNAME: `benchmark-runner-p5rt6-vk9q8`, CPU: `Intel(R) Xeon(R) Platinum 8375C CPU @ 2.90GHz`
-///
-///   SHORT-NAME: `extrinsic`, LONG-NAME: `ExtrinsicBase`, RUNTIME: `Frequency Local Testnet`
-///   WARMUPS: `10`, REPEAT: `100`
-///   WEIGHT-PATH: `runtime/common/src/weights`
-///   WEIGHT-METRIC: `Average`, WEIGHT-MUL: `1.0`, WEIGHT-ADD: `0`
-///
-///   Executed Command:
-///     ./scripts/../target/release/frequency
-///     benchmark
-///     overhead
-///     --execution=wasm
-///     --wasm-execution=compiled
-///     --weight-path=runtime/common/src/weights
-///     --chain=dev
-///     --warmup=10
-///     --repeat=100,
 ///
 /// Time to execute a NO-OP extrinsic, for example `System::remark`.
 /// Calculated by multiplying the *Average* with `1.0` and adding `0`.
 ///
 /// Stats nanoseconds:
-/// - Min, Max: 90_148, 102_526
-/// - Average:  90_764
-/// - Median:   90_507
-/// - Std-Dev:  1449.85
+///   Min, Max: 104_713, 111_324
+///   Average:  105_455
+///   Median:   105_091
+///   Std-Dev:  1133.64
 ///
 /// Percentiles nanoseconds:
-/// - 99th: 96_896
-/// - 95th: 91_299
-/// - 75th: 90_626
+///   99th: 110_219
+///   95th: 106_592
+///   75th: 105_471
 pub const CAPACITY_EXTRINSIC_BASE_WEIGHT: Weight =
-	Weight::from_parts(WEIGHT_REF_TIME_PER_NANOS.saturating_mul(90_764), 0);
+	Weight::from_parts(WEIGHT_REF_TIME_PER_NANOS.saturating_mul(105_455), 0);
 
 /// Weight functions needed for pallet_msa.
 pub trait WeightInfo {
@@ -77,6 +58,8 @@ pub trait WeightInfo {
 
 // Update test as well to ensure static weight values `tests/stable_weights_test.rs`
 
+// Updated to match v1.7.4 released weights
+
 /// Weights for pallet_msa using the Substrate node and recommended hardware.
 pub struct SubstrateWeight<T>(PhantomData<T>);
 impl<T: frame_system::Config> WeightInfo for SubstrateWeight<T> {
@@ -101,10 +84,10 @@ impl<T: frame_system::Config> WeightInfo for SubstrateWeight<T> {
 		// Proof Size summary in bytes:
 		//  Measured:  `1393`
 		//  Estimated: `14946`
-		// Minimum execution time: 119_554_000 picoseconds.
-		Weight::from_parts(124_216_637, 14946)
-			// Standard Error: 26_556
-			.saturating_add(Weight::from_parts(129_688, 0).saturating_mul(s.into()))
+		// Minimum execution time: 119_384_000 picoseconds.
+		Weight::from_parts(123_084_817, 14946)
+			// Standard Error: 20_681
+			.saturating_add(Weight::from_parts(138_668, 0).saturating_mul(s.into()))
 			.saturating_add(T::DbWeight::get().reads(10_u64))
 			.saturating_add(T::DbWeight::get().writes(7_u64))
 	}
@@ -118,10 +101,10 @@ impl<T: frame_system::Config> WeightInfo for SubstrateWeight<T> {
 	/// Proof: Msa PublicKeyCountForMsaId (max_values: None, max_size: Some(17), added: 2492, mode: MaxEncodedLen)
 	fn add_public_key_to_msa() -> Weight {
 		// Proof Size summary in bytes:
-		//  Measured:  `1654`
+		//  Measured:  `1677`
 		//  Estimated: `18396`
-		// Minimum execution time: 184_446_000 picoseconds.
-		Weight::from_parts(188_662_000, 18396)
+		// Minimum execution time: 175_288_000 picoseconds.
+		Weight::from_parts(177_629_000, 18396)
 			.saturating_add(T::DbWeight::get().reads(8_u64))
 			.saturating_add(T::DbWeight::get().writes(7_u64))
 	}
@@ -140,12 +123,12 @@ impl<T: frame_system::Config> WeightInfo for SubstrateWeight<T> {
 	/// The range of component `s` is `[0, 30]`.
 	fn grant_delegation(s: u32) -> Weight {
 		// Proof Size summary in bytes:
-		//  Measured:  `1447`
+		//  Measured:  `1443`
 		//  Estimated: `14946`
-		// Minimum execution time: 115_100_000 picoseconds.
-		Weight::from_parts(120_342_076, 14946)
-			// Standard Error: 35_029
-			.saturating_add(Weight::from_parts(34_990, 0).saturating_mul(s.into()))
+		// Minimum execution time: 111_571_000 picoseconds.
+		Weight::from_parts(115_947_313, 14946)
+			// Standard Error: 18_186
+			.saturating_add(Weight::from_parts(192_710, 0).saturating_mul(s.into()))
 			.saturating_add(T::DbWeight::get().reads(8_u64))
 			.saturating_add(T::DbWeight::get().writes(4_u64))
 	}
@@ -172,10 +155,10 @@ impl<T: frame_system::Config> WeightInfo for SubstrateWeight<T> {
 		// Proof Size summary in bytes:
 		//  Measured:  `46773`
 		//  Estimated: `59148`
-		// Minimum execution time: 180_329_000 picoseconds.
-		Weight::from_parts(179_112_822, 59148)
-			// Standard Error: 52
-			.saturating_add(Weight::from_parts(1_852, 0).saturating_mul(n.into()))
+		// Minimum execution time: 164_198_000 picoseconds.
+		Weight::from_parts(174_064_230, 59148)
+			// Standard Error: 48
+			.saturating_add(Weight::from_parts(1_527, 0).saturating_mul(n.into()))
 			.saturating_add(T::DbWeight::get().reads(4_u64))
 			.saturating_add(T::DbWeight::get().writes(1_u64))
 	}
@@ -189,8 +172,8 @@ impl<T: frame_system::Config> WeightInfo for SubstrateWeight<T> {
 		// Proof Size summary in bytes:
 		//  Measured:  `36289`
 		//  Estimated: `48664`
-		// Minimum execution time: 169_213_000 picoseconds.
-		Weight::from_parts(174_485_000, 48664)
+		// Minimum execution time: 156_648_000 picoseconds.
+		Weight::from_parts(159_242_000, 48664)
 			.saturating_add(T::DbWeight::get().reads(3_u64))
 			.saturating_add(T::DbWeight::get().writes(1_u64))
 	}
@@ -207,10 +190,10 @@ impl<T: frame_system::Config> WeightInfo for SubstrateWeight<T> {
 		// Proof Size summary in bytes:
 		//  Measured:  `33370`
 		//  Estimated: `45745`
-		// Minimum execution time: 107_769_000 picoseconds.
-		Weight::from_parts(105_222_871, 45745)
-			// Standard Error: 361
-			.saturating_add(Weight::from_parts(8_115, 0).saturating_mul(s.into()))
+		// Minimum execution time: 105_792_000 picoseconds.
+		Weight::from_parts(104_137_090, 45745)
+			// Standard Error: 315
+			.saturating_add(Weight::from_parts(7_325, 0).saturating_mul(s.into()))
 			.saturating_add(T::DbWeight::get().reads(4_u64))
 			.saturating_add(T::DbWeight::get().writes(1_u64))
 	}
@@ -227,10 +210,10 @@ impl<T: frame_system::Config> WeightInfo for SubstrateWeight<T> {
 		// Proof Size summary in bytes:
 		//  Measured:  `416`
 		//  Estimated: `12791`
-		// Minimum execution time: 31_259_000 picoseconds.
-		Weight::from_parts(32_661_101, 12791)
+		// Minimum execution time: 30_996_000 picoseconds.
+		Weight::from_parts(32_297_181, 12791)
 			// Standard Error: 203
-			.saturating_add(Weight::from_parts(786, 0).saturating_mul(s.into()))
+			.saturating_add(Weight::from_parts(594, 0).saturating_mul(s.into()))
 			.saturating_add(T::DbWeight::get().reads(4_u64))
 			.saturating_add(T::DbWeight::get().writes(1_u64))
 	}
@@ -246,8 +229,8 @@ impl<T: frame_system::Config> WeightInfo for SubstrateWeight<T> {
 		// Proof Size summary in bytes:
 		//  Measured:  `1575`
 		//  Estimated: `13950`
-		// Minimum execution time: 37_460_000 picoseconds.
-		Weight::from_parts(39_471_000, 13950)
+		// Minimum execution time: 36_810_000 picoseconds.
+		Weight::from_parts(37_792_000, 13950)
 			.saturating_add(T::DbWeight::get().reads(4_u64))
 			.saturating_add(T::DbWeight::get().writes(1_u64))
 	}
@@ -262,10 +245,10 @@ impl<T: frame_system::Config> WeightInfo for SubstrateWeight<T> {
 		// Proof Size summary in bytes:
 		//  Measured:  `33377`
 		//  Estimated: `45752`
-		// Minimum execution time: 175_937_000 picoseconds.
-		Weight::from_parts(169_857_770, 45752)
-			// Standard Error: 561
-			.saturating_add(Weight::from_parts(15_494, 0).saturating_mul(s.into()))
+		// Minimum execution time: 165_956_000 picoseconds.
+		Weight::from_parts(158_947_612, 45752)
+			// Standard Error: 426
+			.saturating_add(Weight::from_parts(13_664, 0).saturating_mul(s.into()))
 			.saturating_add(T::DbWeight::get().reads(3_u64))
 			.saturating_add(T::DbWeight::get().writes(1_u64))
 	}
@@ -280,10 +263,10 @@ impl<T: frame_system::Config> WeightInfo for SubstrateWeight<T> {
 		// Proof Size summary in bytes:
 		//  Measured:  `349`
 		//  Estimated: `12724`
-		// Minimum execution time: 87_687_000 picoseconds.
-		Weight::from_parts(91_158_457, 12724)
-			// Standard Error: 668
-			.saturating_add(Weight::from_parts(7_009, 0).saturating_mul(s.into()))
+		// Minimum execution time: 85_227_000 picoseconds.
+		Weight::from_parts(87_768_259, 12724)
+			// Standard Error: 543
+			.saturating_add(Weight::from_parts(6_648, 0).saturating_mul(s.into()))
 			.saturating_add(T::DbWeight::get().reads(3_u64))
 			.saturating_add(T::DbWeight::get().writes(1_u64))
 	}
@@ -297,8 +280,8 @@ impl<T: frame_system::Config> WeightInfo for SubstrateWeight<T> {
 		// Proof Size summary in bytes:
 		//  Measured:  `1508`
 		//  Estimated: `13883`
-		// Minimum execution time: 89_775_000 picoseconds.
-		Weight::from_parts(92_238_000, 13883)
+		// Minimum execution time: 88_824_000 picoseconds.
+		Weight::from_parts(90_631_000, 13883)
 			.saturating_add(T::DbWeight::get().reads(3_u64))
 			.saturating_add(T::DbWeight::get().writes(1_u64))
 	}
@@ -315,23 +298,31 @@ impl<T: frame_system::Config> WeightInfo for SubstrateWeight<T> {
 		// Proof Size summary in bytes:
 		//  Measured:  `191`
 		//  Estimated: `12434`
-		// Minimum execution time: 83_385_000 picoseconds.
-		Weight::from_parts(85_563_974, 12434)
-			// Standard Error: 14_428
-			.saturating_add(Weight::from_parts(105_821, 0).saturating_mul(b.into()))
-			.saturating_add(T::DbWeight::get().reads(3_u64))
-			.saturating_add(T::DbWeight::get().writes(3_u64))
+		// Minimum execution time: 83_175_000 picoseconds.
+		Weight::from_parts(85_480_476, 12434)
+			// Standard Error: 25_131
+			.saturating_add(Weight::from_parts(107_272, 0).saturating_mul(b.into()))
+			.saturating_add(RocksDbWeight::get().reads(3_u64))
+			.saturating_add(RocksDbWeight::get().writes(3_u64))
 	}
 	/// Storage: Msa PublicKeyToMsaId (r:1 w:0)
+	/// Proof: Msa PublicKeyToMsaId (max_values: None, max_size: Some(48), added: 2523, mode: MaxEncodedLen)
 	/// Storage: Handles MSAIdToDisplayName (r:1 w:1)
+	/// Proof: Handles MSAIdToDisplayName (max_values: None, max_size: Some(59), added: 2534, mode: MaxEncodedLen)
 	/// Storage: Handles CanonicalBaseHandleToSuffixIndex (r:1 w:1)
+	/// Proof: Handles CanonicalBaseHandleToSuffixIndex (max_values: None, max_size: Some(53), added: 2528, mode: MaxEncodedLen)
 	/// Storage: Handles CanonicalBaseHandleAndSuffixToMSAId (r:0 w:2)
+	/// Proof: Handles CanonicalBaseHandleAndSuffixToMSAId (max_values: None, max_size: Some(67), added: 2542, mode: MaxEncodedLen)
 	/// The range of component `b` is `[3, 30]`.
 	fn change_handle(b: u32, ) -> Weight {
-		Weight::from_parts(96_221_224, 12434)
-			// Standard Error: 9_682
-			.saturating_add(Weight::from_parts(193_495, 0).saturating_mul(b.into()))
-			.saturating_add(T::DbWeight::get().reads(3_u64))
-			.saturating_add(T::DbWeight::get().writes(4_u64))
+		// Proof Size summary in bytes:
+		//  Measured:  `297 + b * (1 ±0)`
+		//  Estimated: `12434`
+		// Minimum execution time: 93_749_000 picoseconds.
+		Weight::from_parts(95_748_064, 12434)
+			// Standard Error: 9_821
+			.saturating_add(Weight::from_parts(212_118, 0).saturating_mul(b.into()))
+			.saturating_add(RocksDbWeight::get().reads(3_u64))
+			.saturating_add(RocksDbWeight::get().writes(4_u64))
 	}
 }

--- a/pallets/frequency-tx-payment/src/tests/pallet_tests.rs
+++ b/pallets/frequency-tx-payment/src/tests/pallet_tests.rs
@@ -190,7 +190,7 @@ fn transaction_payment_with_capacity_and_no_overcharge_post_dispatch_refund_is_s
 			// capacity_balance = free_balance - base_weight(CAPACITY_EXTRINSIC_BASE_WEIGHT)
 			//   - extrinsic_weight(11) * WeightToFee(1)
 			//   - TransactionByteFee(1)* len(10) = 80
-			assert_eq!(Capacity::balance(1), 1_000_000_000 - 90_764_000 - 11 - 10);
+			assert_eq!(Capacity::balance(1), 1_000_000_000 - 105_455_000 - 11 - 10);
 
 			let post_info: PostDispatchInfo =
 				PostDispatchInfo { actual_weight: None, pays_fee: Default::default() };
@@ -204,7 +204,7 @@ fn transaction_payment_with_capacity_and_no_overcharge_post_dispatch_refund_is_s
 			));
 
 			// Checking balance was not modified after post-dispatch.
-			assert_eq!(Capacity::balance(1), 1_000_000_000 - 90_764_000 - 11 - 10);
+			assert_eq!(Capacity::balance(1), 1_000_000_000 - 105_455_000 - 11 - 10);
 		});
 }
 
@@ -293,7 +293,7 @@ fn charge_frq_transaction_payment_withdraw_fee_for_capacity_batch_tx_returns_tup
 			//   + TransactionByteFee(1)* len(10) = CAPACITY_EXTRINSIC_BASE_WEIGHT + 21
 			let res = charge_tx_payment.withdraw_fee(&who, call, &info, len);
 			assert_ok!(&res);
-			assert_eq!(res.unwrap().0, 90_764_000 + 21);
+			assert_eq!(res.unwrap().0, 105_455_000 + 21);
 			assert_eq!(
 				charge_tx_payment.withdraw_fee(&who, call, &info, len).unwrap().1.is_capacity(),
 				true
@@ -328,7 +328,7 @@ fn charge_frq_transaction_payment_withdraw_fee_for_capacity_tx_returns_tupple_wi
 			//   + TransactionByteFee(1)* len(10) = 20
 			assert_eq!(
 				charge_tx_payment.withdraw_fee(&who, call, &info, len).unwrap().0,
-				(90_764_000 + 21u64)
+				(105_455_000 + 21u64)
 			);
 			assert_eq!(
 				charge_tx_payment.withdraw_fee(&who, call, &info, len).unwrap().1.is_capacity(),
@@ -629,7 +629,7 @@ fn withdraw_fee_replenishes_capacity_account_on_new_epoch_before_deducting_fee()
 			assert_eq!(
 				actual_capacity,
 				CapacityDetails {
-					remaining_capacity: total_capacity_issued.saturating_sub(90_764_000 + 21),
+					remaining_capacity: total_capacity_issued.saturating_sub(105_455_000 + 21),
 					total_tokens_staked,
 					total_capacity_issued,
 					last_replenished_epoch: current_epoch,
@@ -676,7 +676,7 @@ fn withdraw_fee_does_not_replenish_if_not_new_epoch() {
 			assert_eq!(
 				actual_capacity,
 				CapacityDetails {
-					remaining_capacity: 2_700_000_000.saturating_sub(90_764_000 + 21),
+					remaining_capacity: 2_700_000_000.saturating_sub(105_455_000 + 21),
 					total_tokens_staked,
 					total_capacity_issued,
 					last_replenished_epoch,
@@ -702,7 +702,7 @@ fn compute_capacity_fee_successful() {
 				<Test as Config>::CapacityCalls::get_stable_weight(call).unwrap(),
 			);
 
-			assert_eq!(fee, 90_764_000 + 21);
+			assert_eq!(fee, 105_455_000 + 21);
 		});
 }
 

--- a/pallets/frequency-tx-payment/src/tests/stable_weights_tests.rs
+++ b/pallets/frequency-tx-payment/src/tests/stable_weights_tests.rs
@@ -10,16 +10,16 @@ fn test_weights_are_stable() {
 			(
 				"create_sponsored_account_with_delegation",
 				SubstrateWeight::<Test>::create_sponsored_account_with_delegation(100),
-				137185437,
+				136951617,
 				14946,
 			),
 			(
 				"add_public_key_to_msa",
 				SubstrateWeight::<Test>::add_public_key_to_msa(),
-				188662000,
+				177629000,
 				18396,
 			),
-			("grant_delegation", SubstrateWeight::<Test>::grant_delegation(100), 123841076, 14946),
+			("grant_delegation", SubstrateWeight::<Test>::grant_delegation(100), 135218313, 14946),
 			(
 				"grant_schema_permissions",
 				SubstrateWeight::<Test>::grant_schema_permissions(100),
@@ -29,38 +29,38 @@ fn test_weights_are_stable() {
 			(
 				"add_onchain_message",
 				SubstrateWeight::<Test>::add_onchain_message(100),
-				179298022,
+				174216930,
 				59148,
 			),
-			("add_ipfs_message", SubstrateWeight::<Test>::add_ipfs_message(), 174485000, 48664),
+			("add_ipfs_message", SubstrateWeight::<Test>::add_ipfs_message(), 159242000, 48664),
 			(
 				"apply_item_actions",
 				SubstrateWeight::<Test>::apply_item_actions(100),
-				106034371,
+				104869590,
 				45745,
 			),
-			("upsert_page", SubstrateWeight::<Test>::upsert_page(100), 32739701, 12791),
-			("delete_page", SubstrateWeight::<Test>::delete_page(), 39471000, 13950),
+			("upsert_page", SubstrateWeight::<Test>::upsert_page(100), 32356581, 12791),
+			("delete_page", SubstrateWeight::<Test>::delete_page(), 37792000, 13950),
 			(
 				"apply_item_actions_with_signature",
 				SubstrateWeight::<Test>::apply_item_actions_with_signature(100),
-				171407170,
+				160314012,
 				45752,
 			),
 			(
 				"upsert_page_with_signature",
 				SubstrateWeight::<Test>::upsert_page_with_signature(100),
-				91859357,
+				88433059,
 				12724,
 			),
 			(
 				"delete_page_with_signature",
 				SubstrateWeight::<Test>::delete_page_with_signature(),
-				92238000,
+				90631000,
 				13883,
 			),
-			("claim_handle", SubstrateWeight::<Test>::claim_handle(100), 96146074, 12434),
-			("change_handle", SubstrateWeight::<Test>::change_handle(100), 115570724, 12434),
+			("claim_handle", SubstrateWeight::<Test>::claim_handle(100), 471207676, 12434),
+			("change_handle", SubstrateWeight::<Test>::change_handle(100), 591959864, 12434),
 		];
 		for t in table {
 			assert_eq!(t.1, Weight::from_parts(t.2, t.3), "{}", t.0);

--- a/pallets/frequency-tx-payment/src/tests/stable_weights_tests.rs
+++ b/pallets/frequency-tx-payment/src/tests/stable_weights_tests.rs
@@ -7,22 +7,63 @@ use crate::capacity_stable_weights::{SubstrateWeight, WeightInfo};
 fn test_weights_are_stable() {
 	ExtBuilder::default().build().execute_with(|| {
 		let table = vec![
-			(SubstrateWeight::<Test>::create_sponsored_account_with_delegation(100), 112601200),
-			(SubstrateWeight::<Test>::add_public_key_to_msa(), 147786000),
-			(SubstrateWeight::<Test>::grant_delegation(100), 107267145),
-			(SubstrateWeight::<Test>::grant_schema_permissions(100), 33071573),
-			(SubstrateWeight::<Test>::add_onchain_message(100), 139576386),
-			(SubstrateWeight::<Test>::add_ipfs_message(), 131669000),
-			(SubstrateWeight::<Test>::apply_item_actions(100), 66240801),
-			(SubstrateWeight::<Test>::upsert_page(100), 23063086),
-			(SubstrateWeight::<Test>::delete_page(), 26000000),
-			(SubstrateWeight::<Test>::apply_item_actions_with_signature(100), 106536191),
-			(SubstrateWeight::<Test>::upsert_page_with_signature(100), 61765307),
-			(SubstrateWeight::<Test>::delete_page_with_signature(), 65000000),
-			(SubstrateWeight::<Test>::claim_handle(100), 100989953),
+			(
+				"create_sponsored_account_with_delegation",
+				SubstrateWeight::<Test>::create_sponsored_account_with_delegation(100),
+				137185437,
+				14946,
+			),
+			(
+				"add_public_key_to_msa",
+				SubstrateWeight::<Test>::add_public_key_to_msa(),
+				188662000,
+				18396,
+			),
+			("grant_delegation", SubstrateWeight::<Test>::grant_delegation(100), 123841076, 14946),
+			(
+				"grant_schema_permissions",
+				SubstrateWeight::<Test>::grant_schema_permissions(100),
+				33071573,
+				0,
+			),
+			(
+				"add_onchain_message",
+				SubstrateWeight::<Test>::add_onchain_message(100),
+				179298022,
+				59148,
+			),
+			("add_ipfs_message", SubstrateWeight::<Test>::add_ipfs_message(), 174485000, 48664),
+			(
+				"apply_item_actions",
+				SubstrateWeight::<Test>::apply_item_actions(100),
+				106034371,
+				45745,
+			),
+			("upsert_page", SubstrateWeight::<Test>::upsert_page(100), 32739701, 12791),
+			("delete_page", SubstrateWeight::<Test>::delete_page(), 39471000, 13950),
+			(
+				"apply_item_actions_with_signature",
+				SubstrateWeight::<Test>::apply_item_actions_with_signature(100),
+				171407170,
+				45752,
+			),
+			(
+				"upsert_page_with_signature",
+				SubstrateWeight::<Test>::upsert_page_with_signature(100),
+				91859357,
+				12724,
+			),
+			(
+				"delete_page_with_signature",
+				SubstrateWeight::<Test>::delete_page_with_signature(),
+				92238000,
+				13883,
+			),
+			("claim_handle", SubstrateWeight::<Test>::claim_handle(100), 96146074, 12434),
+			("change_handle", SubstrateWeight::<Test>::change_handle(100), 115570724, 12434),
 		];
 		for t in table {
-			assert_eq!(t.0, Weight::from_parts(t.1, 0));
+			assert_eq!(t.1, Weight::from_parts(t.2, t.3), "{}", t.0);
 		}
 	});
 }


### PR DESCRIPTION
# Goal
The goal of this PR is to update the stable weights with the PoV and Weights 2.0.

This PR takes the approach of just completely updating the weights, so the stable weights DO CHANGE by more than just the addition of the PoV data.

I am open to a alternative approach that *only* adds the PoV, but I judged that any change might as well just be a complete update.

Closes #1606