### PR TITLE
fix: typo: remove extra } from publish-ci-base-image job

### DIFF
--- a/.github/workflows/merge-pr.yml
+++ b/.github/workflows/merge-pr.yml
@@ -114,5 +114,5 @@ jobs:
           tags: |
             ${{steps.repo_slug.outputs.result}}/${{env.IMAGE_NAME}}:${{env.BRANCH_NAME}}
             ${{steps.repo_slug.outputs.result}}/${{env.IMAGE_NAME}}:latest
-            ${{steps.repo_slug.outputs.result}}/${{env.IMAGE_NAME}}:${{env.IMAGE_VERSION}}}
+            ${{steps.repo_slug.outputs.result}}/${{env.IMAGE_NAME}}:${{env.IMAGE_VERSION}}
           build-args: IMAGE_VERSION=${{env.IMAGE_VERSION}}


### PR DESCRIPTION
# Goal
The goal of this PR is fix a typo in merge-pr.yml.
