### PR TITLE
--ws-external is still required on the old node for testing

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -561,6 +561,7 @@ jobs:
               --rpc-external \
               --rpc-cors=all \
               --rpc-methods=Unsafe \
+              --ws-external \
               --no-telemetry \
               --no-prometheus \
               --reserved-only \


### PR DESCRIPTION
# Goal
The goal of this PR is to allow the metadata CI job to pass using the old params