### PR TITLE
Changelog generation fix

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -689,10 +689,11 @@ jobs:
       - name: Sanitize Changelog
         id: sanitize-changelog
         shell: bash
+        env:
+          CHANGELOG: ${{steps.build-changelog.outputs.changelog}}
         run: |
-          changelog='${{steps.build-changelog.outputs.changelog}}'
           echo "-------------------------------------------------"
-          clean="${changelog//[\`\[\]$'\n']/}"
+          clean="${CHANGELOG//[\`\[\]$'\n']/}"
           echo "sanitized: $clean"
           echo "sanitized=$clean" >> $GITHUB_OUTPUT
       - name: Get Polkadot Version


### PR DESCRIPTION
Moving the assignment of the variable to an env so that it doesn't break on quotes

Tested: https://github.com/LibertyDSNP/frequency/actions/runs/6352301627