### PR TITLE
Feat/split stake extrinsic #1699

### DIFF
--- a/integration-tests/capacity/replenishment.test.ts
+++ b/integration-tests/capacity/replenishment.test.ts
@@ -101,7 +101,7 @@ describe("Capacity Replenishment Testing: ", function () {
       // new user/msa stakes to provider
       const userKeys = createKeys("userKeys");
       await fundKeypair(devAccounts[0].keys, userKeys, 5n * DOLLARS);
-      let [_, events] = await ExtrinsicHelper.stake(userKeys, stakeProviderId, userStakeAmt, 'MaximumCapacity').fundAndSend();
+      let [_, events] = await ExtrinsicHelper.stake(userKeys, stakeProviderId, userStakeAmt).fundAndSend();
       assertEvent(events, 'system.ExtrinsicSuccess');
 
       const payload = JSON.stringify({ changeType: 1, fromId: 1, objectId: 2 })
@@ -125,7 +125,7 @@ describe("Capacity Replenishment Testing: ", function () {
       assert(remainingCapacity < callCapacityCost);
 
       // user stakes tiny additional amount
-      [_, events] = await ExtrinsicHelper.stake(userKeys, stakeProviderId, userIncrementAmt, 'MaximumCapacity').fundAndSend();
+      [_, events] = await ExtrinsicHelper.stake(userKeys, stakeProviderId, userIncrementAmt).fundAndSend();
       assertEvent(events, 'capacity.Staked');
 
       // provider can now send a message

--- a/integration-tests/capacity/staking.test.ts
+++ b/integration-tests/capacity/staking.test.ts
@@ -295,6 +295,8 @@ describe("Capacity Staking Tests", function () {
     describe('provider_boost()', async () => {
         let stakeKeys: KeyringPair;
         let stakeProviderId: u64;
+        let capacityBoostMin: bigint = capacityMin/ 20n; // 5% of the amount
+
         before(async function () {
             stakeKeys = createKeys("StakeKeysProvider");
             stakeProviderId = await createMsaAndProvider(stakeKeys, "SPBoost", accountBalance);
@@ -309,11 +311,10 @@ describe("Capacity Staking Tests", function () {
 
             // Confirm that the capacity was added to the stakeProviderId using the query API
             const capacityStaked = (await firstValueFrom(ExtrinsicHelper.api.query.capacity.capacityLedger(stakeProviderId))).unwrap();
-            assert.equal(capacityStaked.remainingCapacity, capacityMin, `expected capacityLedger.remainingCapacity = 1CENT, got ${capacityStaked.remainingCapacity}`);
+            assert.equal(capacityStaked.remainingCapacity, capacityBoostMin, `expected capacityLedger.remainingCapacity = 1CENT, got ${capacityStaked.remainingCapacity}`);
             assert.equal(capacityStaked.totalTokensStaked, tokenMinStake, `expected capacityLedger.totalTokensStaked = 1CENT, got ${capacityStaked.totalTokensStaked}`);
-            assert.equal(capacityStaked.totalCapacityIssued, capacityMin, `expected capacityLedger.totalCapacityIssued = 1CENT, got ${capacityStaked.totalCapacityIssued}`);
+            assert.equal(capacityStaked.totalCapacityIssued, capacityBoostMin, `expected capacityLedger.totalCapacityIssued = 1CENT, got ${capacityStaked.totalCapacityIssued}`);
             trackedFrozenBalance += tokenMinStake;
-
         })
     })
 })

--- a/integration-tests/capacity/transactions.test.ts
+++ b/integration-tests/capacity/transactions.test.ts
@@ -513,7 +513,7 @@ describe("Capacity Transactions", function () {
       it("fails to pay with Capacity for a non-capacity transaction", async function () {
         const capacityKeys = createKeys("CapacityKeys");
         const capacityProvider = await createMsaAndProvider(capacityKeys, "CapacityProvider", FUNDS_AMOUNT);
-        const nonCapacityTxn = ExtrinsicHelper.stake(capacityKeys, capacityProvider, 1n * CENTS, 'MaximumCapacity');
+        const nonCapacityTxn = ExtrinsicHelper.stake(capacityKeys, capacityProvider, 1n * CENTS);
         await assert.rejects(nonCapacityTxn.payWithCapacity(), {
           name: "RpcError", message:
             "1010: Invalid Transaction: Custom error: 0"

--- a/integration-tests/package-lock.json
+++ b/integration-tests/package-lock.json
@@ -259,7 +259,7 @@
         "node_modules/@frequency-chain/api-augment": {
             "version": "0.0.0",
             "resolved": "file:../js/api-augment/dist/frequency-chain-api-augment-0.0.0.tgz",
-            "integrity": "sha512-oPd4GeewH1pNeLWolIIkscWimFxOzm0FIMrr0ZQjahG2HMkh7iiWwreEjEqVzxGKhNuMlin2YPj2LXQBc5kCkg==",
+            "integrity": "sha512-sP0CWaMuAZJOt5OF3LZ+yx4Rxdf8xc0Gh3nUdkYm+4KBXrwOlM89ae9NaNMxxoCktDChv3Bqf+qacd4hZewwjw==",
             "license": "Apache-2.0",
             "dependencies": {
                 "@polkadot/api": "^10.9.1",

--- a/integration-tests/scaffolding/extrinsicHelpers.ts
+++ b/integration-tests/scaffolding/extrinsicHelpers.ts
@@ -384,8 +384,12 @@ export class ExtrinsicHelper {
     public static setEpochLength(keys: KeyringPair, epoch_length: any): Extrinsic {
         return new Extrinsic(() => ExtrinsicHelper.api.tx.capacity.setEpochLength(epoch_length), keys, ExtrinsicHelper.api.events.capacity.EpochLengthUpdated);
     }
-    public static stake(keys: KeyringPair, target: any, amount: any, stakingType: 'MaximumCapacity' | 'ProviderBoost'): Extrinsic {
-        return new Extrinsic(() => ExtrinsicHelper.api.tx.capacity.stake(target, amount, stakingType), keys, ExtrinsicHelper.api.events.capacity.Staked);
+    public static stake(keys: KeyringPair, target: any, amount: any): Extrinsic {
+        return new Extrinsic(() => ExtrinsicHelper.api.tx.capacity.stake(target, amount), keys, ExtrinsicHelper.api.events.capacity.Staked);
+    }
+
+    public static provider_boost(keys: KeyringPair, target: any, amount: any): Extrinsic {
+        return new Extrinsic(() => ExtrinsicHelper.api.tx.capacity.provider_boost(target, amount), keys, ExtrinsicHelper.api.events.capacity.ProviderBoosted);
     }
 
     public static unstake(keys: KeyringPair, target: any, amount: any): Extrinsic {

--- a/integration-tests/scaffolding/extrinsicHelpers.ts
+++ b/integration-tests/scaffolding/extrinsicHelpers.ts
@@ -388,8 +388,8 @@ export class ExtrinsicHelper {
         return new Extrinsic(() => ExtrinsicHelper.api.tx.capacity.stake(target, amount), keys, ExtrinsicHelper.api.events.capacity.Staked);
     }
 
-    public static provider_boost(keys: KeyringPair, target: any, amount: any): Extrinsic {
-        return new Extrinsic(() => ExtrinsicHelper.api.tx.capacity.provider_boost(target, amount), keys, ExtrinsicHelper.api.events.capacity.ProviderBoosted);
+    public static providerBoost(keys: KeyringPair, target: any, amount: any): Extrinsic {
+        return new Extrinsic(() => ExtrinsicHelper.api.tx.capacity.providerBoost(target, amount), keys, ExtrinsicHelper.api.events.capacity.ProviderBoosted);
     }
 
     public static unstake(keys: KeyringPair, target: any, amount: any): Extrinsic {

--- a/integration-tests/scaffolding/helpers.ts
+++ b/integration-tests/scaffolding/helpers.ts
@@ -288,7 +288,7 @@ export async function stakeToProvider(keys: KeyringPair, providerId: u64, tokens
   }
 }
 export async function boostProvider(keys: KeyringPair, providerId: u64, tokensToStake: bigint): Promise<void> {
-  const stakeOp = ExtrinsicHelper.provider_boost(keys, providerId, tokensToStake);
+  const stakeOp = ExtrinsicHelper.providerBoost(keys, providerId, tokensToStake);
   const [stakeEvent] = await stakeOp.fundAndSend();
   assert.notEqual(stakeEvent, undefined, 'stakeToProvider: should have returned Stake event');
 
@@ -412,7 +412,7 @@ export async function getOrCreateAvroChatMessageItemizedSchema(): Promise<u16> {
 }
 
 export const TokenPerCapacity = 50n;
-export const BoostAdjustment = 5n;
+export const BoostAdjustment = 20n;  // divide by 20 or 5% of Maximum Capacity
 
 export function assertEvent(events: EventMap, eventName: string) {
   assert(events.hasOwnProperty(eventName));

--- a/pallets/capacity/src/benchmarking.rs
+++ b/pallets/capacity/src/benchmarking.rs
@@ -69,11 +69,10 @@ benchmarks! {
 		let amount: BalanceOf<T> = T::MinimumStakingAmount::get();
 		let capacity: BalanceOf<T> = Capacity::<T>::capacity_generated(amount);
 		let target = 1;
-		let staking_type = StakingType::MaximumCapacity;
 
 		register_provider::<T>(target, "Foo");
 
-	}: _ (RawOrigin::Signed(caller.clone()), target, amount, staking_type)
+	}: _ (RawOrigin::Signed(caller.clone()), target, amount)
 	verify {
 		assert!(StakingAccountLedger::<T>::contains_key(&caller));
 		assert!(StakingTargetLedger::<T>::contains_key(&caller, target));
@@ -165,6 +164,22 @@ benchmarks! {
 			to_msa,
 			amount: restake_amount.into()
 		}.into());
+	}
+
+	provider_boost {
+		let caller: T::AccountId = create_funded_account::<T>("account", SEED, 105u32);
+		let amount: BalanceOf<T> = T::MinimumStakingAmount::get();
+		let capacity: BalanceOf<T> = Capacity::<T>::capacity_generated(amount);
+		let target = 1;
+
+		register_provider::<T>(target, "Foo");
+
+	}: _ (RawOrigin::Signed(caller.clone()), target, amount)
+	verify {
+		assert!(StakingAccountLedger::<T>::contains_key(&caller));
+		assert!(StakingTargetLedger::<T>::contains_key(&caller, target));
+		assert!(CapacityLedger::<T>::contains_key(target));
+		assert_last_event::<T>(Event::<T>::ProviderBoosted {account: caller, amount, target, capacity}.into());
 	}
 
 	impl_benchmark_test_suite!(Capacity,

--- a/pallets/capacity/src/tests/change_staking_target_tests.rs
+++ b/pallets/capacity/src/tests/change_staking_target_tests.rs
@@ -164,18 +164,8 @@ fn check_retarget_multiple_stakers() {
 
 		setup_provider(&staker_10k, &from_msa, &647u64, ProviderBoost);
 		setup_provider(&staker_500, &to_msa, &293u64, ProviderBoost);
-		assert_ok!(Capacity::stake(
-			RuntimeOrigin::signed(staker_600.clone()),
-			from_msa,
-			479u64,
-			MaximumCapacity
-		));
-		assert_ok!(Capacity::stake(
-			RuntimeOrigin::signed(staker_400.clone()),
-			to_msa,
-			211u64,
-			MaximumCapacity
-		));
+		assert_ok!(Capacity::stake(RuntimeOrigin::signed(staker_600.clone()), from_msa, 479u64,));
+		assert_ok!(Capacity::stake(RuntimeOrigin::signed(staker_400.clone()), to_msa, 211u64,));
 
 		// 647 * .1 * .05 = 3 (rounded down)
 		// 293 * .1 * .05 = 1 (rounded down)
@@ -204,12 +194,7 @@ fn do_retarget_deletes_staking_target_details_if_zero_balance() {
 
 		// stake additional to provider from another Msa, doesn't matter which type.
 		// total staked to from_msa is now 22u64.
-		assert_ok!(Capacity::stake(
-			RuntimeOrigin::signed(300u64),
-			from_msa,
-			12u64,
-			MaximumCapacity
-		));
+		assert_ok!(Capacity::stake(RuntimeOrigin::signed(300u64), from_msa, 12u64,));
 
 		assert_ok!(Capacity::do_retarget(&staker, &from_msa, &to_msa, &amount, &MaximumCapacity));
 
@@ -362,11 +347,10 @@ fn change_staking_target_test_parametric_validity() {
 		setup_provider(&from_account, &from_target, &staked_amount, ProviderBoost);
 		setup_provider(&from_account, &to_target, &staked_amount, ProviderBoost);
 
-		assert_ok!(Capacity::stake(
+		assert_ok!(Capacity::provider_boost(
 			RuntimeOrigin::signed(from_account),
 			from_target,
 			staked_amount,
-			ProviderBoost
 		));
 
 		struct TestCase {

--- a/pallets/capacity/src/tests/stake_and_deposit_tests.rs
+++ b/pallets/capacity/src/tests/stake_and_deposit_tests.rs
@@ -86,6 +86,35 @@ fn provider_boost_works() {
 }
 
 #[test]
+fn calling_stake_on_provider_boost_target_errors() {
+	new_test_ext().execute_with(|| {
+		let account = 600;
+		let target: MessageSourceId = 1;
+		let amount = 200;
+		register_provider(target, String::from("Bear"));
+		assert_ok!(Capacity::provider_boost(RuntimeOrigin::signed(account), target, amount));
+		assert_noop!(
+			Capacity::stake(RuntimeOrigin::signed(account), target, 50),
+			Error::<Test>::CannotChangeStakingType
+		);
+	})
+}
+#[test]
+fn calling_provider_boost_on_staked_target_errors() {
+	new_test_ext().execute_with(|| {
+		let account = 600;
+		let target: MessageSourceId = 1;
+		let amount = 200;
+		register_provider(target, String::from("Foobear"));
+		assert_ok!(Capacity::stake(RuntimeOrigin::signed(account), target, amount));
+		assert_noop!(
+			Capacity::provider_boost(RuntimeOrigin::signed(account), target, 50),
+			Error::<Test>::CannotChangeStakingType
+		);
+	})
+}
+
+#[test]
 fn stake_errors_invalid_target_when_target_is_not_registered_provider() {
 	new_test_ext().execute_with(|| {
 		let account = 100;

--- a/pallets/capacity/src/tests/testing_utils.rs
+++ b/pallets/capacity/src/tests/testing_utils.rs
@@ -72,7 +72,6 @@ pub fn setup_provider(
 	amount: &u64,
 	staking_type: StakingType,
 ) {
-	// TODO: use provider_boost if staking_type is ProviderBoost
 	let provider_name = String::from("Cst-") + target.to_string().as_str();
 	register_provider(*target, provider_name);
 	if amount.gt(&0u64) {

--- a/pallets/capacity/src/tests/unstaking_tests.rs
+++ b/pallets/capacity/src/tests/unstaking_tests.rs
@@ -1,10 +1,7 @@
 use super::{mock::*, testing_utils::*};
 use crate as pallet_capacity;
 use crate::{CapacityDetails, StakingAccountDetails, StakingTargetDetails, UnlockChunk};
-use common_primitives::{
-	capacity::{StakingType, StakingType::MaximumCapacity},
-	msa::MessageSourceId,
-};
+use common_primitives::{capacity::StakingType, msa::MessageSourceId};
 use frame_support::{assert_noop, assert_ok, traits::Get};
 use pallet_capacity::{BalanceOf, Config, Error, Event};
 use sp_core::bounded::BoundedVec;
@@ -20,12 +17,7 @@ fn unstake_happy_path() {
 
 		register_provider(target, String::from("Test Target"));
 
-		assert_ok!(Capacity::stake(
-			RuntimeOrigin::signed(token_account),
-			target,
-			staking_amount,
-			MaximumCapacity
-		));
+		assert_ok!(Capacity::stake(RuntimeOrigin::signed(token_account), target, staking_amount,));
 		assert_ok!(Capacity::unstake(
 			RuntimeOrigin::signed(token_account),
 			target,
@@ -101,12 +93,7 @@ fn unstake_errors_unstaking_amount_is_zero() {
 
 		register_provider(target, String::from("Test Target"));
 
-		assert_ok!(Capacity::stake(
-			RuntimeOrigin::signed(token_account),
-			target,
-			staking_amount,
-			MaximumCapacity
-		));
+		assert_ok!(Capacity::stake(RuntimeOrigin::signed(token_account), target, staking_amount,));
 		assert_noop!(
 			Capacity::unstake(RuntimeOrigin::signed(token_account), target, unstaking_amount),
 			Error::<Test>::UnstakedAmountIsZero
@@ -124,12 +111,7 @@ fn unstake_errors_max_unlocking_chunks_exceeded() {
 
 		register_provider(target, String::from("Test Target"));
 
-		assert_ok!(Capacity::stake(
-			RuntimeOrigin::signed(token_account),
-			target,
-			staking_amount,
-			MaximumCapacity
-		));
+		assert_ok!(Capacity::stake(RuntimeOrigin::signed(token_account), target, staking_amount,));
 
 		for _n in 0..<Test as pallet_capacity::Config>::MaxUnlockingChunks::get() {
 			assert_ok!(Capacity::unstake(
@@ -156,12 +138,7 @@ fn unstake_errors_amount_to_unstake_exceeds_amount_staked() {
 
 		register_provider(target, String::from("Test Target"));
 
-		assert_ok!(Capacity::stake(
-			RuntimeOrigin::signed(token_account),
-			target,
-			staking_amount,
-			MaximumCapacity
-		));
+		assert_ok!(Capacity::stake(RuntimeOrigin::signed(token_account), target, staking_amount,));
 		assert_noop!(
 			Capacity::unstake(RuntimeOrigin::signed(token_account), target, unstaking_amount),
 			Error::<Test>::InsufficientStakingBalance

--- a/pallets/capacity/src/weights.rs
+++ b/pallets/capacity/src/weights.rs
@@ -56,6 +56,8 @@ pub trait WeightInfo {
 	fn unstake() -> Weight;
 	fn set_epoch_length() -> Weight;
 	fn change_staking_target() -> Weight;
+
+	fn provider_boost() -> Weight;
 }
 
 /// Weights for pallet_capacity using the Substrate node and recommended hardware.
@@ -146,6 +148,13 @@ impl<T: frame_system::Config> WeightInfo for SubstrateWeight<T> {
 		Weight::from_parts(1_000_000, 0)
 			.saturating_add(T::DbWeight::get().writes(1_u64))
 	}
+
+	/// Storage:
+	/// Proof:
+	fn provider_boost() -> Weight {
+		Weight::from_parts(1_000_000, 0)
+			.saturating_add(T::DbWeight::get().writes(1_u64))
+	}
 }
 
 // For backwards compatibility and tests
@@ -232,6 +241,13 @@ impl WeightInfo for () {
 	/// Storage:
 	/// Proof:
 	fn change_staking_target() -> Weight {
+		Weight::from_parts(1_000_000, 0)
+			.saturating_add(RocksDbWeight::get().writes(1_u64))
+	}
+
+	/// Storage:
+	/// Proof:
+	fn provider_boost() -> Weight {
 		Weight::from_parts(1_000_000, 0)
 			.saturating_add(RocksDbWeight::get().writes(1_u64))
 	}


### PR DESCRIPTION
# Goal
The goal of this PR is to split the `stake` extrinsic into two: `stake` and `provider_boost` 

Closes #1707 

# Discussion
* `stake` now always stakes MaximumCapacity type,
* `provider_boost` always stakes ProviderBoost type.
* Tests have been adjusted to account for this
* Tests have been added to validate behavior specific to each type and also that disallowing changing staking types is still working.

# Checklist
- [x] Tests added
- [x] Benchmarks added
- [x] Weights updated
