### PR TITLE
Error message fixes: descriptive error, set to Payment error for now

### DIFF
--- a/integration-tests/capacity/transactions.test.ts
+++ b/integration-tests/capacity/transactions.test.ts
@@ -102,7 +102,7 @@ describe("Capacity Transactions", function () {
         const claimHandle = ExtrinsicHelper.claimHandle(newControlKeypair, claimHandlePayload);
         await assert.rejects(claimHandle.payWithCapacity(), {
           name: "RpcError", message:
-            "1010: Invalid Transaction: Custom error: 3"
+            "1010: Invalid Transaction: Inability to pay some fees , e.g. account balance too low"
         });
       });
 
@@ -589,7 +589,7 @@ describe("Capacity Transactions", function () {
 
         await assert.rejects(grantDelegationOp.payWithCapacity(), {
           name: 'RpcError',
-          message: /Custom error: 3/,
+          message: /1010: Invalid Transaction: Inability to pay some fees , e.g. account balance too low/,
         })
       });
     });

--- a/pallets/frequency-tx-payment/src/payment.rs
+++ b/pallets/frequency-tx-payment/src/payment.rs
@@ -37,7 +37,6 @@ where
 	) -> Result<Self::Balance, TransactionValidityError> {
 		ensure!(
 			Curr::free_balance(key) >= Curr::minimum_balance(),
-			//ChargeFrqTransactionPaymentError::BelowMinDeposit.into()
 			TransactionValidityError::Invalid(InvalidTransaction::Payment)
 		);
 
@@ -47,7 +46,6 @@ where
 		if T::Capacity::can_replenish(msa_id) {
 			ensure!(
 				T::Capacity::replenish_all_for(msa_id).is_ok(),
-				//ChargeFrqTransactionPaymentError::TargetCapacityNotFound.into()
 				TransactionValidityError::Invalid(InvalidTransaction::Payment)
 			);
 		}

--- a/pallets/frequency-tx-payment/src/payment.rs
+++ b/pallets/frequency-tx-payment/src/payment.rs
@@ -37,7 +37,8 @@ where
 	) -> Result<Self::Balance, TransactionValidityError> {
 		ensure!(
 			Curr::free_balance(key) >= Curr::minimum_balance(),
-			ChargeFrqTransactionPaymentError::BelowMinDeposit.into()
+			//ChargeFrqTransactionPaymentError::BelowMinDeposit.into()
+			TransactionValidityError::Invalid(InvalidTransaction::Payment)
 		);
 
 		let msa_id = Msa::ensure_valid_msa_key(key)
@@ -46,7 +47,8 @@ where
 		if T::Capacity::can_replenish(msa_id) {
 			ensure!(
 				T::Capacity::replenish_all_for(msa_id).is_ok(),
-				ChargeFrqTransactionPaymentError::TargetCapacityNotFound.into()
+				//ChargeFrqTransactionPaymentError::TargetCapacityNotFound.into()
+				TransactionValidityError::Invalid(InvalidTransaction::Payment)
 			);
 		}
 

--- a/pallets/frequency-tx-payment/src/tests/pallet_tests.rs
+++ b/pallets/frequency-tx-payment/src/tests/pallet_tests.rs
@@ -552,10 +552,11 @@ fn withdraw_fee_returns_custom_error_when_the_account_key_does_not_have_the_requ
 			let call: &<Test as Config>::RuntimeCall =
 				&RuntimeCall::Balances(BalancesCall::transfer { dest: 2, value: 100 });
 
-			let expected_err = TransactionValidityError::Invalid(InvalidTransaction::Custom(
-				ChargeFrqTransactionPaymentError::BelowMinDeposit as u8,
-			));
+			// let expected_err = TransactionValidityError::Invalid(InvalidTransaction::Custom(
+			// 	ChargeFrqTransactionPaymentError::BelowMinDeposit as u8,
+			// ));
 
+			let expected_err = TransactionValidityError::Invalid(InvalidTransaction::Payment);
 			assert_withdraw_fee_result(account_id, call, Some(expected_err));
 		});
 }

--- a/pallets/frequency-tx-payment/src/tests/pallet_tests.rs
+++ b/pallets/frequency-tx-payment/src/tests/pallet_tests.rs
@@ -552,10 +552,6 @@ fn withdraw_fee_returns_custom_error_when_the_account_key_does_not_have_the_requ
 			let call: &<Test as Config>::RuntimeCall =
 				&RuntimeCall::Balances(BalancesCall::transfer { dest: 2, value: 100 });
 
-			// let expected_err = TransactionValidityError::Invalid(InvalidTransaction::Custom(
-			// 	ChargeFrqTransactionPaymentError::BelowMinDeposit as u8,
-			// ));
-
 			let expected_err = TransactionValidityError::Invalid(InvalidTransaction::Payment);
 			assert_withdraw_fee_result(account_id, call, Some(expected_err));
 		});

--- a/runtime/frequency/src/lib.rs
+++ b/runtime/frequency/src/lib.rs
@@ -263,7 +263,7 @@ pub const VERSION: RuntimeVersion = RuntimeVersion {
 	spec_name: create_runtime_str!("frequency-rococo"),
 	impl_name: create_runtime_str!("frequency"),
 	authoring_version: 1,
-	spec_version: 53,
+	spec_version: 54,
 	impl_version: 0,
 	apis: RUNTIME_API_VERSIONS,
 	transaction_version: 1,

--- a/runtime/frequency/src/lib.rs
+++ b/runtime/frequency/src/lib.rs
@@ -249,7 +249,7 @@ pub const VERSION: RuntimeVersion = RuntimeVersion {
 	spec_name: create_runtime_str!("frequency"),
 	impl_name: create_runtime_str!("frequency"),
 	authoring_version: 1,
-	spec_version: 53,
+	spec_version: 54,
 	impl_version: 0,
 	apis: RUNTIME_API_VERSIONS,
 	transaction_version: 1,


### PR DESCRIPTION
# Goal
The goal of this PR is to return descriptive error for some capacity related checks
* return `Payment` error in places of `BelowMinDeposit` and `TargetCapacityNotFound` to better catch errors at client side

Closes #1680 

# Discussion
<!-- List discussion items -->

# Checklist
- [x] Chain spec updated
- [ ] Custom RPC OR Runtime API added/changed? Updated js/api-augment.
- [ ] Design doc(s) updated
- [ ] Tests added
- [ ] Benchmarks added
- [ ] Weights updated
