### PR TITLE
e2e testing improvements

### DIFF
--- a/e2e/capacity/replenishment.test.ts
+++ b/e2e/capacity/replenishment.test.ts
@@ -103,8 +103,8 @@ describe("Capacity Replenishment Testing: ", function () {
       // new user/msa stakes to provider
       const userKeys = createKeys("userKeys");
       await fundKeypair(fundingSource, userKeys, 5n * DOLLARS);
-      let [_, events] = await ExtrinsicHelper.stake(userKeys, stakeProviderId, userStakeAmt).fundAndSend(fundingSource);
-      assertEvent(events, 'system.ExtrinsicSuccess');
+      const { eventMap } = await ExtrinsicHelper.stake(userKeys, stakeProviderId, userStakeAmt).fundAndSend(fundingSource);
+      assertEvent(eventMap, 'system.ExtrinsicSuccess');
 
       const payload = JSON.stringify({ changeType: 1, fromId: 1, objectId: 2 })
       const call = ExtrinsicHelper.addOnChainMessage(stakeKeys, schemaId, payload);
@@ -127,12 +127,12 @@ describe("Capacity Replenishment Testing: ", function () {
       assert(remainingCapacity < callCapacityCost);
 
       // user stakes tiny additional amount
-      [_, events] = await ExtrinsicHelper.stake(userKeys, stakeProviderId, userIncrementAmt).fundAndSend(fundingSource);
-      assertEvent(events, 'capacity.Staked');
+      const { eventMap: hasStaked } = await ExtrinsicHelper.stake(userKeys, stakeProviderId, userIncrementAmt).fundAndSend(fundingSource);
+      assertEvent(hasStaked, 'capacity.Staked');
 
       // provider can now send a message
-      [_, events] = await call.payWithCapacity(-1);
-      assertEvent(events, 'capacity.CapacityWithdrawn');
+      const { eventMap: hasCapacityWithdrawn } = await call.payWithCapacity(-1);
+      assertEvent(hasCapacityWithdrawn, 'capacity.CapacityWithdrawn');
 
       remainingCapacity = (await getRemainingCapacity(stakeProviderId)).toBigInt();
       // show that capacity was replenished and then fee deducted.

--- a/e2e/handles/handles.test.ts
+++ b/e2e/handles/handles.test.ts
@@ -70,7 +70,7 @@ describe("🤝 Handles", () => {
         /// Check chain to getNextSuffixesForHandle
 
         it("should be able to claim a handle and check suffix (=suffix_assumed if available on chain)", async function () {
-            const handle = "test1";
+            const handle = "test-" + Math.random().toFixed(10).toString().replaceAll("0.", "");
             let handle_bytes = new Bytes(ExtrinsicHelper.api.registry, handle);
             /// Get presumptive suffix from chain (rpc)
             let suffixes_response = await ExtrinsicHelper.getNextSuffixesForHandle(handle, 10);

--- a/e2e/handles/handles.test.ts
+++ b/e2e/handles/handles.test.ts
@@ -27,7 +27,7 @@ describe("🤝 Handles", () => {
 
     describe("@Claim Handle", () => {
         it("should be able to claim a handle", async function () {
-            const handle = "test_handle";
+            let handle = "test_handle";
             let currentBlock = await getBlockNumber();
             const handle_vec = new Bytes(ExtrinsicHelper.api.registry, handle);
             const payload = {
@@ -36,12 +36,10 @@ describe("🤝 Handles", () => {
             }
             const claimHandlePayload = ExtrinsicHelper.api.registry.createType("CommonPrimitivesHandlesClaimHandlePayload", payload);
             const claimHandle = ExtrinsicHelper.claimHandle(msaOwnerKeys, claimHandlePayload);
-            const [event] = await claimHandle.fundAndSend(fundingSource);
+            const { target: event } = await claimHandle.fundAndSend(fundingSource);
             assert.notEqual(event, undefined, "claimHandle should return an event");
-            if (event && claimHandle.api.events.handles.HandleClaimed.is(event)) {
-                let handle = event.data.handle.toString();
-                assert.notEqual(handle, "", "claimHandle should emit a handle");
-            }
+            handle = event!.data.handle.toString();
+            assert.notEqual(handle, "", "claimHandle should emit a handle");
         });
     });
 
@@ -61,12 +59,10 @@ describe("🤝 Handles", () => {
             await ExtrinsicHelper.runToBlock(currentBlock + expirationOffset + 1); // Must be at least 1 > original expiration
 
             const retireHandle = ExtrinsicHelper.retireHandle(msaOwnerKeys);
-            const [event] = await retireHandle.fundAndSend(fundingSource);
+            const { target: event } = await retireHandle.fundAndSend(fundingSource);
             assert.notEqual(event, undefined, "retireHandle should return an event");
-            if (event && retireHandle.api.events.handles.HandleRetired.is(event)) {
-                let handle = event.data.handle.toString();
-                assert.notEqual(handle, "", "retireHandle should return the correct handle");
-            }
+            const handle = event!.data.handle.toString();
+            assert.notEqual(handle, "", "retireHandle should return the correct handle");
         });
     });
 
@@ -74,7 +70,7 @@ describe("🤝 Handles", () => {
         /// Check chain to getNextSuffixesForHandle
 
         it("should be able to claim a handle and check suffix (=suffix_assumed if available on chain)", async function () {
-            const handle = "test1";
+            let handle = "test1";
             let handle_bytes = new Bytes(ExtrinsicHelper.api.registry, handle);
             /// Get presumptive suffix from chain (rpc)
             let suffixes_response = await ExtrinsicHelper.getNextSuffixesForHandle(handle, 10);
@@ -91,12 +87,10 @@ describe("🤝 Handles", () => {
             };
             const claimHandlePayload = ExtrinsicHelper.api.registry.createType("CommonPrimitivesHandlesClaimHandlePayload", payload_ext);
             const claimHandle = ExtrinsicHelper.claimHandle(msaOwnerKeys, claimHandlePayload);
-            const [event] = await claimHandle.fundAndSend(fundingSource);
+            const { target: event } = await claimHandle.fundAndSend(fundingSource);
             assert.notEqual(event, undefined, "claimHandle should return an event");
-            if (event && claimHandle.api.events.handles.HandleClaimed.is(event)) {
-                let handle = event.data.handle.toString();
-                assert.notEqual(handle, "", "claimHandle should emit a handle");
-            }
+            handle = event!.data.handle.toString();
+            assert.notEqual(handle, "", "claimHandle should emit a handle");
             // get handle using msa (rpc)
             let handle_response = await ExtrinsicHelper.getHandleForMSA(msa_id);
             if (!handle_response.isSome) {
@@ -135,7 +129,7 @@ describe("🤝 Handles", () => {
             await ExtrinsicHelper.runToBlock(currentBlock + expirationOffset + 1);
             try {
                 const retireHandle = ExtrinsicHelper.retireHandle(msaOwnerKeys);
-                const [event] = await retireHandle.fundAndSend(fundingSource);
+                const { target: event } = await retireHandle.fundAndSend(fundingSource);
                 assert.equal(event, undefined, "retireHandle should not return an event");
             }
             catch (e) {

--- a/e2e/handles/handles.test.ts
+++ b/e2e/handles/handles.test.ts
@@ -70,7 +70,7 @@ describe("🤝 Handles", () => {
         /// Check chain to getNextSuffixesForHandle
 
         it("should be able to claim a handle and check suffix (=suffix_assumed if available on chain)", async function () {
-            let handle = "test1";
+            const handle = "test1";
             let handle_bytes = new Bytes(ExtrinsicHelper.api.registry, handle);
             /// Get presumptive suffix from chain (rpc)
             let suffixes_response = await ExtrinsicHelper.getNextSuffixesForHandle(handle, 10);
@@ -89,8 +89,9 @@ describe("🤝 Handles", () => {
             const claimHandle = ExtrinsicHelper.claimHandle(msaOwnerKeys, claimHandlePayload);
             const { target: event } = await claimHandle.fundAndSend(fundingSource);
             assert.notEqual(event, undefined, "claimHandle should return an event");
-            handle = event!.data.handle.toString();
-            assert.notEqual(handle, "", "claimHandle should emit a handle");
+            const displayHandle = event!.data.handle.toUtf8();
+            assert.notEqual(displayHandle, "", "claimHandle should emit a handle");
+
             // get handle using msa (rpc)
             let handle_response = await ExtrinsicHelper.getHandleForMSA(msa_id);
             if (!handle_response.isSome) {
@@ -103,13 +104,10 @@ describe("🤝 Handles", () => {
             assert.equal(suffix, suffix_assumed, "suffix should be equal to suffix_assumed");
 
             /// Get MSA from full display handle (rpc)
-            let display_handle = handle + "." + suffix;
-            let msa_option = await ExtrinsicHelper.getMsaForHandle(display_handle);
-            if (!msa_option.isSome) {
-                throw new Error("msa_option should be Some");
-            }
-            let msa_from_handle = msa_option.unwrap();
-            assert.equal(msa_from_handle.toString(), msa_id.toString(), "msa_from_handle should be equal to msa_id");
+            const msaOption = await ExtrinsicHelper.getMsaForHandle(displayHandle);
+            assert(msaOption.isSome, "msaOption should be Some");
+            const msaFromHandle = msaOption.unwrap();
+            assert.equal(msaFromHandle.toString(), msa_id.toString(), "msaFromHandle should be equal to msa_id");
         });
     });
 

--- a/e2e/messages/addIPFSMessage.test.ts
+++ b/e2e/messages/addIPFSMessage.test.ts
@@ -7,11 +7,10 @@ import { PARQUET_BROADCAST } from "../schemas/fixtures/parquetBroadcastSchemaTyp
 import assert from "assert";
 import { createAndFundKeypair } from "../scaffolding/helpers";
 import { ExtrinsicHelper } from "../scaffolding/extrinsicHelpers";
-import { u16, u32 } from "@polkadot/types";
+import { u16 } from "@polkadot/types";
 import { firstValueFrom } from "rxjs";
 import { MessageResponse } from "@frequency-chain/api-augment/interfaces";
 import { ipfsCid } from "./ipfs";
-import { isDev } from "../scaffolding/env";
 import { getFundingSource } from "../scaffolding/funding";
 
 describe("Add Offchain Message", function () {
@@ -20,7 +19,6 @@ describe("Add Offchain Message", function () {
     let keys: KeyringPair;
     let schemaId: u16;
     let dummySchemaId: u16;
-    let messageBlockNumber: u32;
 
     let ipfs_cid_64: string;
     let ipfs_cid_32: string;
@@ -43,17 +41,13 @@ describe("Add Offchain Message", function () {
 
         // Create a schema for IPFS
         const createSchema = ExtrinsicHelper.createSchema(keys, PARQUET_BROADCAST, "Parquet", "IPFS");
-        const [event] = await createSchema.fundAndSend(fundingSource);
-        if (event && createSchema.api.events.schemas.SchemaCreated.is(event)) {
-            [, schemaId] = event.data;
-        }
+        const { target: event } = await createSchema.fundAndSend(fundingSource);
+        schemaId = event!.data.schemaId;
 
         // Create a dummy on-chain schema
         const createDummySchema = ExtrinsicHelper.createSchema(keys, { type: "record", name: "Dummy on-chain schema", fields: [] }, "AvroBinary", "OnChain");
-        const [dummySchemaEvent] = await createDummySchema.fundAndSend(fundingSource);
-        if (dummySchemaEvent && createDummySchema.api.events.schemas.SchemaCreated.is(dummySchemaEvent)) {
-            [, dummySchemaId] = dummySchemaEvent.data;
-        }
+        const { target: dummySchemaEvent } = await createDummySchema.fundAndSend(fundingSource);
+        dummySchemaId = dummySchemaEvent!.data.schemaId;
     });
 
     it('should fail if insufficient funds', async function () {
@@ -99,14 +93,11 @@ describe("Add Offchain Message", function () {
 
     it("should successfully add an IPFS message", async function () {
         const f = ExtrinsicHelper.addIPFSMessage(keys, schemaId, ipfs_cid_64, ipfs_payload_len);
-        const [event] = await f.fundAndSend(fundingSource);
+        const { target: event } = await f.fundAndSend(fundingSource);
 
         assert.notEqual(event, undefined, "should have returned a MessagesStored event");
-        if (event && f.api.events.messages.MessagesStored.is(event)) {
-            messageBlockNumber = event.data.blockNumber;
-            assert.deepEqual(event.data.schemaId, schemaId, 'schema ids should be equal');
-            assert.notEqual(event.data.blockNumber, undefined, 'should have a block number');
-        }
+        assert.deepEqual(event?.data.schemaId, schemaId, 'schema ids should be equal');
+        assert.notEqual(event?.data.blockNumber, undefined, 'should have a block number');
     });
 
     it("should successfully retrieve added message and returned CID should have Base32 encoding", async function () {
@@ -119,14 +110,11 @@ describe("Add Offchain Message", function () {
     describe("Add OnChain Message and successfully retrieve it", function () {
         it("should successfully add and retrieve an onchain message", async function () {
             const f = ExtrinsicHelper.addOnChainMessage(keys, dummySchemaId, "0xdeadbeef");
-            const [event] = await f.fundAndSend(fundingSource);
+            const { target: event } = await f.fundAndSend(fundingSource);
 
             assert.notEqual(event, undefined, "should have returned a MessagesStored event");
-            if (event && f.api.events.messages.MessagesStored.is(event)) {
-                messageBlockNumber = event.data.blockNumber;
-                assert.deepEqual(event.data.schemaId, dummySchemaId, 'schema ids should be equal');
-                assert.notEqual(event.data.blockNumber, undefined, 'should have a block number');
-            }
+            assert.deepEqual(event?.data.schemaId, dummySchemaId, 'schema ids should be equal');
+            assert.notEqual(event?.data.blockNumber, undefined, 'should have a block number');
 
             const get = await firstValueFrom(ExtrinsicHelper.api.rpc.messages.getBySchemaId(
                     dummySchemaId,

--- a/e2e/miscellaneous/utilityBatch.test.ts
+++ b/e2e/miscellaneous/utilityBatch.test.ts
@@ -23,7 +23,7 @@ describe("Utility Batch Filtering", function () {
         goodBatch.push(ExtrinsicHelper.api.tx.system.remark("Hello From Batch"))
         goodBatch.push(ExtrinsicHelper.api.tx.msa.create())
         const batch = ExtrinsicHelper.executeUtilityBatchAll(sender, goodBatch);
-        const [event, eventMap] = await batch.fundAndSend(fundingSource);
+        const { target: event, eventMap } = await batch.fundAndSend(fundingSource);
         assert.notEqual(event, undefined, "should return an event");
         assert.notEqual(eventMap, undefined, "should return an eventMap");
     });
@@ -60,7 +60,7 @@ describe("Utility Batch Filtering", function () {
 
         // batch
         const batch = ExtrinsicHelper.executeUtilityBatch(sender, badBatch);
-        let [ok, eventMap] = await batch.fundAndSend(fundingSource);
+        const { target: ok, eventMap } = await batch.fundAndSend(fundingSource);
         assert.equal(ok, undefined, "should not return an ok event");
         assert.equal(eventMap["utility.BatchCompleted"], undefined, "should not return a batch completed event");
         assert.notEqual(eventMap["utility.BatchInterrupted"], undefined, "should return a batch interrupted event");
@@ -76,7 +76,7 @@ describe("Utility Batch Filtering", function () {
 
         // forceBatch
         const forceBatch = ExtrinsicHelper.executeUtilityForceBatch(sender, badBatch);
-        let [ok, eventMap] = await forceBatch.fundAndSend(fundingSource);
+        const { target: ok, eventMap } = await forceBatch.fundAndSend(fundingSource);
         assert.equal(ok, undefined, "should not return an ok event");
         assert.equal(eventMap["utility.BatchCompleted"], undefined, "should not return a batch completed event");
         assert.notEqual(eventMap["utility.BatchCompletedWithErrors"], undefined, "should return a batch completed with error event");

--- a/e2e/miscellaneous/utilityBatch.test.ts
+++ b/e2e/miscellaneous/utilityBatch.test.ts
@@ -1,7 +1,7 @@
 import assert from "assert";
 import { KeyringPair } from "@polkadot/keyring/types";
 import { ExtrinsicHelper } from "../scaffolding/extrinsicHelpers";
-import { createAndFundKeypair } from "../scaffolding/helpers";
+import { createAndFundKeypair, getNonce } from "../scaffolding/helpers";
 import { ApiTypes, SubmittableExtrinsic } from "@polkadot/api/types";
 import { getFundingSource } from "../scaffolding/funding";
 
@@ -12,8 +12,9 @@ describe("Utility Batch Filtering", function () {
     const fundingSource = getFundingSource("misc-util-batch");
 
     before(async function () {
-        sender = await createAndFundKeypair(fundingSource, 50_000_000n);
-        recipient = await createAndFundKeypair(fundingSource, 50_000_000n);
+        let nonce = await getNonce(fundingSource);
+        sender = await createAndFundKeypair(fundingSource, 50_000_000n, "utility-sender", nonce++);
+        recipient = await createAndFundKeypair(fundingSource, 50_000_000n, "utility-recipient", nonce++);
     });
 
     it("should successfully execute ✅ batch with allowed calls", async function () {

--- a/e2e/msa/createMsa.test.ts
+++ b/e2e/msa/createMsa.test.ts
@@ -22,15 +22,13 @@ describe("Create Accounts", function () {
 
         it("should successfully create an MSA account", async function () {
             const f = ExtrinsicHelper.createMsa(keys);
-            const [msaCreatedEvent, chainEvents] = await f.fundAndSend(fundingSource);
+            const { target: msaCreatedEvent, eventMap: chainEvents } = await f.fundAndSend(fundingSource);
 
             assert.notEqual(chainEvents["system.ExtrinsicSuccess"], undefined, "should have returned an ExtrinsicSuccess event");
             assert.notEqual(msaCreatedEvent, undefined, "should have returned  an MsaCreated event");
             assert.notEqual(chainEvents["transactionPayment.TransactionFeePaid"], undefined, "should have returned a TransactionFeePaid event");
 
-            if (msaCreatedEvent && ExtrinsicHelper.api.events.msa.MsaCreated.is(msaCreatedEvent)) {
-                msaId = msaCreatedEvent.data.msaId;
-            }
+            msaId = msaCreatedEvent!.data.msaId;
         });
 
         it("should fail to create an MSA for a keypair already associated with an MSA", async function () {
@@ -142,7 +140,7 @@ describe("Create Accounts", function () {
             newSig = signPayloadSr25519(authorizedKeys[0], addKeyData);
             const addPublicKeyOp = ExtrinsicHelper.addPublicKeyToMsa(keys, ownerSig, newSig, payload);
 
-            const [publicKeyEvents] = await addPublicKeyOp.fundAndSend(fundingSource);
+            const { target: publicKeyEvents } = await addPublicKeyOp.fundAndSend(fundingSource);
 
             assert.notEqual(publicKeyEvents, undefined, 'should have added public key');
 
@@ -171,7 +169,7 @@ describe("Create Accounts", function () {
             ownerSig = signPayloadSr25519(authorizedKeys[0], addKeyData);
             newSig = signPayloadSr25519(additionalKeys, addKeyData);
             const op = ExtrinsicHelper.addPublicKeyToMsa(authorizedKeys[0], ownerSig, newSig, newPayload);
-            const [event] = await op.fundAndSend(fundingSource);
+            const { target: event } = await op.fundAndSend(fundingSource);
             assert.notEqual(event, undefined, 'should have added public key');
             authorizedKeys.push(additionalKeys);
         });
@@ -233,7 +231,7 @@ describe("Create Accounts", function () {
         it("should delete all other authorized keys", async function () {
             for (const key of authorizedKeys) {
                 const op = ExtrinsicHelper.deletePublicKey(keys, key.publicKey);
-                const [event] = await op.fundAndSend(fundingSource);
+                const { target: event } = await op.fundAndSend(fundingSource);
                 assert.notEqual(event, undefined, "should have returned PublicKeyDeleted event");
             };
             authorizedKeys = [];
@@ -241,7 +239,7 @@ describe("Create Accounts", function () {
 
         it("should allow retiring MSA after additional keys have been deleted", async function () {
             const retireMsaOp = ExtrinsicHelper.retireMsa(keys);
-            const [event, eventMap] = await retireMsaOp.fundAndSend(fundingSource);
+            const { target: event, eventMap } = await retireMsaOp.fundAndSend(fundingSource);
 
             assert.notEqual(eventMap["msa.PublicKeyDeleted"], undefined, 'should have deleted public key (retired)');
             assert.notEqual(event, undefined, 'should have retired msa');

--- a/e2e/scaffolding/extrinsicHelpers.ts
+++ b/e2e/scaffolding/extrinsicHelpers.ts
@@ -1,20 +1,19 @@
 import { ApiPromise, ApiRx } from "@polkadot/api";
 import { ApiTypes, AugmentedEvent, SubmittableExtrinsic } from "@polkadot/api/types";
 import { KeyringPair } from "@polkadot/keyring/types";
-import {Compact, u128, u16, u32, u64, Vec, Option, Bool} from "@polkadot/types";
+import { Compact, u128, u16, u32, u64, Vec, Option, Bool } from "@polkadot/types";
 import { FrameSystemAccountInfo, SpRuntimeDispatchError } from "@polkadot/types/lookup";
 import { AnyNumber, AnyTuple, Codec, IEvent, ISubmittableResult } from "@polkadot/types/types";
-import {firstValueFrom, filter, map, pipe, tap} from "rxjs";
+import { firstValueFrom, filter, map, pipe, tap } from "rxjs";
 import { getBlockNumber, getExistentialDeposit, log, Sr25519Signature } from "./helpers";
 import { connect, connectPromise } from "./apiConnection";
-import { CreatedBlock, DispatchError, Event, SignedBlock } from "@polkadot/types/interfaces";
+import { DispatchError, Event, SignedBlock } from "@polkadot/types/interfaces";
 import { IsEvent } from "@polkadot/types/metadata/decorate/types";
 import { HandleResponse, ItemizedStoragePageResponse, MessageSourceId, PaginatedStorageResponse, PresumptiveSuffixesResponse, SchemaResponse } from "@frequency-chain/api-augment/interfaces";
 import { u8aToHex } from "@polkadot/util/u8a/toHex";
 import { u8aWrapBytes } from "@polkadot/util";
 import type { Call } from '@polkadot/types/interfaces/runtime';
 import { hasRelayChain } from "./env";
-import { getFundingSource } from "./funding";
 
 export type ReleaseSchedule = {
     start: number;
@@ -60,7 +59,7 @@ export class EventError extends Error {
     }
 }
 
-export type EventMap = { [key: string]: Event }
+export type EventMap = Record<string, Event>;
 
 function eventKey(event: Event): string {
     return `${event.section}.${event.method}`;
@@ -93,14 +92,16 @@ function eventKey(event: Event): string {
  */
 
 type ParsedEvent<C extends Codec[] = Codec[], N = unknown> = IEvent<C, N>;
-export type ParsedEventResult<C extends Codec[] = Codec[], N = unknown> = [ParsedEvent<C, N> | undefined, EventMap];
+export type ParsedEventResult<C extends Codec[] = Codec[], N = unknown> = {
+    target?: ParsedEvent<C, N>;
+    eventMap: EventMap;
+};
 
 
-export class Extrinsic<T extends ISubmittableResult = ISubmittableResult, C extends Codec[] = Codec[], N = unknown> {
+export class Extrinsic<N = unknown, T extends ISubmittableResult = ISubmittableResult, C extends Codec[] = Codec[]> {
 
     private event?: IsEvent<C, N>;
     private extrinsic: () => SubmittableExtrinsic<"rxjs", T>;
-    // private call: Call;
     private keys: KeyringPair;
     public api: ApiRx;
 
@@ -111,21 +112,21 @@ export class Extrinsic<T extends ISubmittableResult = ISubmittableResult, C exte
         this.api = ExtrinsicHelper.api;
     }
 
-    public signAndSend(nonce?: number): Promise<ParsedEventResult> {
-        return firstValueFrom(this.extrinsic().signAndSend(this.keys, {nonce: nonce}).pipe(
+    public signAndSend(nonce?: number) {
+        return firstValueFrom(this.extrinsic().signAndSend(this.keys, { nonce: nonce }).pipe(
             filter(({ status }) => status.isInBlock || status.isFinalized),
             this.parseResult(this.event),
         ))
     }
 
-    public sudoSignAndSend(): Promise<[ParsedEvent<C, N> | undefined, EventMap]> {
+    public sudoSignAndSend() {
         return firstValueFrom(this.api.tx.sudo.sudo(this.extrinsic()).signAndSend(this.keys).pipe(
             filter(({ status }) => status.isInBlock || status.isFinalized),
             this.parseResult(this.event),
         ))
     }
 
-    public payWithCapacity(nonce?: number): Promise<ParsedEventResult> {
+    public payWithCapacity(nonce?: number) {
         return firstValueFrom(this.api.tx.frequencyTxPayment.payWithCapacity(this.extrinsic()).signAndSend(this.keys, { nonce }).pipe(
             filter(({ status }) => status.isInBlock || status.isFinalized),
             this.parseResult(this.event),
@@ -151,7 +152,7 @@ export class Extrinsic<T extends ISubmittableResult = ISubmittableResult, C exte
         }
     }
 
-    public async fundAndSend(source: KeyringPair): Promise<ParsedEventResult> {
+    public async fundAndSend(source: KeyringPair) {
         await this.fundOperation(source);
         log("Fund and Send", `Fund Source: ${source.address}`);
         return this.signAndSend();
@@ -166,33 +167,33 @@ export class Extrinsic<T extends ISubmittableResult = ISubmittableResult, C exte
                     throw err;
                 }
             }),
-            map((result: ISubmittableResult) => result.events.reduce((acc, { event }) => {
-                acc[eventKey(event)] = event;
-                if (targetEvent && targetEvent.is(event)) {
-                    acc["defaultEvent"] = event;
+            map((result: ISubmittableResult) => {
+                const eventMap = result.events.reduce((acc, { event }) => {
+                    acc[eventKey(event)] = event;
+                    if (this.api.events.sudo.Sudid.is(event)) {
+                        let { data: [result] } = event;
+                        if (result.isErr) {
+                            let err = new EventError(result.asErr);
+                            log(err.toString());
+                            throw err;
+                        }
+                    }
+                    return acc;
+                }, {} as EventMap);
+
+                const target = targetEvent && result.events.find(({ event }) => targetEvent.is(event))?.event;
+                // Required for Typescript to be happy
+                if (target && targetEvent.is(target)) {
+                    return { target, eventMap };
                 }
-                if(this.api.events.sudo.Sudid.is(event)) {
-                  let { data: [result] } = event;
-                  if (result.isErr) {
-                    let err = new EventError(result.asErr);
-                    log(err.toString());
-                    throw err;
-                  }
-                }
-                return acc;
-            }, {} as EventMap)),
-            map((em) => {
-                let result: ParsedEventResult<T, N> = [undefined, {}];
-                if (targetEvent && targetEvent.is(em?.defaultEvent)) {
-                    result[0] = em.defaultEvent;
-                }
-                result[1] = em;
-                return result;
+
+                return { eventMap };
             }),
-            tap((events) => log(events)),
+            tap(({ eventMap }) => {
+                Object.entries(eventMap).map(([k, v]) => log(k, v.toHuman()));
+            }),
         );
     }
-
 }
 
 export class ExtrinsicHelper {
@@ -225,26 +226,26 @@ export class ExtrinsicHelper {
     }
 
     /** Balance Extrinsics */
-    public static transferFunds(source: KeyringPair, dest: KeyringPair, amount: Compact<u128> | AnyNumber): Extrinsic {
+    public static transferFunds(source: KeyringPair, dest: KeyringPair, amount: Compact<u128> | AnyNumber) {
         return new Extrinsic(() => ExtrinsicHelper.api.tx.balances.transferKeepAlive(dest.address, amount), source, ExtrinsicHelper.api.events.balances.Transfer);
     }
 
-    public static emptyAccount(source: KeyringPair, dest: KeyringPair["address"]): Extrinsic {
+    public static emptyAccount(source: KeyringPair, dest: KeyringPair["address"]) {
         return new Extrinsic(() => ExtrinsicHelper.api.tx.balances.transferAll(dest, false), source, ExtrinsicHelper.api.events.balances.Transfer);
     }
 
     /** Schema Extrinsics */
-    public static createSchema(keys: KeyringPair, model: any, modelType: "AvroBinary" | "Parquet", payloadLocation: "OnChain" | "IPFS" | "Itemized" | "Paginated"): Extrinsic {
+    public static createSchema(keys: KeyringPair, model: any, modelType: "AvroBinary" | "Parquet", payloadLocation: "OnChain" | "IPFS" | "Itemized" | "Paginated") {
         return new Extrinsic(() => ExtrinsicHelper.api.tx.schemas.createSchema(JSON.stringify(model), modelType, payloadLocation), keys, ExtrinsicHelper.api.events.schemas.SchemaCreated);
     }
 
-  /** Schema v2 Extrinsics */
-  public static createSchemaV2(keys: KeyringPair, model: any, modelType: "AvroBinary" | "Parquet", payloadLocation: "OnChain" | "IPFS" | "Itemized" | "Paginated", grant: ("AppendOnly"| "SignatureRequired")[]): Extrinsic {
-    return new Extrinsic(() => ExtrinsicHelper.api.tx.schemas.createSchemaV2(JSON.stringify(model), modelType, payloadLocation, grant), keys, ExtrinsicHelper.api.events.schemas.SchemaCreated);
-  }
+    /** Schema v2 Extrinsics */
+    public static createSchemaV2(keys: KeyringPair, model: any, modelType: "AvroBinary" | "Parquet", payloadLocation: "OnChain" | "IPFS" | "Itemized" | "Paginated", grant: ("AppendOnly" | "SignatureRequired")[]) {
+        return new Extrinsic(() => ExtrinsicHelper.api.tx.schemas.createSchemaV2(JSON.stringify(model), modelType, payloadLocation, grant), keys, ExtrinsicHelper.api.events.schemas.SchemaCreated);
+    }
 
     /** Generic Schema Extrinsics */
-    public static createSchemaWithSettingsGov(keys: KeyringPair, model: any, modelType: "AvroBinary" | "Parquet", payloadLocation: "OnChain" | "IPFS"| "Itemized" | "Paginated", grant: "AppendOnly"| "SignatureRequired"): Extrinsic {
+    public static createSchemaWithSettingsGov(keys: KeyringPair, model: any, modelType: "AvroBinary" | "Parquet", payloadLocation: "OnChain" | "IPFS" | "Itemized" | "Paginated", grant: "AppendOnly" | "SignatureRequired") {
         return new Extrinsic(() => ExtrinsicHelper.api.tx.schemas.createSchemaViaGovernance(keys.publicKey, JSON.stringify(model), modelType, payloadLocation, [grant]), keys, ExtrinsicHelper.api.events.schemas.SchemaCreated);
     }
 
@@ -254,91 +255,91 @@ export class ExtrinsicHelper {
     }
 
     /** MSA Extrinsics */
-    public static createMsa(keys: KeyringPair): Extrinsic {
+    public static createMsa(keys: KeyringPair) {
         return new Extrinsic(() => ExtrinsicHelper.api.tx.msa.create(), keys, ExtrinsicHelper.api.events.msa.MsaCreated);
     }
 
-    public static addPublicKeyToMsa(keys: KeyringPair, ownerSignature: Sr25519Signature, newSignature: Sr25519Signature, payload: AddKeyData): Extrinsic {
+    public static addPublicKeyToMsa(keys: KeyringPair, ownerSignature: Sr25519Signature, newSignature: Sr25519Signature, payload: AddKeyData) {
         return new Extrinsic(() => ExtrinsicHelper.api.tx.msa.addPublicKeyToMsa(keys.publicKey, ownerSignature, newSignature, payload), keys, ExtrinsicHelper.api.events.msa.PublicKeyAdded);
     }
 
-    public static deletePublicKey(keys: KeyringPair, publicKey: Uint8Array): Extrinsic {
+    public static deletePublicKey(keys: KeyringPair, publicKey: Uint8Array) {
         ExtrinsicHelper.api.query.msa
         return new Extrinsic(() => ExtrinsicHelper.api.tx.msa.deleteMsaPublicKey(publicKey), keys, ExtrinsicHelper.api.events.msa.PublicKeyDeleted);
     }
 
-    public static retireMsa(keys: KeyringPair): Extrinsic {
+    public static retireMsa(keys: KeyringPair) {
         return new Extrinsic(() => ExtrinsicHelper.api.tx.msa.retireMsa(), keys, ExtrinsicHelper.api.events.msa.MsaRetired);
     }
 
-    public static createProvider(keys: KeyringPair, providerName: string): Extrinsic {
+    public static createProvider(keys: KeyringPair, providerName: string) {
         return new Extrinsic(() => ExtrinsicHelper.api.tx.msa.createProvider(providerName), keys, ExtrinsicHelper.api.events.msa.ProviderCreated);
     }
 
-    public static createSponsoredAccountWithDelegation(delegatorKeys: KeyringPair, providerKeys: KeyringPair, signature: Sr25519Signature, payload: AddProviderPayload): Extrinsic {
+    public static createSponsoredAccountWithDelegation(delegatorKeys: KeyringPair, providerKeys: KeyringPair, signature: Sr25519Signature, payload: AddProviderPayload) {
         return new Extrinsic(() => ExtrinsicHelper.api.tx.msa.createSponsoredAccountWithDelegation(delegatorKeys.publicKey, signature, payload), providerKeys, ExtrinsicHelper.api.events.msa.MsaCreated);
     }
 
-    public static grantDelegation(delegatorKeys: KeyringPair, providerKeys: KeyringPair, signature: Sr25519Signature, payload: AddProviderPayload): Extrinsic {
+    public static grantDelegation(delegatorKeys: KeyringPair, providerKeys: KeyringPair, signature: Sr25519Signature, payload: AddProviderPayload) {
         return new Extrinsic(() => ExtrinsicHelper.api.tx.msa.grantDelegation(delegatorKeys.publicKey, signature, payload), providerKeys, ExtrinsicHelper.api.events.msa.DelegationGranted);
     }
 
-    public static grantSchemaPermissions(delegatorKeys: KeyringPair, providerMsaId: any, schemaIds: any): Extrinsic {
+    public static grantSchemaPermissions(delegatorKeys: KeyringPair, providerMsaId: any, schemaIds: any) {
         return new Extrinsic(() => ExtrinsicHelper.api.tx.msa.grantSchemaPermissions(providerMsaId, schemaIds), delegatorKeys, ExtrinsicHelper.api.events.msa.DelegationUpdated);
     }
 
-    public static revokeSchemaPermissions(delegatorKeys: KeyringPair, providerMsaId: any, schemaIds: any): Extrinsic {
+    public static revokeSchemaPermissions(delegatorKeys: KeyringPair, providerMsaId: any, schemaIds: any) {
         return new Extrinsic(() => ExtrinsicHelper.api.tx.msa.revokeSchemaPermissions(providerMsaId, schemaIds), delegatorKeys, ExtrinsicHelper.api.events.msa.DelegationUpdated);
     }
 
-    public static revokeDelegationByDelegator(keys: KeyringPair, providerMsaId: any): Extrinsic {
+    public static revokeDelegationByDelegator(keys: KeyringPair, providerMsaId: any) {
         return new Extrinsic(() => ExtrinsicHelper.api.tx.msa.revokeDelegationByDelegator(providerMsaId), keys, ExtrinsicHelper.api.events.msa.DelegationRevoked);
     }
 
-    public static revokeDelegationByProvider(delegatorMsaId: u64, providerKeys: KeyringPair): Extrinsic {
+    public static revokeDelegationByProvider(delegatorMsaId: u64, providerKeys: KeyringPair) {
         return new Extrinsic(() => ExtrinsicHelper.api.tx.msa.revokeDelegationByProvider(delegatorMsaId), providerKeys, ExtrinsicHelper.api.events.msa.DelegationRevoked);
     }
 
     /** Messages Extrinsics */
-    public static addIPFSMessage(keys: KeyringPair, schemaId: any, cid: string, payload_length: number): Extrinsic {
+    public static addIPFSMessage(keys: KeyringPair, schemaId: any, cid: string, payload_length: number) {
         return new Extrinsic(() => ExtrinsicHelper.api.tx.messages.addIpfsMessage(schemaId, cid, payload_length), keys, ExtrinsicHelper.api.events.messages.MessagesStored);
     }
 
     /** Stateful Storage Extrinsics */
-    public static applyItemActions(keys: KeyringPair, schemaId: any, msa_id: MessageSourceId, actions: any, target_hash: any): Extrinsic {
-        return new Extrinsic(() => ExtrinsicHelper.api.tx.statefulStorage.applyItemActions(msa_id, schemaId, target_hash,actions), keys, ExtrinsicHelper.api.events.statefulStorage.ItemizedPageUpdated);
+    public static applyItemActions(keys: KeyringPair, schemaId: any, msa_id: MessageSourceId, actions: any, target_hash: any) {
+        return new Extrinsic(() => ExtrinsicHelper.api.tx.statefulStorage.applyItemActions(msa_id, schemaId, target_hash, actions), keys, ExtrinsicHelper.api.events.statefulStorage.ItemizedPageUpdated);
     }
 
-    public static removePage(keys: KeyringPair, schemaId: any, msa_id: MessageSourceId, page_id: any, target_hash: any): Extrinsic {
+    public static removePage(keys: KeyringPair, schemaId: any, msa_id: MessageSourceId, page_id: any, target_hash: any) {
         return new Extrinsic(() => ExtrinsicHelper.api.tx.statefulStorage.deletePage(msa_id, schemaId, page_id, target_hash), keys, ExtrinsicHelper.api.events.statefulStorage.PaginatedPageDeleted);
     }
 
-    public static upsertPage(keys: KeyringPair, schemaId: any, msa_id: MessageSourceId, page_id: any, payload: any, target_hash: any): Extrinsic {
+    public static upsertPage(keys: KeyringPair, schemaId: any, msa_id: MessageSourceId, page_id: any, payload: any, target_hash: any) {
         return new Extrinsic(() => ExtrinsicHelper.api.tx.statefulStorage.upsertPage(msa_id, schemaId, page_id, target_hash, payload), keys, ExtrinsicHelper.api.events.statefulStorage.PaginatedPageUpdated);
     }
 
-    public static applyItemActionsWithSignature(delegatorKeys: KeyringPair, providerKeys: KeyringPair, signature: Sr25519Signature, payload: ItemizedSignaturePayload): Extrinsic {
-      return new Extrinsic(() => ExtrinsicHelper.api.tx.statefulStorage.applyItemActionsWithSignature(delegatorKeys.publicKey, signature, payload), providerKeys, ExtrinsicHelper.api.events.statefulStorage.ItemizedPageUpdated);
+    public static applyItemActionsWithSignature(delegatorKeys: KeyringPair, providerKeys: KeyringPair, signature: Sr25519Signature, payload: ItemizedSignaturePayload) {
+        return new Extrinsic(() => ExtrinsicHelper.api.tx.statefulStorage.applyItemActionsWithSignature(delegatorKeys.publicKey, signature, payload), providerKeys, ExtrinsicHelper.api.events.statefulStorage.ItemizedPageUpdated);
     }
 
-    public static applyItemActionsWithSignatureV2(delegatorKeys: KeyringPair, providerKeys: KeyringPair, signature: Sr25519Signature, payload: ItemizedSignaturePayloadV2): Extrinsic {
-      return new Extrinsic(() => ExtrinsicHelper.api.tx.statefulStorage.applyItemActionsWithSignatureV2(delegatorKeys.publicKey, signature, payload), providerKeys, ExtrinsicHelper.api.events.statefulStorage.ItemizedPageUpdated);
+    public static applyItemActionsWithSignatureV2(delegatorKeys: KeyringPair, providerKeys: KeyringPair, signature: Sr25519Signature, payload: ItemizedSignaturePayloadV2) {
+        return new Extrinsic(() => ExtrinsicHelper.api.tx.statefulStorage.applyItemActionsWithSignatureV2(delegatorKeys.publicKey, signature, payload), providerKeys, ExtrinsicHelper.api.events.statefulStorage.ItemizedPageUpdated);
     }
 
-    public static deletePageWithSignature(delegatorKeys: KeyringPair, providerKeys: KeyringPair, signature: Sr25519Signature, payload: PaginatedDeleteSignaturePayload): Extrinsic {
-      return new Extrinsic(() => ExtrinsicHelper.api.tx.statefulStorage.deletePageWithSignature(delegatorKeys.publicKey, signature, payload), providerKeys, ExtrinsicHelper.api.events.statefulStorage.PaginatedPageDeleted);
+    public static deletePageWithSignature(delegatorKeys: KeyringPair, providerKeys: KeyringPair, signature: Sr25519Signature, payload: PaginatedDeleteSignaturePayload) {
+        return new Extrinsic(() => ExtrinsicHelper.api.tx.statefulStorage.deletePageWithSignature(delegatorKeys.publicKey, signature, payload), providerKeys, ExtrinsicHelper.api.events.statefulStorage.PaginatedPageDeleted);
     }
 
-    public static deletePageWithSignatureV2(delegatorKeys: KeyringPair, providerKeys: KeyringPair, signature: Sr25519Signature, payload: PaginatedDeleteSignaturePayloadV2): Extrinsic {
-      return new Extrinsic(() => ExtrinsicHelper.api.tx.statefulStorage.deletePageWithSignatureV2(delegatorKeys.publicKey, signature, payload), providerKeys, ExtrinsicHelper.api.events.statefulStorage.PaginatedPageDeleted);
+    public static deletePageWithSignatureV2(delegatorKeys: KeyringPair, providerKeys: KeyringPair, signature: Sr25519Signature, payload: PaginatedDeleteSignaturePayloadV2) {
+        return new Extrinsic(() => ExtrinsicHelper.api.tx.statefulStorage.deletePageWithSignatureV2(delegatorKeys.publicKey, signature, payload), providerKeys, ExtrinsicHelper.api.events.statefulStorage.PaginatedPageDeleted);
     }
 
-    public static upsertPageWithSignature(delegatorKeys: KeyringPair, providerKeys: KeyringPair, signature: Sr25519Signature, payload: PaginatedUpsertSignaturePayload): Extrinsic {
-      return new Extrinsic(() => ExtrinsicHelper.api.tx.statefulStorage.upsertPageWithSignature(delegatorKeys.publicKey, signature, payload), providerKeys, ExtrinsicHelper.api.events.statefulStorage.PaginatedPageUpdated);
+    public static upsertPageWithSignature(delegatorKeys: KeyringPair, providerKeys: KeyringPair, signature: Sr25519Signature, payload: PaginatedUpsertSignaturePayload) {
+        return new Extrinsic(() => ExtrinsicHelper.api.tx.statefulStorage.upsertPageWithSignature(delegatorKeys.publicKey, signature, payload), providerKeys, ExtrinsicHelper.api.events.statefulStorage.PaginatedPageUpdated);
     }
 
-    public static upsertPageWithSignatureV2(delegatorKeys: KeyringPair, providerKeys: KeyringPair, signature: Sr25519Signature, payload: PaginatedUpsertSignaturePayloadV2): Extrinsic {
-      return new Extrinsic(() => ExtrinsicHelper.api.tx.statefulStorage.upsertPageWithSignatureV2(delegatorKeys.publicKey, signature, payload), providerKeys, ExtrinsicHelper.api.events.statefulStorage.PaginatedPageUpdated);
+    public static upsertPageWithSignatureV2(delegatorKeys: KeyringPair, providerKeys: KeyringPair, signature: Sr25519Signature, payload: PaginatedUpsertSignaturePayloadV2) {
+        return new Extrinsic(() => ExtrinsicHelper.api.tx.statefulStorage.upsertPageWithSignatureV2(delegatorKeys.publicKey, signature, payload), providerKeys, ExtrinsicHelper.api.events.statefulStorage.PaginatedPageUpdated);
     }
 
     public static getItemizedStorage(msa_id: MessageSourceId, schemaId: any): Promise<ItemizedStoragePageResponse> {
@@ -349,16 +350,16 @@ export class ExtrinsicHelper {
         return firstValueFrom(ExtrinsicHelper.api.rpc.statefulStorage.getPaginatedStorage(msa_id, schemaId));
     }
 
-    public static timeReleaseTransfer(keys: KeyringPair, who: KeyringPair, schedule: ReleaseSchedule): Extrinsic {
+    public static timeReleaseTransfer(keys: KeyringPair, who: KeyringPair, schedule: ReleaseSchedule) {
         return new Extrinsic(() => ExtrinsicHelper.api.tx.timeRelease.transfer(who.address, schedule), keys, ExtrinsicHelper.api.events.timeRelease.ReleaseScheduleAdded);
     }
 
-    public static claimHandle(delegatorKeys: KeyringPair, payload: any): Extrinsic {
+    public static claimHandle(delegatorKeys: KeyringPair, payload: any) {
         const proof = { Sr25519: u8aToHex(delegatorKeys.sign(u8aWrapBytes(payload.toU8a()))) }
         return new Extrinsic(() => ExtrinsicHelper.api.tx.handles.claimHandle(delegatorKeys.publicKey, proof, payload), delegatorKeys, ExtrinsicHelper.api.events.handles.HandleClaimed);
     }
 
-    public static retireHandle(delegatorKeys: KeyringPair): Extrinsic {
+    public static retireHandle(delegatorKeys: KeyringPair) {
         return new Extrinsic(() => ExtrinsicHelper.api.tx.handles.retireHandle(), delegatorKeys, ExtrinsicHelper.api.events.handles.HandleRetired);
     }
 
@@ -368,8 +369,7 @@ export class ExtrinsicHelper {
     }
 
     public static getMsaForHandle(handle: string): Promise<Option<MessageSourceId>> {
-        let msa_response = ExtrinsicHelper.api.rpc.handles.getMsaForHandle(handle);
-        return firstValueFrom(msa_response);
+        return ExtrinsicHelper.apiPromise.rpc.handles.getMsaForHandle(handle);
     }
 
     public static getNextSuffixesForHandle(base_handle: string, count: number): Promise<PresumptiveSuffixesResponse> {
@@ -378,43 +378,43 @@ export class ExtrinsicHelper {
     }
 
     public static validateHandle(base_handle: string): Promise<Bool> {
-      let validationResult = ExtrinsicHelper.api.rpc.handles.validateHandle(base_handle);
-      return firstValueFrom(validationResult);
+        let validationResult = ExtrinsicHelper.api.rpc.handles.validateHandle(base_handle);
+        return firstValueFrom(validationResult);
     }
 
-    public static addOnChainMessage(keys: KeyringPair, schemaId: any, payload: string): Extrinsic {
+    public static addOnChainMessage(keys: KeyringPair, schemaId: any, payload: string) {
         return new Extrinsic(() => ExtrinsicHelper.api.tx.messages.addOnchainMessage(null, schemaId, payload), keys, ExtrinsicHelper.api.events.messages.MessagesStored);
     }
 
     /** Capacity Extrinsics **/
-    public static setEpochLength(keys: KeyringPair, epoch_length: any): Extrinsic {
+    public static setEpochLength(keys: KeyringPair, epoch_length: any) {
         return new Extrinsic(() => ExtrinsicHelper.api.tx.capacity.setEpochLength(epoch_length), keys, ExtrinsicHelper.api.events.capacity.EpochLengthUpdated);
     }
-    public static stake(keys: KeyringPair, target: any, amount: any): Extrinsic {
+    public static stake(keys: KeyringPair, target: any, amount: any) {
         return new Extrinsic(() => ExtrinsicHelper.api.tx.capacity.stake(target, amount), keys, ExtrinsicHelper.api.events.capacity.Staked);
     }
 
-    public static unstake(keys: KeyringPair, target: any, amount: any): Extrinsic {
+    public static unstake(keys: KeyringPair, target: any, amount: any) {
         return new Extrinsic(() => ExtrinsicHelper.api.tx.capacity.unstake(target, amount), keys, ExtrinsicHelper.api.events.capacity.UnStaked);
     }
 
-    public static withdrawUnstaked(keys: KeyringPair): Extrinsic {
+    public static withdrawUnstaked(keys: KeyringPair) {
         return new Extrinsic(() => ExtrinsicHelper.api.tx.capacity.withdrawUnstaked(), keys, ExtrinsicHelper.api.events.capacity.StakeWithdrawn);
     }
 
-    public static payWithCapacityBatchAll(keys: KeyringPair, calls: any): Extrinsic {
+    public static payWithCapacityBatchAll(keys: KeyringPair, calls: any) {
         return new Extrinsic(() => ExtrinsicHelper.api.tx.frequencyTxPayment.payWithCapacityBatchAll(calls), keys, ExtrinsicHelper.api.events.utility.BatchCompleted);
     }
 
-    public static executeUtilityBatchAll(keys: KeyringPair, calls: any): Extrinsic {
+    public static executeUtilityBatchAll(keys: KeyringPair, calls: any) {
         return new Extrinsic(() => ExtrinsicHelper.api.tx.utility.batchAll(calls), keys, ExtrinsicHelper.api.events.utility.BatchCompleted);
     }
 
-    public static executeUtilityBatch(keys: KeyringPair, calls: any): Extrinsic {
+    public static executeUtilityBatch(keys: KeyringPair, calls: any) {
         return new Extrinsic(() => ExtrinsicHelper.api.tx.utility.batch(calls), keys, ExtrinsicHelper.api.events.utility.BatchCompleted);
     }
 
-    public static executeUtilityForceBatch(keys: KeyringPair, calls: any): Extrinsic {
+    public static executeUtilityForceBatch(keys: KeyringPair, calls: any) {
         return new Extrinsic(() => ExtrinsicHelper.api.tx.utility.forceBatch(calls), keys, ExtrinsicHelper.api.events.utility.BatchCompleted);
     }
 

--- a/e2e/scaffolding/globalHooks.ts
+++ b/e2e/scaffolding/globalHooks.ts
@@ -1,3 +1,5 @@
+// These run ONCE per entire test run
+
 import { cryptoWaitReady } from "@polkadot/util-crypto";
 import workerpool from 'workerpool';
 import { ExtrinsicHelper } from "./extrinsicHelpers";

--- a/e2e/scaffolding/helpers.ts
+++ b/e2e/scaffolding/helpers.ts
@@ -410,8 +410,9 @@ export const TokenPerCapacity = 50n;
 export function assertEvent(events: EventMap, eventName: string) {
   assert(events.hasOwnProperty(eventName));
 }
+
 export async function getRemainingCapacity(providerId: u64): Promise<u128> {
-  const capacityStaked = (await firstValueFrom(ExtrinsicHelper.api.query.capacity.capacityLedger(providerId))).unwrap();
+  const capacityStaked = (await ExtrinsicHelper.apiPromise.query.capacity.capacityLedger(providerId)).unwrap();
   return capacityStaked.remainingCapacity;
 }
 

--- a/e2e/scaffolding/rootHooks.ts
+++ b/e2e/scaffolding/rootHooks.ts
@@ -1,3 +1,5 @@
+// These run once per TEST FILE
+
 import { cryptoWaitReady } from "@polkadot/util-crypto";
 import { ExtrinsicHelper } from "./extrinsicHelpers";
 import { drainFundedKeys } from "./helpers";

--- a/e2e/scenarios/grantDelegation.test.ts
+++ b/e2e/scenarios/grantDelegation.test.ts
@@ -28,37 +28,25 @@ describe("Delegation Scenario Tests", function () {
         [noMsaKeys, keys, otherMsaKeys, providerKeys, otherProviderKeys] = await createAndFundKeypairs(fundingSource, ["noMsaKeys", "keys", "otherMsaKeys", "providerKeys", "otherProviderKeys"]);
 
         const createMsaOp = ExtrinsicHelper.createMsa(keys);
-        let [msaCreatedEvent] = await createMsaOp.fundAndSend(fundingSource);
-        if (msaCreatedEvent && createMsaOp.api.events.msa.MsaCreated.is(msaCreatedEvent)) {
-            msaId = msaCreatedEvent.data.msaId;
-        }
-        assert.notEqual(msaId, undefined, 'setup should populate msaId');
+        let { target: msaCreatedEvent } = await createMsaOp.fundAndSend(fundingSource);
+        msaId = msaCreatedEvent!.data.msaId;
 
-        [msaCreatedEvent] = await ExtrinsicHelper.createMsa(otherMsaKeys).fundAndSend(fundingSource);
-        if (msaCreatedEvent && createMsaOp.api.events.msa.MsaCreated.is(msaCreatedEvent)) {
-            otherMsaId = msaCreatedEvent.data.msaId;
-        }
-        assert.notEqual(otherMsaId, undefined, 'setup should populate otherMsaId');
+        ({ target: msaCreatedEvent } = await ExtrinsicHelper.createMsa(otherMsaKeys).fundAndSend(fundingSource));
+        otherMsaId = msaCreatedEvent!.data.msaId;
 
         let createProviderMsaOp = ExtrinsicHelper.createMsa(providerKeys);
         await createProviderMsaOp.fundAndSend(fundingSource);
         let createProviderOp = ExtrinsicHelper.createProvider(providerKeys, "MyPoster");
-        let [providerEvent] = await createProviderOp.fundAndSend(fundingSource);
+        let { target: providerEvent } = await createProviderOp.fundAndSend(fundingSource);
         assert.notEqual(providerEvent, undefined, "setup should return a ProviderCreated event");
-        if (providerEvent && ExtrinsicHelper.api.events.msa.ProviderCreated.is(providerEvent)) {
-            providerId = providerEvent.data.providerId;
-        }
-        assert.notEqual(providerId, undefined, "setup should populate providerId");
+        providerId = providerEvent!.data.providerId;
 
         createProviderMsaOp = ExtrinsicHelper.createMsa(otherProviderKeys);
         await createProviderMsaOp.fundAndSend(fundingSource);
         createProviderOp = ExtrinsicHelper.createProvider(otherProviderKeys, "MyPoster");
-        [providerEvent] = await createProviderOp.fundAndSend(fundingSource);
+        ({ target: providerEvent } = await createProviderOp.fundAndSend(fundingSource));
         assert.notEqual(providerEvent, undefined, "setup should return a ProviderCreated event");
-        if (providerEvent && ExtrinsicHelper.api.events.msa.ProviderCreated.is(providerEvent)) {
-            otherProviderId = providerEvent.data.providerId;
-        }
-        assert.notEqual(otherProviderId, undefined, "setup should populate providerId");
+        otherProviderId = providerEvent!.data.providerId;
 
         const createSchemaOp = ExtrinsicHelper.createSchema(keys, {
             type: "record",
@@ -92,19 +80,14 @@ describe("Delegation Scenario Tests", function () {
                 },
             ]
         }, "AvroBinary", "OnChain");
-        let [createSchemaEvent] = await createSchemaOp.fundAndSend(fundingSource);
+        let { target: createSchemaEvent } = await createSchemaOp.fundAndSend(fundingSource);
         assert.notEqual(createSchemaEvent, undefined, "setup should return SchemaCreated event");
-        if (createSchemaEvent && ExtrinsicHelper.api.events.schemas.SchemaCreated.is(createSchemaEvent)) {
-            schemaId = createSchemaEvent.data.schemaId;
-        }
-        assert.notEqual(schemaId, undefined, "setup should populate schemaId");
+        schemaId = createSchemaEvent!.data.schemaId;
 
         // Create a second schema
-        [createSchemaEvent] = await createSchemaOp.fundAndSend(fundingSource);
+        ({ target: createSchemaEvent } = await createSchemaOp.fundAndSend(fundingSource));
         assert.notEqual(createSchemaEvent, undefined, "setup should return SchemaCreated event");
-        if (createSchemaEvent && ExtrinsicHelper.api.events.schemas.SchemaCreated.is(createSchemaEvent)) {
-            schemaId2 = createSchemaEvent.data.schemaId;
-        }
+        schemaId2 = createSchemaEvent!.data.schemaId;
     });
 
     describe("delegation grants", function () {
@@ -161,12 +144,10 @@ describe("Delegation Scenario Tests", function () {
             const addProviderData = ExtrinsicHelper.api.registry.createType("PalletMsaAddProvider", payload);
 
             const grantDelegationOp = ExtrinsicHelper.grantDelegation(keys, providerKeys, signPayloadSr25519(keys, addProviderData), payload);
-            const [grantDelegationEvent] = await grantDelegationOp.fundAndSend(fundingSource);
+            const { target: grantDelegationEvent } = await grantDelegationOp.fundAndSend(fundingSource);
             assert.notEqual(grantDelegationEvent, undefined, "should have returned DelegationGranted event");
-            if (grantDelegationEvent && grantDelegationOp.api.events.msa.DelegationGranted.is(grantDelegationEvent)) {
-                assert.deepEqual(grantDelegationEvent.data.providerId, providerId, 'provider IDs should match');
-                assert.deepEqual(grantDelegationEvent.data.delegatorId, msaId, 'delegator IDs should match');
-            }
+            assert.deepEqual(grantDelegationEvent?.data.providerId, providerId, 'provider IDs should match');
+            assert.deepEqual(grantDelegationEvent?.data.delegatorId, msaId, 'delegator IDs should match');
         });
 
         it('initial granted schemas should be correct', async function () {
@@ -185,12 +166,10 @@ describe("Delegation Scenario Tests", function () {
             const addProviderData = ExtrinsicHelper.api.registry.createType("PalletMsaAddProvider", payload);
 
             const grantDelegationOp = ExtrinsicHelper.grantDelegation(keys, providerKeys, signPayloadSr25519(keys, addProviderData), payload);
-            const [grantDelegationEvent] = await grantDelegationOp.fundAndSend(fundingSource);
+            const { target: grantDelegationEvent } = await grantDelegationOp.fundAndSend(fundingSource);
             assert.notEqual(grantDelegationEvent, undefined, "should have returned DelegationGranted event");
-            if (grantDelegationEvent && grantDelegationOp.api.events.msa.DelegationGranted.is(grantDelegationEvent)) {
-                assert.deepEqual(grantDelegationEvent.data.providerId, providerId, 'provider IDs should match');
-                assert.deepEqual(grantDelegationEvent.data.delegatorId, msaId, 'delegator IDs should match');
-            }
+            assert.deepEqual(grantDelegationEvent?.data.providerId, providerId, 'provider IDs should match');
+            assert.deepEqual(grantDelegationEvent?.data.delegatorId, msaId, 'delegator IDs should match');
             let grants = await firstValueFrom(ExtrinsicHelper.api.rpc.msa.grantedSchemaIdsByMsaId(msaId, providerId));
             const grantedSchemaIds = grants.unwrap().filter((grant) => grant.revoked_at.toBigInt() === 0n).map((grant) => grant.schema_id.toNumber());
             const expectedSchemaIds = [schemaId.toNumber(), schemaId2.toNumber()];
@@ -219,11 +198,8 @@ describe("Delegation Scenario Tests", function () {
             }
 
             const sop = ExtrinsicHelper.createSchema(keys, schema, "AvroBinary", "OnChain");
-            const [sevent] = await sop.fundAndSend(fundingSource);
-            let sid: u16 | undefined;
-            if (!!sevent && sop.api.events.schemas.SchemaCreated.is(sevent)) {
-                sid = sevent.data[1];
-            }
+            const { target: sevent } = await sop.fundAndSend(fundingSource);
+            const sid = sevent?.data.schemaId;
             assert.notEqual(sid, undefined, "should have created schema");
 
             const op = ExtrinsicHelper.revokeSchemaPermissions(keys, providerId, [sid]);
@@ -248,12 +224,10 @@ describe("Delegation Scenario Tests", function () {
 
         it("should revoke a delegation by delegator", async function () {
             const revokeDelegationOp = ExtrinsicHelper.revokeDelegationByDelegator(keys, providerId);
-            const [revokeDelegationEvent] = await revokeDelegationOp.fundAndSend(fundingSource);
+            const { target: revokeDelegationEvent } = await revokeDelegationOp.fundAndSend(fundingSource);
             assert.notEqual(revokeDelegationEvent, undefined, "should have returned DelegationRevoked event");
-            if (!!revokeDelegationEvent && revokeDelegationOp.api.events.msa.DelegationRevoked.is(revokeDelegationEvent)) {
-                assert.deepEqual(revokeDelegationEvent.data.providerId, providerId, 'provider ids should be equal');
-                assert.deepEqual(revokeDelegationEvent.data.delegatorId, msaId, 'delegator ids should be equal');
-            }
+            assert.deepEqual(revokeDelegationEvent?.data.providerId, providerId, 'provider ids should be equal');
+            assert.deepEqual(revokeDelegationEvent?.data.delegatorId, msaId, 'delegator ids should be equal');
         });
 
         it("should fail to revoke a delegation that has already been revoked (InvalidDelegation)", async function () {
@@ -272,12 +246,10 @@ describe("Delegation Scenario Tests", function () {
             let revokedAtBlock: bigint;
             async function revokeDelegationByProvider (myMsaId: u64 | undefined) {
               const op = ExtrinsicHelper.revokeDelegationByProvider(myMsaId as u64, providerKeys);
-              const [revokeEvent] = await op.fundAndSend(fundingSource);
+              const { target: revokeEvent } = await op.fundAndSend(fundingSource);
               assert.notEqual(revokeEvent, undefined, "should have returned a DelegationRevoked event");
-              if (revokeEvent && op.api.events.msa.DelegationRevoked.is(revokeEvent)) {
-                assert.deepEqual(revokeEvent.data.delegatorId, myMsaId, 'delegator ids should match');
-                assert.deepEqual(revokeEvent.data.providerId, providerId, 'provider ids should match');
-              }
+              assert.deepEqual(revokeEvent?.data.delegatorId, myMsaId, 'delegator ids should match');
+              assert.deepEqual(revokeEvent?.data.providerId, providerId, 'provider ids should match');
               revokedAtBlock = (await ExtrinsicHelper.apiPromise.rpc.chain.getBlock()).block.header.number.toBigInt()
             }
 
@@ -286,8 +258,8 @@ describe("Delegation Scenario Tests", function () {
                 const payload = await generateDelegationPayload({ authorizedMsaId: providerId, schemaIds: [schemaId] });
                 const addProviderData = ExtrinsicHelper.api.registry.createType("PalletMsaAddProvider", payload);
                 const op = ExtrinsicHelper.createSponsoredAccountWithDelegation(newKeys, providerKeys, signPayloadSr25519(newKeys, addProviderData), payload);
-                const [msaEvent] = await op.fundAndSend(fundingSource);
-                msaId = (msaEvent && op.api.events.msa.MsaCreated.is(msaEvent) ? msaEvent.data.msaId : undefined);
+                const { target: msaEvent } = await op.fundAndSend(fundingSource);
+                msaId = msaEvent?.data.msaId;
                 assert.notEqual(msaId, undefined, 'should have returned an MSA');
             });
 
@@ -302,12 +274,10 @@ describe("Delegation Scenario Tests", function () {
 
             it("should revoke a delegation by provider", async function () {
                 const op = ExtrinsicHelper.revokeDelegationByProvider(msaId as u64, providerKeys);
-                const [revokeEvent] = await op.fundAndSend(fundingSource);
+                const { target: revokeEvent } = await op.fundAndSend(fundingSource);
                 assert.notEqual(revokeEvent, undefined, "should have returned a DelegationRevoked event");
-                if (revokeEvent && op.api.events.msa.DelegationRevoked.is(revokeEvent)) {
-                    assert.deepEqual(revokeEvent.data.delegatorId, msaId, 'delegator ids should match');
-                    assert.deepEqual(revokeEvent.data.providerId, providerId, 'provider ids should match');
-                }
+                assert.deepEqual(revokeEvent?.data.delegatorId, msaId, 'delegator ids should match');
+                assert.deepEqual(revokeEvent?.data.providerId, providerId, 'provider ids should match');
                 revokedAtBlock = (await ExtrinsicHelper.apiPromise.rpc.chain.getBlock()).block.header.number.toBigInt()
             });
 
@@ -330,16 +300,14 @@ describe("Delegation Scenario Tests", function () {
               const payload = await generateDelegationPayload({ authorizedMsaId: providerId, schemaIds: [schemaId] });
               const addProviderData = ExtrinsicHelper.api.registry.createType("PalletMsaAddProvider", payload);
               const op = ExtrinsicHelper.createSponsoredAccountWithDelegation(delegatorKeys, providerKeys, signPayloadSr25519(delegatorKeys, addProviderData), payload);
-              const [msaEvent] = await op.fundAndSend(fundingSource);
-              const newMsaId = (msaEvent && op.api.events.msa.MsaCreated.is(msaEvent) ? msaEvent.data.msaId : undefined);
+              const { target: msaEvent } = await op.fundAndSend(fundingSource);
+              const newMsaId = msaEvent?.data.msaId;
               assert.notEqual(newMsaId, undefined, 'should have returned an MSA');
               await revokeDelegationByProvider(newMsaId);
               const retireMsaOp = ExtrinsicHelper.retireMsa(delegatorKeys);
-              const [retireMsaEvent] = await retireMsaOp.fundAndSend(fundingSource);
+              const { target: retireMsaEvent } = await retireMsaOp.fundAndSend(fundingSource);
               assert.notEqual(retireMsaEvent, undefined, "should have returned MsaRetired event");
-              if (!!retireMsaEvent && retireMsaOp.api.events.msa.MsaRetired.is(retireMsaEvent)) {
-                assert.deepEqual(retireMsaEvent.data.msaId, newMsaId, 'msaId should be equal');
-              }
+              assert.deepEqual(retireMsaEvent?.data.msaId, newMsaId, 'msaId should be equal');
             });
 
           it("should fail to retire msa with any active delegations", async function () {
@@ -347,8 +315,8 @@ describe("Delegation Scenario Tests", function () {
             const payload = await generateDelegationPayload({ authorizedMsaId: providerId, schemaIds: [schemaId] });
             const addProviderData = ExtrinsicHelper.api.registry.createType("PalletMsaAddProvider", payload);
             const op = ExtrinsicHelper.createSponsoredAccountWithDelegation(delegatorKeys, providerKeys, signPayloadSr25519(delegatorKeys, addProviderData), payload);
-            const [msaEvent] = await op.fundAndSend(fundingSource);
-            const newMsaId = (msaEvent && op.api.events.msa.MsaCreated.is(msaEvent) ? msaEvent.data.msaId : undefined);
+            const { target: msaEvent } = await op.fundAndSend(fundingSource);
+            const newMsaId = msaEvent?.data.msaId;
             assert.notEqual(newMsaId, undefined, 'should have returned an MSA');
             const retireMsaOp = ExtrinsicHelper.retireMsa(delegatorKeys);
             await assert.rejects(retireMsaOp.fundAndSend(fundingSource), { name: 'RpcError', message: /Custom error: 6$/ });
@@ -430,7 +398,7 @@ describe("Delegation Scenario Tests", function () {
             const addProviderData = ExtrinsicHelper.api.registry.createType("PalletMsaAddProvider", payload);
 
             op = ExtrinsicHelper.createSponsoredAccountWithDelegation(sponsorKeys, providerKeys, signPayloadSr25519(sponsorKeys, addProviderData), payload);
-            const [event, eventMap] = await op.fundAndSend(fundingSource);
+            const { target: event, eventMap } = await op.fundAndSend(fundingSource);
             assert.notEqual(event, undefined, 'should have returned MsaCreated event');
             assert.notEqual(eventMap["msa.DelegationGranted"], undefined, 'should have returned DelegationGranted event');
             await assert.rejects(op.fundAndSend(fundingSource), { name: 'SignatureAlreadySubmitted' }, "should reject double submission");

--- a/e2e/schemas/createSchema.test.ts
+++ b/e2e/schemas/createSchema.test.ts
@@ -102,7 +102,7 @@ describe("#createSchema", function () {
 
   it("should successfully create an Avro GraphChange schema", async function () {
     const f = ExtrinsicHelper.createSchema(keys, AVRO_GRAPH_CHANGE, "AvroBinary", "OnChain");
-    const [createSchemaEvent, eventMap] = await f.fundAndSend(fundingSource);
+    const { target: createSchemaEvent, eventMap } = await f.fundAndSend(fundingSource);
 
     assertExtrinsicSuccess(eventMap);
     assert.notEqual(createSchemaEvent, undefined);
@@ -110,7 +110,7 @@ describe("#createSchema", function () {
 
   it("should successfully create an Avro GraphChange schema v2", async function () {
     const f = ExtrinsicHelper.createSchemaV2(keys, AVRO_GRAPH_CHANGE, "AvroBinary", "OnChain", []);
-    const [createSchemaEvent, eventMap] = await f.fundAndSend(fundingSource);
+    const { target: createSchemaEvent, eventMap } = await f.fundAndSend(fundingSource);
 
     assertExtrinsicSuccess(eventMap);
     assert.notEqual(createSchemaEvent, undefined);

--- a/e2e/stateful-pallet-storage/handleSignatureRequired.test.ts
+++ b/e2e/stateful-pallet-storage/handleSignatureRequired.test.ts
@@ -39,19 +39,14 @@ describe("📗 Stateful Pallet Storage Signature Required", () => {
 
     // Create a schema for Itemized PayloadLocation
     const createSchema = ExtrinsicHelper.createSchema(providerKeys, AVRO_CHAT_MESSAGE, "AvroBinary", "Itemized");
-    const [event] = await createSchema.fundAndSend(fundingSource);
-    if (event && createSchema.api.events.schemas.SchemaCreated.is(event)) {
-      itemizedSchemaId = event.data.schemaId;
-    }
-    assert.notEqual(itemizedSchemaId, undefined, "setup should populate schemaId");
+    const { target: event } = await createSchema.fundAndSend(fundingSource);
+    itemizedSchemaId = event!.data.schemaId;
+
     // Create a schema for Paginated PayloadLocation
     const createSchema2 = ExtrinsicHelper.createSchema(providerKeys, AVRO_CHAT_MESSAGE, "AvroBinary", "Paginated");
-    const [event2] = await createSchema2.fundAndSend(fundingSource);
+    const { target: event2 } = await createSchema2.fundAndSend(fundingSource);
     assert.notEqual(event2, undefined, "setup should return a SchemaCreated event");
-    if (event2 && createSchema2.api.events.schemas.SchemaCreated.is(event2)) {
-      paginatedSchemaId = event2.data.schemaId;
-      assert.notEqual(paginatedSchemaId, undefined, "setup should populate schemaId");
-    }
+      paginatedSchemaId = event2!.data.schemaId;
 
     // Create a MSA for the delegator
     [delegatorKeys, msa_id] = await createDelegator(fundingSource);
@@ -87,7 +82,7 @@ describe("📗 Stateful Pallet Storage Signature Required", () => {
       });
       const itemizedPayloadData = ExtrinsicHelper.api.registry.createType("PalletStatefulStorageItemizedSignaturePayload", payload);
       let itemized_add_result_1 = ExtrinsicHelper.applyItemActionsWithSignature(delegatorKeys, providerKeys, signPayloadSr25519(delegatorKeys, itemizedPayloadData), payload);
-      const [pageUpdateEvent1, chainEvents] = await itemized_add_result_1.fundAndSend(fundingSource);
+      const { target: pageUpdateEvent1, eventMap: chainEvents } = await itemized_add_result_1.fundAndSend(fundingSource);
       assert.notEqual(chainEvents["system.ExtrinsicSuccess"], undefined, "should have returned an ExtrinsicSuccess event");
       assert.notEqual(chainEvents["transactionPayment.TransactionFeePaid"], undefined, "should have returned a TransactionFeePaid event");
       assert.notEqual(pageUpdateEvent1, undefined, "should have returned a PalletStatefulStorageItemizedActionApplied event");
@@ -118,7 +113,7 @@ describe("📗 Stateful Pallet Storage Signature Required", () => {
       });
       const itemizedPayloadData = ExtrinsicHelper.api.registry.createType("PalletStatefulStorageItemizedSignaturePayloadV2", payload);
       let itemized_add_result_1 = ExtrinsicHelper.applyItemActionsWithSignatureV2(delegatorKeys, providerKeys, signPayloadSr25519(delegatorKeys, itemizedPayloadData), payload);
-      const [pageUpdateEvent1, chainEvents] = await itemized_add_result_1.fundAndSend(fundingSource);
+      const { target: pageUpdateEvent1, eventMap: chainEvents } = await itemized_add_result_1.fundAndSend(fundingSource);
       assert.notEqual(chainEvents["system.ExtrinsicSuccess"], undefined, "should have returned an ExtrinsicSuccess event");
       assert.notEqual(chainEvents["transactionPayment.TransactionFeePaid"], undefined, "should have returned a TransactionFeePaid event");
       assert.notEqual(pageUpdateEvent1, undefined, "should have returned a PalletStatefulStorageItemizedActionApplied event");
@@ -141,7 +136,7 @@ describe("📗 Stateful Pallet Storage Signature Required", () => {
       });
       const upsertPayloadData = ExtrinsicHelper.api.registry.createType("PalletStatefulStoragePaginatedUpsertSignaturePayload", upsertPayload);
       let upsert_result = ExtrinsicHelper.upsertPageWithSignature(delegatorKeys, providerKeys, signPayloadSr25519(delegatorKeys, upsertPayloadData), upsertPayload);
-      const [pageUpdateEvent, chainEvents1] = await upsert_result.fundAndSend(fundingSource);
+      const { target: pageUpdateEvent, eventMap: chainEvents1 } = await upsert_result.fundAndSend(fundingSource);
       assert.notEqual(chainEvents1["system.ExtrinsicSuccess"], undefined, "should have returned an ExtrinsicSuccess event");
       assert.notEqual(chainEvents1["transactionPayment.TransactionFeePaid"], undefined, "should have returned a TransactionFeePaid event");
       assert.notEqual(pageUpdateEvent, undefined, "should have returned a PalletStatefulStoragePaginatedPageUpdate event");
@@ -156,7 +151,7 @@ describe("📗 Stateful Pallet Storage Signature Required", () => {
       });
       const deletePayloadData = ExtrinsicHelper.api.registry.createType("PalletStatefulStoragePaginatedDeleteSignaturePayload", deletePayload);
       let remove_result = ExtrinsicHelper.deletePageWithSignature(delegatorKeys, providerKeys, signPayloadSr25519(delegatorKeys, deletePayloadData), deletePayload);
-      const [pageRemove, chainEvents2] = await remove_result.fundAndSend(fundingSource);
+      const { target: pageRemove, eventMap: chainEvents2 } = await remove_result.fundAndSend(fundingSource);
       assert.notEqual(chainEvents2["system.ExtrinsicSuccess"], undefined, "should have returned an ExtrinsicSuccess event");
       assert.notEqual(chainEvents2["transactionPayment.TransactionFeePaid"], undefined, "should have returned a TransactionFeePaid event");
       assert.notEqual(pageRemove, undefined, "should have returned a event");
@@ -180,7 +175,7 @@ describe("📗 Stateful Pallet Storage Signature Required", () => {
       });
       const upsertPayloadData = ExtrinsicHelper.api.registry.createType("PalletStatefulStoragePaginatedUpsertSignaturePayloadV2", upsertPayload);
       let upsert_result = ExtrinsicHelper.upsertPageWithSignatureV2(delegatorKeys, providerKeys, signPayloadSr25519(delegatorKeys, upsertPayloadData), upsertPayload);
-      const [pageUpdateEvent, chainEvents1] = await upsert_result.fundAndSend(fundingSource);
+      const { target: pageUpdateEvent, eventMap: chainEvents1 } = await upsert_result.fundAndSend(fundingSource);
       assert.notEqual(chainEvents1["system.ExtrinsicSuccess"], undefined, "should have returned an ExtrinsicSuccess event");
       assert.notEqual(chainEvents1["transactionPayment.TransactionFeePaid"], undefined, "should have returned a TransactionFeePaid event");
       assert.notEqual(pageUpdateEvent, undefined, "should have returned a PalletStatefulStoragePaginatedPageUpdate event");
@@ -194,7 +189,7 @@ describe("📗 Stateful Pallet Storage Signature Required", () => {
       });
       const deletePayloadData = ExtrinsicHelper.api.registry.createType("PalletStatefulStoragePaginatedDeleteSignaturePayloadV2", deletePayload);
       let remove_result = ExtrinsicHelper.deletePageWithSignatureV2(delegatorKeys, providerKeys, signPayloadSr25519(delegatorKeys, deletePayloadData), deletePayload);
-      const [pageRemove, chainEvents2] = await remove_result.fundAndSend(fundingSource);
+      const { target: pageRemove, eventMap: chainEvents2 } = await remove_result.fundAndSend(fundingSource);
       assert.notEqual(chainEvents2["system.ExtrinsicSuccess"], undefined, "should have returned an ExtrinsicSuccess event");
       assert.notEqual(chainEvents2["transactionPayment.TransactionFeePaid"], undefined, "should have returned a TransactionFeePaid event");
       assert.notEqual(pageRemove, undefined, "should have returned a event");

--- a/e2e/sudo/sudo.test.ts
+++ b/e2e/sudo/sudo.test.ts
@@ -64,12 +64,9 @@ describe("Sudo required", function () {
       if (isTestnet()) this.skip();
 
       const createSchema = ExtrinsicHelper.createSchemaWithSettingsGov(sudoKey, AVRO_GRAPH_CHANGE, "AvroBinary", "Itemized", "AppendOnly");
-      const [event] = await createSchema.sudoSignAndSend();
+      const { target: event } = await createSchema.sudoSignAndSend();
       assert.notEqual(event, undefined);
-      let itemizedSchemaId: u16 = new u16(ExtrinsicHelper.api.registry, 0);
-      if (event && createSchema.api.events.schemas.SchemaCreated.is(event)) {
-        itemizedSchemaId = event.data.schemaId;
-      }
+      const itemizedSchemaId: u16 = event?.data.schemaId || new u16(ExtrinsicHelper.api.registry, 0);
       assert.notEqual(itemizedSchemaId.toNumber(), 0);
       let schema_response = await ExtrinsicHelper.getSchema(itemizedSchemaId);
       assert(schema_response.isSome);
@@ -95,11 +92,8 @@ describe("Sudo required", function () {
 
         // Create a schema for Itemized PayloadLocation
         const createSchema = ExtrinsicHelper.createSchemaWithSettingsGov(sudoKey, AVRO_CHAT_MESSAGE, "AvroBinary", "Itemized", "AppendOnly");
-        const [event] = await createSchema.sudoSignAndSend();
-        if (event && createSchema.api.events.schemas.SchemaCreated.is(event)) {
-          itemizedSchemaId = event.data.schemaId;
-        }
-        assert.notEqual(itemizedSchemaId, undefined, "setup should populate schemaId");
+        const { target: event } = await createSchema.sudoSignAndSend();
+        itemizedSchemaId = event!.data.schemaId;
 
         // Create a MSA for the delegator and delegate to the provider for the itemized schema
         [, msa_id] = await createDelegatorAndDelegation(fundingSource, itemizedSchemaId, providerId, providerKeys);


### PR DESCRIPTION
# Goal
The goal of this PR is to improve the e2e tests.

NOTE: Parallel testing locally is still flaky. Another PR coming, but wanted to keep these separate for readability

Part of #1731 

# Discussion
- Big Change: `signAndSend` now returns a correctly typed object!
    - This leads to a large number of basically the same change all over.
    - the default event (previously the `response[0]` field) now is typed, so no need to use `is` everywhere
    - Using `?` (`result?.data.msaId` for example) allows for a nice handling of the default event data
    - Using `!` (`result!.data.msaId` for example) allows for a nice throwing of the default event data when we expect it, but don't have it. (fine for tests)
- A few small cleanups like removing unused imports
- Additional helpful comments
- Fixing an issue with handles test not being able to run more than 90 times in a row

# Testing
- `make e2e-tests`
- Reading through the comments separately might be easier