### PR TITLE
Testing e2e add autononce feature

### DIFF
--- a/e2e/.mocharc.json
+++ b/e2e/.mocharc.json
@@ -9,5 +9,5 @@
     ],
     "loader": "ts-node/esm",
     "spec": ["./{,!(node_modules|load-tests)/**}/*.test.ts"],
-    "timeout": 10000
+    "timeout": 20000
 }

--- a/e2e/capacity/replenishment.test.ts
+++ b/e2e/capacity/replenishment.test.ts
@@ -78,7 +78,7 @@ describe("Capacity Replenishment Testing: ", function () {
 
   function assert_capacity_call_fails_with_balance_too_low(call: Extrinsic) {
     return assert.rejects(
-      call.payWithCapacity(-1), { name: "RpcError", message: /1010.+account balance too low/ });
+      call.payWithCapacity('current'), { name: "RpcError", message: /1010.+account balance too low/ });
   }
 
   describe("Capacity is not replenished", function () {
@@ -132,7 +132,7 @@ describe("Capacity Replenishment Testing: ", function () {
       assertEvent(hasStaked, 'capacity.Staked');
 
       // provider can now send a message
-      const { eventMap: hasCapacityWithdrawn } = await call.payWithCapacity(-1);
+      const { eventMap: hasCapacityWithdrawn } = await call.payWithCapacity();
       assertEvent(hasCapacityWithdrawn, 'capacity.CapacityWithdrawn');
 
       remainingCapacity = (await getCapacity(stakeProviderId)).remainingCapacity.toBigInt();

--- a/e2e/capacity/transactions.test.ts
+++ b/e2e/capacity/transactions.test.ts
@@ -65,7 +65,7 @@ describe("Capacity Transactions", function () {
         const ownerSig: Sr25519Signature = signPayloadSr25519(capacityKeys, addKeyPayloadCodec);
         const newSig: Sr25519Signature = signPayloadSr25519(newControlKeypair, addKeyPayloadCodec);
         const addPublicKeyOp = ExtrinsicHelper.addPublicKeyToMsa(capacityKeys, ownerSig, newSig, addKeyPayload);
-        const { eventMap } = await addPublicKeyOp.signAndSend(-1);
+        const { eventMap } = await addPublicKeyOp.signAndSend();
         assertEvent(eventMap, "system.ExtrinsicSuccess");
         assertEvent(eventMap, "msa.PublicKeyAdded");
       }
@@ -102,7 +102,7 @@ describe("Capacity Transactions", function () {
         };
         const claimHandlePayload = ExtrinsicHelper.api.registry.createType("CommonPrimitivesHandlesClaimHandlePayload", handlePayload);
         const claimHandle = ExtrinsicHelper.claimHandle(newControlKeypair, claimHandlePayload);
-        await assert.rejects(claimHandle.payWithCapacity(), {
+        await assert.rejects(claimHandle.payWithCapacity('current'), {
           name: "RpcError", message:
             "1010: Invalid Transaction: Inability to pay some fees , e.g. account balance too low"
         });
@@ -506,7 +506,7 @@ describe("Capacity Transactions", function () {
         const capacityKeys = createKeys("CapacityKeys");
         const capacityProvider = await createMsaAndProvider(fundingSource, capacityKeys, "CapacityProvider", FUNDS_AMOUNT);
         const nonCapacityTxn = ExtrinsicHelper.stake(capacityKeys, capacityProvider, 1n * CENTS);
-        await assert.rejects(nonCapacityTxn.payWithCapacity(), {
+        await assert.rejects(nonCapacityTxn.payWithCapacity('current'), {
           name: "RpcError", message:
             "1010: Invalid Transaction: Custom error: 0"
         });
@@ -531,7 +531,7 @@ describe("Capacity Transactions", function () {
         const grantDelegationOp = ExtrinsicHelper.grantDelegation(delegatorKeys, noCapacityKeys,
           signPayloadSr25519(noCapacityKeys, addProviderData), payload);
 
-        await assert.rejects(grantDelegationOp.payWithCapacity(), {
+        await assert.rejects(grantDelegationOp.payWithCapacity('current'), {
           name: "RpcError", message:
             "1010: Invalid Transaction: Inability to pay some fees , e.g. account balance too low"
         });
@@ -571,7 +571,7 @@ describe("Capacity Transactions", function () {
         const grantDelegationOp = ExtrinsicHelper.grantDelegation(delegatorKeys, noTokensKeys,
           signPayloadSr25519(delegatorKeys, addProviderData), payload);
 
-        await assert.rejects(grantDelegationOp.payWithCapacity(), {
+        await assert.rejects(grantDelegationOp.payWithCapacity('current'), {
           name: 'RpcError',
           message: "1010: Invalid Transaction: Inability to pay some fees , e.g. account balance too low",
         })
@@ -611,7 +611,7 @@ describe("Capacity Transactions", function () {
           const grantDelegationOp = ExtrinsicHelper.grantDelegation(delegatorKeys, noProviderKeys,
             signPayloadSr25519(delegatorKeys, addProviderData), payload);
 
-          await assert.rejects(grantDelegationOp.payWithCapacity(), {
+          await assert.rejects(grantDelegationOp.payWithCapacity('current'), {
             name: "RpcError", message:
               "1010: Invalid Transaction: Inability to pay some fees , e.g. account balance too low"
           });
@@ -630,7 +630,7 @@ describe("Capacity Transactions", function () {
           const grantDelegationOp = ExtrinsicHelper.grantDelegation(delegatorKeys, emptyKeys,
             signPayloadSr25519(delegatorKeys, addProviderData), payload);
 
-          await assert.rejects(grantDelegationOp.payWithCapacity(), {
+          await assert.rejects(grantDelegationOp.payWithCapacity('current'), {
             name: "RpcError", message:
               "1010: Invalid Transaction: Custom error: 1"
           });

--- a/e2e/handles/handles.test.ts
+++ b/e2e/handles/handles.test.ts
@@ -58,7 +58,7 @@ describe("🤝 Handles", () => {
             await ExtrinsicHelper.runToBlock(currentBlock + expirationOffset + 1); // Must be at least 1 > original expiration
 
             const retireHandle = ExtrinsicHelper.retireHandle(msaOwnerKeys);
-            const { target: event } = await retireHandle.fundAndSend(fundingSource);
+            const { target: event } = await retireHandle.signAndSend('current');
             assert.notEqual(event, undefined, "retireHandle should return an event");
             const handle = event!.data.handle.toString();
             assert.notEqual(handle, "", "retireHandle should return the correct handle");

--- a/e2e/handles/handles.test.ts
+++ b/e2e/handles/handles.test.ts
@@ -10,22 +10,21 @@ import { getBlockNumber } from "../scaffolding/helpers";
 import { hasRelayChain } from "../scaffolding/env";
 import { getFundingSource } from "../scaffolding/funding";
 
-describe("🤝 Handles", () => {
+describe("🤝 Handles", function () {
     const fundingSource = getFundingSource("handles");
+    const expirationOffset = hasRelayChain() ? 10 : 100;
 
-    let msa_id: MessageSourceId;
-    let msaOwnerKeys: KeyringPair;
+    describe("Claim and Retire", function () {
+        let msa_id: MessageSourceId;
+        let msaOwnerKeys: KeyringPair;
 
-    let expirationOffset = hasRelayChain() ? 10 : 100;
+        before(async function () {
+            // Create a MSA for the delegator
+            [msaOwnerKeys, msa_id] = await createDelegator(fundingSource);
+            assert.notEqual(msaOwnerKeys, undefined, "setup should populate delegator_key");
+            assert.notEqual(msa_id, undefined, "setup should populate msa_id");
+        });
 
-    before(async function () {
-        // Create a MSA for the delegator
-        [msaOwnerKeys, msa_id] = await createDelegator(fundingSource);
-        assert.notEqual(msaOwnerKeys, undefined, "setup should populate delegator_key");
-        assert.notEqual(msa_id, undefined, "setup should populate msa_id");
-    });
-
-    describe("@Claim Handle", () => {
         it("should be able to claim a handle", async function () {
             const handle = getTestHandle();
             let currentBlock = await getBlockNumber();
@@ -40,9 +39,7 @@ describe("🤝 Handles", () => {
             assert.notEqual(event, undefined, "claimHandle should return an event");
             assert.notEqual(event!.data.handle.toString(), "", "claimHandle should emit a handle");
         });
-    });
 
-    describe("@Retire Handle", () => {
         it("should be able to retire a handle", async function () {
             let handle_response = await ExtrinsicHelper.getHandleForMSA(msa_id);
             if (!handle_response.isSome) {
@@ -65,77 +62,88 @@ describe("🤝 Handles", () => {
         });
     });
 
-    describe("@Alt Path: Claim Handle with possible presumptive suffix/RPC test", () => {
-        /// Check chain to getNextSuffixesForHandle
+    describe("Claim and Retire Alt", function () {
+        let msa_id: MessageSourceId;
+        let msaOwnerKeys: KeyringPair;
 
-        it("should be able to claim a handle and check suffix (=suffix_assumed if available on chain)", async function () {
-            const handle = getTestHandle();
-            let handle_bytes = new Bytes(ExtrinsicHelper.api.registry, handle);
-            /// Get presumptive suffix from chain (rpc)
-            let suffixes_response = await ExtrinsicHelper.getNextSuffixesForHandle(handle, 10);
-            let resp_base_handle = suffixes_response.base_handle.toString();
-            assert.equal(resp_base_handle, handle, "resp_base_handle should be equal to handle");
-            let suffix_assumed = suffixes_response.suffixes[0];
-            assert.notEqual(suffix_assumed, 0, "suffix_assumed should not be 0");
+        before(async function () {
+            // Create a MSA for the delegator
+            [msaOwnerKeys, msa_id] = await createDelegator(fundingSource);
+            assert.notEqual(msaOwnerKeys, undefined, "setup should populate delegator_key");
+            assert.notEqual(msa_id, undefined, "setup should populate msa_id");
+        });
 
-            let currentBlock = await getBlockNumber();
-            /// Claim handle (extrinsic)
-            const payload_ext = {
-                baseHandle: handle_bytes,
-                expiration: currentBlock + expirationOffset,
-            };
-            const claimHandlePayload = ExtrinsicHelper.api.registry.createType("CommonPrimitivesHandlesClaimHandlePayload", payload_ext);
-            const claimHandle = ExtrinsicHelper.claimHandle(msaOwnerKeys, claimHandlePayload);
-            const { target: event } = await claimHandle.fundAndSend(fundingSource);
-            assert.notEqual(event, undefined, "claimHandle should return an event");
-            const displayHandle = event!.data.handle.toUtf8();
-            assert.notEqual(displayHandle, "", "claimHandle should emit a handle");
+        describe("Claim Handle with possible presumptive suffix/RPC test", function () {
 
-            // get handle using msa (rpc)
-            let handle_response = await ExtrinsicHelper.getHandleForMSA(msa_id);
-            if (!handle_response.isSome) {
-                throw new Error("handle_response should be Some");
-            }
-            let full_handle_state = handle_response.unwrap();
-            let suffix_from_state = full_handle_state.suffix;
-            let suffix = suffix_from_state.toNumber();
-            assert.notEqual(suffix, 0, "suffix should not be 0");
-            assert.equal(suffix, suffix_assumed, "suffix should be equal to suffix_assumed");
+            it("should be able to claim a handle and check suffix (=suffix_assumed if available on chain)", async function () {
+                const handle = getTestHandle();
+                let handle_bytes = new Bytes(ExtrinsicHelper.api.registry, handle);
+                /// Get presumptive suffix from chain (rpc)
+                let suffixes_response = await ExtrinsicHelper.getNextSuffixesForHandle(handle, 10);
+                let resp_base_handle = suffixes_response.base_handle.toString();
+                assert.equal(resp_base_handle, handle, "resp_base_handle should be equal to handle");
+                let suffix_assumed = suffixes_response.suffixes[0];
+                assert.notEqual(suffix_assumed, 0, "suffix_assumed should not be 0");
 
-            /// Get MSA from full display handle (rpc)
-            const msaOption = await ExtrinsicHelper.getMsaForHandle(displayHandle);
-            assert(msaOption.isSome, "msaOption should be Some");
-            const msaFromHandle = msaOption.unwrap();
-            assert.equal(msaFromHandle.toString(), msa_id.toString(), "msaFromHandle should be equal to msa_id");
+                let currentBlock = await getBlockNumber();
+                /// Claim handle (extrinsic)
+                const payload_ext = {
+                    baseHandle: handle_bytes,
+                    expiration: currentBlock + expirationOffset,
+                };
+                const claimHandlePayload = ExtrinsicHelper.api.registry.createType("CommonPrimitivesHandlesClaimHandlePayload", payload_ext);
+                const claimHandle = ExtrinsicHelper.claimHandle(msaOwnerKeys, claimHandlePayload);
+                const { target: event } = await claimHandle.fundAndSend(fundingSource, true);
+                assert.notEqual(event, undefined, "claimHandle should return an event");
+                const displayHandle = event!.data.handle.toUtf8();
+                assert.notEqual(displayHandle, "", "claimHandle should emit a handle");
+
+                // get handle using msa (rpc)
+                let handle_response = await ExtrinsicHelper.getHandleForMSA(msa_id);
+                if (!handle_response.isSome) {
+                    throw new Error("handle_response should be Some");
+                }
+                let full_handle_state = handle_response.unwrap();
+                let suffix_from_state = full_handle_state.suffix;
+                let suffix = suffix_from_state.toNumber();
+                assert.notEqual(suffix, 0, "suffix should not be 0");
+                assert.equal(suffix, suffix_assumed, "suffix should be equal to suffix_assumed");
+
+                /// Get MSA from full display handle (rpc)
+                const msaOption = await ExtrinsicHelper.getMsaForHandle(displayHandle);
+                assert(msaOption.isSome, "msaOption should be Some");
+                const msaFromHandle = msaOption.unwrap();
+                assert.equal(msaFromHandle.toString(), msa_id.toString(), "msaFromHandle should be equal to msa_id");
+            });
+        });
+
+        describe("👇 Negative Test: Early retire handle", function () {
+            it("should not be able to retire a handle before expiration", async function () {
+                let handle_response = await ExtrinsicHelper.getHandleForMSA(msa_id);
+                if (!handle_response.isSome) {
+                    throw new Error("handle_response should be Some");
+                }
+
+                let full_handle_state = handle_response.unwrap();
+                let suffix_from_state = full_handle_state.suffix;
+                let suffix = suffix_from_state.toNumber();
+                assert.notEqual(suffix, 0, "suffix should not be 0");
+
+                let currentBlock = await getBlockNumber();
+                await ExtrinsicHelper.runToBlock(currentBlock + expirationOffset + 1);
+                try {
+                    const retireHandle = ExtrinsicHelper.retireHandle(msaOwnerKeys);
+                    const { target: event } = await retireHandle.fundAndSend(fundingSource);
+                    assert.equal(event, undefined, "retireHandle should not return an event");
+                }
+                catch (e) {
+                    assert.notEqual(e, undefined, "retireHandle should throw an error");
+                }
+            });
         });
     });
 
-    describe("👇 Negative Test: Early retire handle", () => {
-        it("should not be able to retire a handle before expiration", async function () {
-            let handle_response = await ExtrinsicHelper.getHandleForMSA(msa_id);
-            if (!handle_response.isSome) {
-                throw new Error("handle_response should be Some");
-            }
-
-            let full_handle_state = handle_response.unwrap();
-            let suffix_from_state = full_handle_state.suffix;
-            let suffix = suffix_from_state.toNumber();
-            assert.notEqual(suffix, 0, "suffix should not be 0");
-
-            let currentBlock = await getBlockNumber();
-            await ExtrinsicHelper.runToBlock(currentBlock + expirationOffset + 1);
-            try {
-                const retireHandle = ExtrinsicHelper.retireHandle(msaOwnerKeys);
-                const { target: event } = await retireHandle.fundAndSend(fundingSource);
-                assert.equal(event, undefined, "retireHandle should not return an event");
-            }
-            catch (e) {
-                assert.notEqual(e, undefined, "retireHandle should throw an error");
-            }
-        });
-    });
-
-    describe("Suffixes Integrity Check", () => {
+    describe("Suffixes Integrity Check", function () {
         it("should return same suffixes for `abcdefg` from chain as hardcoded", async function () {
             let suffixes = await ExtrinsicHelper.getNextSuffixesForHandle("abcdefg", 10);
             let suffixes_expected = [23, 65, 16, 53, 25, 75, 29, 26, 10, 87];
@@ -144,8 +152,8 @@ describe("🤝 Handles", () => {
         });
     });
 
-    describe("validateHandle basic test", () => {
-        it('returns true for good handle, and false for bad handle', async () => {
+    describe("validateHandle basic test", function () {
+        it('returns true for good handle, and false for bad handle', async function () {
             let res = await ExtrinsicHelper.validateHandle("Robert`DROP TABLE STUDENTS;--");
             assert.equal(res.toHuman(), false);
             res = await ExtrinsicHelper.validateHandle("Little Bobby Tables")

--- a/e2e/handles/handles.test.ts
+++ b/e2e/handles/handles.test.ts
@@ -93,7 +93,7 @@ describe("🤝 Handles", function () {
                 };
                 const claimHandlePayload = ExtrinsicHelper.api.registry.createType("CommonPrimitivesHandlesClaimHandlePayload", payload_ext);
                 const claimHandle = ExtrinsicHelper.claimHandle(msaOwnerKeys, claimHandlePayload);
-                const { target: event } = await claimHandle.fundAndSend(fundingSource, true);
+                const { target: event } = await claimHandle.fundAndSend(fundingSource);
                 assert.notEqual(event, undefined, "claimHandle should return an event");
                 const displayHandle = event!.data.handle.toUtf8();
                 assert.notEqual(displayHandle, "", "claimHandle should emit a handle");

--- a/e2e/messages/addIPFSMessage.test.ts
+++ b/e2e/messages/addIPFSMessage.test.ts
@@ -50,7 +50,7 @@ describe("Add Offchain Message", function () {
     });
 
     it('should fail if insufficient funds', async function () {
-        await assert.rejects(ExtrinsicHelper.addIPFSMessage(keys, schemaId, ipfs_cid_64, ipfs_payload_len).signAndSend(), {
+        await assert.rejects(ExtrinsicHelper.addIPFSMessage(keys, schemaId, ipfs_cid_64, ipfs_payload_len).signAndSend('current'), {
             name: 'RpcError',
             message: /Inability to pay some fees/,
         });

--- a/e2e/msa/msaKeyManagement.test.ts
+++ b/e2e/msa/msaKeyManagement.test.ts
@@ -164,7 +164,7 @@ describe("MSA Key management", function () {
         it("should disallow retiring MSA belonging to a provider", async function () {
             const [providerKeys] = await createProviderKeysAndId(fundingSource);
             const retireOp = ExtrinsicHelper.retireMsa(providerKeys);
-            await assert.rejects(retireOp.signAndSend(), {
+            await assert.rejects(retireOp.signAndSend('current'), {
                 name: 'RpcError',
                 message: /Custom error: 2/,
             });
@@ -199,7 +199,7 @@ describe("MSA Key management", function () {
 
         it("should disallow retiring an MSA with more than one key authorized", async function () {
             const retireOp = ExtrinsicHelper.retireMsa(keys);
-            await assert.rejects(retireOp.signAndSend(), {
+            await assert.rejects(retireOp.signAndSend('current'), {
                 name: 'RpcError',
                 message: /Custom error: 3/,
             });
@@ -207,7 +207,7 @@ describe("MSA Key management", function () {
 
         it("should fail to delete public key for self", async function () {
             const op = ExtrinsicHelper.deletePublicKey(keys, keys.publicKey);
-            await assert.rejects(op.signAndSend(), {
+            await assert.rejects(op.signAndSend('current'), {
                 name: 'RpcError',
                 message: /Custom error: 4/,
             });
@@ -217,7 +217,7 @@ describe("MSA Key management", function () {
             const [providerKeys] = await createProviderKeysAndId(fundingSource);
 
             const op = ExtrinsicHelper.deletePublicKey(providerKeys, keys.publicKey);
-            await assert.rejects(op.signAndSend(), {
+            await assert.rejects(op.signAndSend('current'), {
                 name: 'RpcError',
                 message: /Custom error: 5/,
             });
@@ -226,7 +226,7 @@ describe("MSA Key management", function () {
         it("should test for 'NoKeyExists' error", async function () {
             const key = createKeys("nothing key");
             const op = ExtrinsicHelper.deletePublicKey(keys, key.publicKey);
-            await assert.rejects(op.signAndSend(), {
+            await assert.rejects(op.signAndSend('current'), {
                 name: 'RpcError',
                 message: /Custom error: 1/,
             });
@@ -234,13 +234,13 @@ describe("MSA Key management", function () {
 
         it("should delete secondary key", async function () {
             const op = ExtrinsicHelper.deletePublicKey(keys, secondaryKey.publicKey);
-            const { target: event } = await op.signAndSend();
+            const { target: event } = await op.signAndSend('current');
             assert.notEqual(event, undefined, "should have returned PublicKeyDeleted event");
         });
 
         it("should allow retiring MSA after additional keys have been deleted", async function () {
             const retireMsaOp = ExtrinsicHelper.retireMsa(keys);
-            const { target: event, eventMap } = await retireMsaOp.signAndSend();
+            const { target: event, eventMap } = await retireMsaOp.signAndSend('current');
 
             assert.notEqual(eventMap["msa.PublicKeyDeleted"], undefined, 'should have deleted public key (retired)');
             assert.notEqual(event, undefined, 'should have retired msa');

--- a/e2e/scaffolding/autoNonce.ts
+++ b/e2e/scaffolding/autoNonce.ts
@@ -1,0 +1,56 @@
+
+/**
+ * The AutoNonce Module keeps track of nonces used by tests
+ * Because all keys in the tests are managed by the tests, the nonces are determined by:
+ * 1. Prior transaction count
+ * 2. Not counting transactions that had RPC failures
+ */
+
+import type { KeyringPair } from "@polkadot/keyring/types";
+import { ExtrinsicHelper } from "./extrinsicHelpers";
+
+export type AutoNonce = number | 'auto' | 'current';
+
+const nonceCache = new Map<string, number>();
+
+const getNonce = async (keys: KeyringPair) => {
+  return (await ExtrinsicHelper.getAccountInfo(keys.address)).nonce.toNumber();
+}
+
+const reset = (keys: KeyringPair) => {
+  nonceCache.delete(keys.address);
+}
+
+const current = async (keys: KeyringPair): Promise<number> => {
+  return nonceCache.get(keys.address) || await getNonce(keys);
+}
+
+const increment = async (keys: KeyringPair) => {
+  const nonce = await current(keys);
+  nonceCache.set(keys.address, nonce + 1);
+  return nonce;
+}
+
+/**
+ * Use the auto nonce system
+ * @param keys The KeyringPair that will be used for sending a transaction
+ * @param inputNonce
+ *        "auto" (default) for using the auto system
+ *        "current" for just getting the current one instead of incrementing
+ *        <number> for just using a specific number (also sets it to increments for the future)
+ * @returns
+ */
+const auto = (keys: KeyringPair, inputNonce: AutoNonce = 'auto'): Promise<number> => {
+  switch(inputNonce) {
+    case 'auto': return increment(keys);
+    case 'current': return current(keys);
+    default:
+      nonceCache.set(keys.address, inputNonce + 1);
+      return Promise.resolve(inputNonce);
+  }
+}
+
+export default {
+  auto,
+  reset,
+}

--- a/e2e/scaffolding/extrinsicHelpers.ts
+++ b/e2e/scaffolding/extrinsicHelpers.ts
@@ -142,11 +142,11 @@ export class Extrinsic<N = unknown, T extends ISubmittableResult = ISubmittableR
                 this.parseResult(this.event),
             ));
         } catch (e) {
-                if ((e as any).name === "RpcError" && inputNonce === 'auto') {
-                    console.error("WARNING: Unexpected RPC Error! If it is expected, use 'current' for the nonce.");
-                }
-                throw e;
+            if ((e as any).name === "RpcError" && inputNonce === 'auto') {
+                console.error("WARNING: Unexpected RPC Error! If it is expected, use 'current' for the nonce.");
             }
+            throw e;
+        }
     }
 
     public async sudoSignAndSend() {

--- a/e2e/scaffolding/extrinsicHelpers.ts
+++ b/e2e/scaffolding/extrinsicHelpers.ts
@@ -3,9 +3,10 @@ import { ApiTypes, AugmentedEvent, SubmittableExtrinsic } from "@polkadot/api/ty
 import { KeyringPair } from "@polkadot/keyring/types";
 import { Compact, u128, u16, u32, u64, Vec, Option, Bool } from "@polkadot/types";
 import { FrameSystemAccountInfo, SpRuntimeDispatchError } from "@polkadot/types/lookup";
-import { AnyNumber, AnyTuple, Codec, IEvent, ISubmittableResult } from "@polkadot/types/types";
+import { AnyJson, AnyNumber, AnyTuple, Codec, IEvent, ISubmittableResult } from "@polkadot/types/types";
 import { firstValueFrom, filter, map, pipe, tap } from "rxjs";
 import { getBlockNumber, getExistentialDeposit, log, Sr25519Signature } from "./helpers";
+import autoNonce, { AutoNonce } from "./autoNonce";
 import { connect, connectPromise } from "./apiConnection";
 import { DispatchError, Event, SignedBlock } from "@polkadot/types/interfaces";
 import { IsEvent } from "@polkadot/types/metadata/decorate/types";
@@ -56,6 +57,17 @@ export class EventError extends Error {
 
     public toString() {
         return `${this.section}.${this.name}: ${this.message}`;
+    }
+}
+
+class CallError extends Error {
+    message: string;
+    result: AnyJson;
+
+    constructor(submittable: ISubmittableResult, msg?: string) {
+        super();
+        this.result = submittable.toHuman();
+        this.message = msg ?? "Call Error";
     }
 }
 
@@ -112,22 +124,42 @@ export class Extrinsic<N = unknown, T extends ISubmittableResult = ISubmittableR
         this.api = ExtrinsicHelper.api;
     }
 
-    public signAndSend(nonce?: number) {
-        return firstValueFrom(this.extrinsic().signAndSend(this.keys, { nonce: nonce }).pipe(
+    // This uses automatic nonce management by default.
+    public async signAndSend(inputNonce?: AutoNonce) {
+        const nonce = await autoNonce.auto(this.keys, inputNonce);
+
+        try {
+            const op = this.extrinsic();
+            return await firstValueFrom(op.signAndSend(this.keys, { nonce }).pipe(
+                tap((result) => {
+                    // If we learn a transaction has an error status (this does NOT include RPC errors)
+                    // Then throw an error
+                    if (result.isError) {
+                        throw new CallError(result, `Failed Transaction for ${this.event?.meta.name || "unknown"}`);
+                    }
+                }),
+                filter(({ status }) => status.isInBlock || status.isFinalized),
+                this.parseResult(this.event),
+            ));
+        } catch (e) {
+                if ((e as any).name === "RpcError" && inputNonce === 'auto') {
+                    console.error("WARNING: Unexpected RPC Error! If it is expected, use 'current' for the nonce.");
+                }
+                throw e;
+            }
+    }
+
+    public async sudoSignAndSend() {
+        const nonce = await autoNonce.auto(this.keys);
+        return await firstValueFrom(this.api.tx.sudo.sudo(this.extrinsic()).signAndSend(this.keys, { nonce }).pipe(
             filter(({ status }) => status.isInBlock || status.isFinalized),
             this.parseResult(this.event),
         ))
     }
 
-    public sudoSignAndSend() {
-        return firstValueFrom(this.api.tx.sudo.sudo(this.extrinsic()).signAndSend(this.keys).pipe(
-            filter(({ status }) => status.isInBlock || status.isFinalized),
-            this.parseResult(this.event),
-        ))
-    }
-
-    public payWithCapacity(nonce?: number) {
-        return firstValueFrom(this.api.tx.frequencyTxPayment.payWithCapacity(this.extrinsic()).signAndSend(this.keys, { nonce }).pipe(
+    public async payWithCapacity(inputNonce?: AutoNonce) {
+        const nonce = await autoNonce.auto(this.keys, inputNonce);
+        return await firstValueFrom(this.api.tx.frequencyTxPayment.payWithCapacity(this.extrinsic()).signAndSend(this.keys, { nonce }).pipe(
             filter(({ status }) => status.isInBlock || status.isFinalized),
             this.parseResult(this.event),
         ))

--- a/e2e/scenarios/grantDelegation.test.ts
+++ b/e2e/scenarios/grantDelegation.test.ts
@@ -3,7 +3,7 @@ import { KeyringPair } from "@polkadot/keyring/types";
 import { u16, u64 } from "@polkadot/types";
 import assert from "assert";
 import { AddProviderPayload, Extrinsic, ExtrinsicHelper } from "../scaffolding/extrinsicHelpers";
-import { createAndFundKeypair, createAndFundKeypairs, createKeys, generateDelegationPayload, getBlockNumber, signPayloadSr25519 } from "../scaffolding/helpers";
+import { DOLLARS, createAndFundKeypair, createAndFundKeypairs, createKeys, generateDelegationPayload, getBlockNumber, signPayloadSr25519 } from "../scaffolding/helpers";
 import { SchemaGrantResponse, SchemaId } from "@frequency-chain/api-augment/interfaces";
 import { getFundingSource } from "../scaffolding/funding";
 
@@ -24,26 +24,25 @@ describe("Delegation Scenario Tests", function () {
 
     before(async function () {
         // Fund all the different keys
-        [noMsaKeys, keys, otherMsaKeys, providerKeys, otherProviderKeys] = await createAndFundKeypairs(fundingSource, ["noMsaKeys", "keys", "otherMsaKeys", "providerKeys", "otherProviderKeys"]);
+        [noMsaKeys, keys, otherMsaKeys, providerKeys, otherProviderKeys] = await createAndFundKeypairs(fundingSource, ["noMsaKeys", "keys", "otherMsaKeys", "providerKeys", "otherProviderKeys"], 1n * DOLLARS);
 
-        const createMsaOp = ExtrinsicHelper.createMsa(keys);
-        let { target: msaCreatedEvent } = await createMsaOp.fundAndSend(fundingSource);
-        msaId = msaCreatedEvent!.data.msaId;
+        const { target: msaCreatedEvent1 } = await ExtrinsicHelper.createMsa(keys).signAndSend();
+        msaId = msaCreatedEvent1!.data.msaId;
 
-        ({ target: msaCreatedEvent } = await ExtrinsicHelper.createMsa(otherMsaKeys).fundAndSend(fundingSource));
-        otherMsaId = msaCreatedEvent!.data.msaId;
+        const { target: msaCreatedEvent2 } = await ExtrinsicHelper.createMsa(otherMsaKeys).signAndSend();
+        otherMsaId = msaCreatedEvent2!.data.msaId;
 
         let createProviderMsaOp = ExtrinsicHelper.createMsa(providerKeys);
-        await createProviderMsaOp.fundAndSend(fundingSource);
+        await createProviderMsaOp.signAndSend();
         let createProviderOp = ExtrinsicHelper.createProvider(providerKeys, "MyPoster");
-        let { target: providerEvent } = await createProviderOp.fundAndSend(fundingSource);
+        let { target: providerEvent } = await createProviderOp.signAndSend();
         assert.notEqual(providerEvent, undefined, "setup should return a ProviderCreated event");
         providerId = providerEvent!.data.providerId;
 
         createProviderMsaOp = ExtrinsicHelper.createMsa(otherProviderKeys);
-        await createProviderMsaOp.fundAndSend(fundingSource);
+        await createProviderMsaOp.signAndSend();
         createProviderOp = ExtrinsicHelper.createProvider(otherProviderKeys, "MyPoster");
-        ({ target: providerEvent } = await createProviderOp.fundAndSend(fundingSource));
+        ({ target: providerEvent } = await createProviderOp.signAndSend());
         assert.notEqual(providerEvent, undefined, "setup should return a ProviderCreated event");
         otherProviderId = providerEvent!.data.providerId;
 
@@ -79,12 +78,12 @@ describe("Delegation Scenario Tests", function () {
                 },
             ]
         }, "AvroBinary", "OnChain");
-        let { target: createSchemaEvent } = await createSchemaOp.fundAndSend(fundingSource);
+        let { target: createSchemaEvent } = await createSchemaOp.signAndSend();
         assert.notEqual(createSchemaEvent, undefined, "setup should return SchemaCreated event");
         schemaId = createSchemaEvent!.data.schemaId;
 
         // Create a second schema
-        ({ target: createSchemaEvent } = await createSchemaOp.fundAndSend(fundingSource));
+        ({ target: createSchemaEvent } = await createSchemaOp.signAndSend());
         assert.notEqual(createSchemaEvent, undefined, "setup should return SchemaCreated event");
         schemaId2 = createSchemaEvent!.data.schemaId;
     });

--- a/e2e/scenarios/grantDelegation.test.ts
+++ b/e2e/scenarios/grantDelegation.test.ts
@@ -238,12 +238,12 @@ describe("Delegation Scenario Tests", function () {
             await assert.rejects(op.signAndSend('current'), { name: 'RpcError', message: /Custom error: 0$/ });
         });
 
-        describe('Successful revocation', () => {
+        describe('Successful revocation', function () {
             let newKeys: KeyringPair;
             let msaId: u64 | undefined;
             let revokedAtBlock: number;
 
-            before(async () => {
+            before(async function () {
                 newKeys = createKeys();
                 const payload = await generateDelegationPayload({ authorizedMsaId: providerId, schemaIds: [schemaId] });
                 const addProviderData = ExtrinsicHelper.api.registry.createType("PalletMsaAddProvider", payload);
@@ -253,7 +253,7 @@ describe("Delegation Scenario Tests", function () {
                 assert.notEqual(msaId, undefined, 'should have returned an MSA');
             });
 
-            it("schema permissions revoked block of delegation should be zero", async () => {
+            it("schema permissions revoked block of delegation should be zero", async function () {
                 const delegationsResponse = await ExtrinsicHelper.apiPromise.rpc.msa.grantedSchemaIdsByMsaId(msaId, providerId);
                 assert(delegationsResponse.isSome);
                 const delegations: SchemaGrantResponse[] = delegationsResponse.unwrap().toArray();
@@ -271,7 +271,7 @@ describe("Delegation Scenario Tests", function () {
                 revokedAtBlock = await getBlockNumber();
             });
 
-            it("revoked delegation should be reflected in all previously-granted schema permissions", async () => {
+            it("revoked delegation should be reflected in all previously-granted schema permissions", async function () {
                 // Make a block first to make sure the state has rolled to the next block
                 const currentBlock = await getBlockNumber();
                 ExtrinsicHelper.runToBlock(currentBlock + 1);

--- a/e2e/schemas/createSchema.test.ts
+++ b/e2e/schemas/createSchema.test.ts
@@ -20,7 +20,7 @@ describe("#createSchema", function () {
 
   it("should fail if account does not have enough tokens", async function () {
 
-    await assert.rejects(ExtrinsicHelper.createSchema(accountWithNoFunds, AVRO_GRAPH_CHANGE, "AvroBinary", "OnChain").signAndSend(), {
+    await assert.rejects(ExtrinsicHelper.createSchema(accountWithNoFunds, AVRO_GRAPH_CHANGE, "AvroBinary", "OnChain").signAndSend('current'), {
       name: 'RpcError',
       message: /Inability to pay some fees/,
     });
@@ -28,7 +28,7 @@ describe("#createSchema", function () {
 
   it("should fail if account does not have enough tokens v2", async function () {
 
-    await assert.rejects(ExtrinsicHelper.createSchemaV2(accountWithNoFunds, AVRO_GRAPH_CHANGE, "AvroBinary", "OnChain",[]).signAndSend(), {
+    await assert.rejects(ExtrinsicHelper.createSchemaV2(accountWithNoFunds, AVRO_GRAPH_CHANGE, "AvroBinary", "OnChain",[]).signAndSend('current'), {
       name: 'RpcError',
       message: /Inability to pay some fees/,
     });

--- a/e2e/stateful-pallet-storage/handleItemized.test.ts
+++ b/e2e/stateful-pallet-storage/handleItemized.test.ts
@@ -9,7 +9,7 @@ import { MessageSourceId, SchemaId } from "@frequency-chain/api-augment/interfac
 import { Bytes, u16, u64 } from "@polkadot/types";
 import { getFundingSource } from "../scaffolding/funding";
 
-describe("📗 Stateful Pallet Storage", () => {
+describe("📗 Stateful Pallet Storage", function ()  {
     const fundingSource = getFundingSource("stateful-storage-handle-itemized");
     let schemaId_deletable: SchemaId;
     let schemaId_unsupported: SchemaId;
@@ -40,7 +40,7 @@ describe("📗 Stateful Pallet Storage", () => {
         [badMsaId] = await createMsa(fundingSource);
     });
 
-    describe("Itemized Storage Tests 😊/😥", () => {
+    describe("Itemized Storage Tests 😊/😥", function () {
 
         it("✅ should be able to call applyItemizedAction and apply actions", async function () {
 
@@ -132,7 +132,7 @@ describe("📗 Stateful Pallet Storage", () => {
         });
     });
 
-    describe("Itemized Storage Remove Action Tests", () => {
+    describe("Itemized Storage Remove Action Tests", function () {
 
         it("✅ should be able to call applyItemizedAction and apply remove actions", async function () {
             let target_hash = await getCurrentItemizedHash(msa_id, schemaId_deletable);
@@ -205,7 +205,7 @@ describe("📗 Stateful Pallet Storage", () => {
         });
     });
 
-    describe("Itemized Storage RPC Tests", () => {
+    describe("Itemized Storage RPC Tests", function () {
         it("✅ should be able to call getItemizedStorage and get data for itemized schema", async function () {
             const result = await ExtrinsicHelper.getItemizedStorage(msa_id, schemaId_deletable);
             assert.notEqual(result.hash, undefined, "should have returned a hash");

--- a/e2e/stateful-pallet-storage/handlePaginated.test.ts
+++ b/e2e/stateful-pallet-storage/handlePaginated.test.ts
@@ -9,7 +9,7 @@ import { MessageSourceId, SchemaId } from "@frequency-chain/api-augment/interfac
 import { Bytes, u16, u64 } from "@polkadot/types";
 import { getFundingSource } from "../scaffolding/funding";
 
-describe("📗 Stateful Pallet Storage", () => {
+describe("📗 Stateful Pallet Storage", function () {
     const fundingSource = getFundingSource("stateful-storage-handle-paginated");
 
     let schemaId: SchemaId;
@@ -44,7 +44,7 @@ describe("📗 Stateful Pallet Storage", () => {
         [badMsaId] = await createMsa(fundingSource);
     });
 
-    describe("Paginated Storage Upsert/Remove Tests 😊/😥", () => {
+    describe("Paginated Storage Upsert/Remove Tests 😊/😥", function () {
 
         it("✅ should be able to call upsert page and add a page and remove a page via id", async function () {
             let page_id = 0;
@@ -127,7 +127,7 @@ describe("📗 Stateful Pallet Storage", () => {
         });
     });
 
-    describe("Paginated Storage Removal Negative Tests 😊/😥", () => {
+    describe("Paginated Storage Removal Negative Tests 😊/😥", function () {
 
         it("🛑 should fail call to remove page with invalid schemaId", async function () {
             let fake_schema_id = 999;
@@ -165,7 +165,7 @@ describe("📗 Stateful Pallet Storage", () => {
         });
     });
 
-    describe("Paginated Storage RPC Tests", () => {
+    describe("Paginated Storage RPC Tests", function () {
         it("✅ should be able to call get_paginated_storage and get paginated data", async function () {
             const result = await ExtrinsicHelper.getPaginatedStorage(msa_id, schemaId);
             assert.notEqual(result, undefined, "should have returned a valid response");

--- a/e2e/stateful-pallet-storage/handleSignatureRequired.test.ts
+++ b/e2e/stateful-pallet-storage/handleSignatureRequired.test.ts
@@ -19,7 +19,7 @@ import { MessageSourceId, SchemaId } from "@frequency-chain/api-augment/interfac
 import { Bytes, u16 } from "@polkadot/types";
 import { getFundingSource } from "../scaffolding/funding";
 
-describe("📗 Stateful Pallet Storage Signature Required", () => {
+describe("📗 Stateful Pallet Storage Signature Required", function () {
   const fundingSource = getFundingSource("stateful-storage-handle-sig-req");
 
 
@@ -54,7 +54,7 @@ describe("📗 Stateful Pallet Storage Signature Required", () => {
     assert.notEqual(msa_id, undefined, "setup should populate msa_id");
   });
 
-  describe("Itemized With Signature Storage Tests", () => {
+  describe("Itemized With Signature Storage Tests", function () {
 
     it("should be able to call applyItemizedActionWithSignature and apply actions", async function () {
 
@@ -120,7 +120,7 @@ describe("📗 Stateful Pallet Storage Signature Required", () => {
     });
   });
 
-  describe("Paginated With Signature Storage Tests", () => {
+  describe("Paginated With Signature Storage Tests", function () {
 
     it("should be able to call upsert a page and delete it successfully", async function () {
       let page_id = new u16(ExtrinsicHelper.api.registry, 1);

--- a/e2e/sudo/sudo.test.ts
+++ b/e2e/sudo/sudo.test.ts
@@ -75,7 +75,7 @@ describe("Sudo required", function () {
     });
 
 
-    describe("📗 Stateful Pallet Storage AppendOnly Schemas", () => {
+    describe("📗 Stateful Pallet Storage AppendOnly Schemas", function () {
       // This requires schema creation abilities
 
       let itemizedSchemaId: SchemaId;
@@ -99,7 +99,7 @@ describe("Sudo required", function () {
         assert.notEqual(msa_id, undefined, "setup should populate msa_id");
       });
 
-      describe("Itemized With AppendOnly Storage Tests", () => {
+      describe("Itemized With AppendOnly Storage Tests", function () {
 
         it("should not be able to call delete action", async function () {
 


### PR DESCRIPTION
# Goal
The goal of this PR is to make nonce management easy inside of e2e tests.

This does it via a module that caches and then keeps a local state up. 

Part of #1731 


# Discussion
- RPC errors will NOT increment nonces, so those must use the `current` option
- Also split up some of the handles tests to make this easier
- Made sure everything was using `function ()` instead of `() =>` for mocha