### PR TITLE
Run Mode improvements for e2e tests and more

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -26,8 +26,8 @@ start-manual:
 start-interval:
 	./scripts/init.sh start-frequency-interval
 
-start-interval-1:
-	./scripts/init.sh start-frequency-interval-1
+start-interval-short:
+	./scripts/init.sh start-frequency-interval 1
 
 .PHONY: stop
 stop-relay:

--- a/Makefile
+++ b/Makefile
@@ -236,6 +236,9 @@ test:
 e2e-tests:
 	./scripts/run_e2e_tests.sh
 
+e2e-tests-serial:
+	./scripts/run_e2e_tests.sh -c serial
+
 e2e-tests-only:
 	./scripts/run_e2e_tests.sh -s
 

--- a/e2e/README.md
+++ b/e2e/README.md
@@ -13,7 +13,7 @@ To run an individual test (after starting up a Frequency node):
 
 Note: this is for the "createMsa" tests
 
-`npm run test -- --grep createMsa`
+`npm run test:serial -- --grep createMsa`
 
 See below for running load tests.
 

--- a/e2e/README.md
+++ b/e2e/README.md
@@ -58,18 +58,23 @@ with the following methods:
         }
     ```
 7. Extrinsic helper methods & returned events
-Many of the extrinsic helper methods pass an event type to the underlying Extrincic object that can be used to parse the targeted event type
-from the resulting stream and return it specifically. The `Extrinsic::signAndSend()` method returns an array of `[targetEvent, eventMap]` where
-`targetEvent` will be the parsed target event *if present*. The `eventMap` is a map of <string, event> with the keys being `paletteName.eventName`.
+Many of the extrinsic helper methods pass an event type to the underlying Extrinsic object that can be used to parse the targeted event type
+from the resulting stream and return it specifically. The `Extrinsic::signAndSend()` method returns an object of `{ target, eventMap }` where
+`target` will be the parsed target event *if present*. The `eventMap` is a map of <string, event> with the keys being `paletteName.eventName`.
 A special key "defaultEvent" is added to also contain the target event, if present.
 Events may be used with type guards to access the event-specific structure. Event types are in the `ApiRx.events.<palette>.*` structure, and can be
 accessed like so:
     ```
     const extrinsic = ExtrinsicHelper.createMsa(keypair);
-    const [targetEvent, eventMap] = await extrinsic.fundAndSend();
-    if (targetEvent && ExtrinsicHelper.api.events.msa.MsaCreated.is(targetEvent)) {
+    const { target: targetEvent, eventMap } = await extrinsic.fundAndSend();
+    if (targetEvent) {
         const msaId = targetEvent.data.msaId;
     }
+    // OR null coalescing
+    const maybeMsaId = targetEvent?.data.msaId;
+
+    // OR Throw unless defined
+    const throwIfNotMsaId = targetEvent!.data.msaId;
     ```
 
 Load Testing

--- a/e2e/package.json
+++ b/e2e/package.json
@@ -7,6 +7,7 @@
         "clean": "rm -Rf dist",
         "build": "tsc -p ./tsconfig.json",
         "test": "mocha",
+        "test:serial": "mocha --parallel=false",
         "test:relay": "mocha --config .relay-chain.mocharc.json",
         "test:load": "mocha --config .load-test.mocharc.json",
         "format": "tsc --noEmit --pretty",

--- a/scripts/init.sh
+++ b/scripts/init.sh
@@ -80,6 +80,9 @@ start-frequency-instant)
 
   ./target/debug/frequency \
     --dev \
+    --state-pruning archive \
+    -lbasic-authorship=debug \
+    -ltxpool=debug \
     -lruntime=debug \
     --sealing=instant \
     --wasm-execution=compiled \
@@ -109,6 +112,9 @@ start-frequency-interval)
 
   ./target/debug/frequency \
     --dev \
+    --state-pruning archive \
+    -lbasic-authorship=debug \
+    -ltxpool=debug \
     -lruntime=debug \
     --sealing=interval \
     --sealing-interval=${interval} \

--- a/scripts/init.sh
+++ b/scripts/init.sh
@@ -94,7 +94,9 @@ start-frequency-instant)
   ;;
 
 start-frequency-interval)
-  printf "\nBuilding Frequency without relay.  Running with interval sealing ...\n"
+  defaultInterval=12
+  interval=${2-$defaultInterval}
+  printf "\nBuilding Frequency without relay.  Running with interval sealing with interval of $interval seconds...\n"
   cargo build --features frequency-no-relay
 
   parachain_dir=$base_dir/parachain/${para_id}
@@ -109,34 +111,7 @@ start-frequency-interval)
     --dev \
     -lruntime=debug \
     --sealing=interval \
-    --wasm-execution=compiled \
-    --no-telemetry \
-    --no-prometheus \
-    --port $((30333)) \
-    --rpc-port $((9944)) \
-    --rpc-external \
-    --rpc-cors all \
-    --rpc-methods=Unsafe \
-    --tmp
-  ;;
-
-  start-frequency-interval-1)
-  printf "\nBuilding Frequency without relay.  Running with interval sealing 1 second blocktime...\n"
-  cargo build --features frequency-no-relay
-
-  parachain_dir=$base_dir/parachain/${para_id}
-  mkdir -p $parachain_dir;
-
-  if [ "$2" == "purge" ]; then
-    echo "purging parachain..."
-    rm -rf $parachain_dir
-  fi
-
-  ./target/debug/frequency \
-    --dev \
-    -lruntime=debug \
-    --sealing=interval \
-    --sealing-interval=1 \
+    --sealing-interval=${interval} \
     --wasm-execution=compiled \
     --no-telemetry \
     --no-prometheus \

--- a/scripts/run_e2e_tests.sh
+++ b/scripts/run_e2e_tests.sh
@@ -65,6 +65,11 @@ case "${CHAIN}" in
             LOCAL_NODE_BLOCK_SEALING="manual"
         fi
     ;;
+    "serial")
+        PROVIDER_URL="ws://127.0.0.1:9944"
+        NPM_RUN_COMMAND="test:serial"
+        CHAIN_ENVIRONMENT="dev"
+    ;;
     "rococo_local")
         PROVIDER_URL="ws://127.0.0.1:9944"
         NPM_RUN_COMMAND="test:relay"


### PR DESCRIPTION
# Goal
The goal of this PR is a small set of improvements:

- Update e2e readme
- Add additional debug logging defaults to the init.sh script for instant and interval sealing
- Add a interval param to the interval sealing init.sh runner
- Add serial run mode for e2e tests

Part of https://github.com/LibertyDSNP/frequency/issues/1731

# Testing
- `make e2e-tests-serial`
- `make start-interval-short`
- `make start` or `make start-interval*` and see `txpool` and `basic-authorship` logs