### PR TITLE
fix: relect complete delegation revocation in individual schema revoked_at block numbers

### DIFF
--- a/pallets/msa/src/lib.rs
+++ b/pallets/msa/src/lib.rs
@@ -1329,7 +1329,13 @@ impl<T: Config> Pallet<T> {
 
 		let mut schema_list = Vec::new();
 		for (schema_id, revoked_at) in schema_permissions {
-			schema_list.push(SchemaGrant { schema_id, revoked_at });
+			let mut actual_revoked_at = revoked_at;
+			if provider_info.revoked_at > T::BlockNumber::zero() &&
+				(revoked_at > provider_info.revoked_at || revoked_at == T::BlockNumber::zero())
+			{
+				actual_revoked_at = provider_info.revoked_at;
+			}
+			schema_list.push(SchemaGrant { schema_id, revoked_at: actual_revoked_at });
 		}
 		Ok(Some(schema_list))
 	}


### PR DESCRIPTION
# Goal
The goal of this PR is to properly relect the revocation of a complete delegation when the RPC returns individual schema grants `revoked_at`

Closes #1682 

# Discussion
<!-- List discussion items -->

# Checklist
- [ ] Chain spec updated
- [ ] Custom RPC OR Runtime API added/changed? Updated js/api-augment.
- [ ] Design doc(s) updated
- [x] Tests added
- [ ] Benchmarks added
- [ ] Weights updated
