### PR TITLE
Fix bug with StakingAccountDetails#withdraw

### DIFF
--- a/pallets/capacity/src/tests/staking_account_details_tests.rs
+++ b/pallets/capacity/src/tests/staking_account_details_tests.rs
@@ -39,6 +39,14 @@ fn staking_account_details_withdraw_goes_to_zero_when_result_below_minimum() {
 	assert_eq!(Ok(10u64), staking_account_details.withdraw(6, 3));
 	assert_eq!(0u64, staking_account_details.active);
 	assert_eq!(10u64, staking_account_details.total);
+
+	staking_account_details.deposit(10);
+	assert_eq!(Ok(10u64), staking_account_details.withdraw(9, 3));
+	assert_eq!(0u64, staking_account_details.active);
+
+	staking_account_details.deposit(10);
+	assert_eq!(Ok(10u64), staking_account_details.withdraw(11, 3));
+	assert_eq!(0u64, staking_account_details.active);
 }
 
 #[test]

--- a/pallets/capacity/src/types.rs
+++ b/pallets/capacity/src/types.rs
@@ -105,12 +105,14 @@ impl<T: Config> StakingAccountDetails<T> {
 			self.unlocking.len() < T::MaxUnlockingChunks::get() as usize,
 			Error::<T>::MaxUnlockingChunksExceeded
 		);
-		let mut active = self.active.saturating_sub(amount);
+
+		let current_active = self.active;
+		let mut new_active = self.active.saturating_sub(amount);
 		let mut actual_unstaked: BalanceOf<T> = amount;
 
-		if active.le(&T::MinimumStakingAmount::get()) {
-			actual_unstaked = amount.saturating_add(active);
-			active = Zero::zero();
+		if new_active.le(&T::MinimumStakingAmount::get()) {
+			actual_unstaked = current_active;
+			new_active = Zero::zero();
 		}
 		let unlock_chunk = UnlockChunk { value: actual_unstaked, thaw_at };
 
@@ -119,7 +121,7 @@ impl<T: Config> StakingAccountDetails<T> {
 			.try_push(unlock_chunk)
 			.map_err(|_| Error::<T>::MaxUnlockingChunksExceeded)?;
 
-		self.active = active;
+		self.active = new_active;
 		Ok(actual_unstaked)
 	}
 }


### PR DESCRIPTION
# Goal
The goal of this PR is to fix the bug with calling `StakingAccountDetails#withdraw` with more than what is in `self.active`.

Closes #1768 

# Discussion
To verify, you can undo the fix and run the regression test, and verify the red/green test behavior.

This bug cannot be triggered with our current code, because we already verify that the unstake amount does not exceed what's staked and emits `AmountToUnstakeExceedsAmountStaked` - see [`decrease_active_staking_balance`](https://github.com/LibertyDSNP/frequency/blob/ef28664464a0429a5a23019c25d37f8779e57c66/pallets/capacity/src/lib.rs#L523), 
however, if we were ever to change that verification and rely on the `withdraw` function calculation it would be triggered. Regardless of whether the bug _would have been_ triggered, the code itself should still be correct, and the function definitely should never return an amount greater than `self.active`.

Note that this does not change the intended behavior. It could be argued that instead it should return an error if the amount requested exceeds active, so it would parallel the behavior of the extrinsic.  In such case it should use a `checked_sub` instead of `saturating_sub`, and change the return value to be `Result<BalanceOf<T>, DispatchError>` when `checked_sub` fails.

# Checklist
- [x] Tests added
