### PR TITLE
CI Fix: Prior release now uses the new cli arguments

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -561,7 +561,6 @@ jobs:
               --rpc-external \
               --rpc-cors=all \
               --rpc-methods=Unsafe \
-              --ws-external \
               --no-telemetry \
               --no-prometheus \
               --reserved-only \


### PR DESCRIPTION
Now that v1.8.0 is out using the new CLI arguments, we need to make the ref-node use the new CLI as well.