### PR TITLE
Fix pre upgrade schema

### DIFF
--- a/pallets/schemas/src/migration/v3.rs
+++ b/pallets/schemas/src/migration/v3.rs
@@ -49,6 +49,7 @@ pub fn get_known_schemas() -> BTreeMap<SchemaId, Vec<u8>> {
 pub mod old {
 	use super::*;
 	use common_primitives::schema::{ModelType, PayloadLocation, SchemaSettings};
+	use frame_support::storage_alias;
 
 	#[derive(Clone, Encode, Decode, PartialEq, Debug, TypeInfo, Eq, MaxEncodedLen)]
 	/// A structure defining a Schema information (excluding the payload)
@@ -60,6 +61,13 @@ pub mod old {
 		/// additional control settings for the schema
 		pub settings: SchemaSettings,
 	}
+
+	/// Storage for message schema struct data
+	/// - Key: Schema Id
+	/// - Value: [`Schema`](Schema)
+	#[storage_alias]
+	pub(crate) type SchemaInfos<T: Config> =
+		StorageMap<Pallet<T>, Twox64Concat, SchemaId, OldSchemaInfo, OptionQuery>;
 }
 
 /// migration to v3 implementation
@@ -73,7 +81,7 @@ impl<T: Config> OnRuntimeUpgrade for MigrateToV3<T> {
 	#[cfg(feature = "try-runtime")]
 	fn pre_upgrade() -> Result<Vec<u8>, TryRuntimeError> {
 		log::info!(target: LOG_TARGET, "Running pre_upgrade...");
-		let count = SchemaInfos::<T>::iter().count() as u32;
+		let count = old::SchemaInfos::<T>::iter().count() as u32;
 		log::info!(target: LOG_TARGET, "Finish pre_upgrade for {:?}", count);
 		Ok(count.encode())
 	}

--- a/pallets/schemas/src/migration/v3.rs
+++ b/pallets/schemas/src/migration/v3.rs
@@ -62,9 +62,7 @@ pub mod old {
 		pub settings: SchemaSettings,
 	}
 
-	/// Storage for message schema struct data
-	/// - Key: Schema Id
-	/// - Value: [`Schema`](Schema)
+	/// Old Storage for schema info struct data
 	#[storage_alias]
 	pub(crate) type SchemaInfos<T: Config> =
 		StorageMap<Pallet<T>, Twox64Concat, SchemaId, OldSchemaInfo, OptionQuery>;


### PR DESCRIPTION
# Goal
The goal of this PR is to fix the pre migration issue that somehow got slipped into `main` branch. 
An example of the error is the following:

```
2023-12-21 20:34:20 Running pre_upgrade...
2023-12-21 20:34:20 (key, value) failed to decode at [238, 198, 243, 193, 61, 38, 174, 37, 7, 201, 155, 103, 81, 225, 158, 118, 13, 72, 203, 53, 182, 108, 220, 238, 63, 151, 213, 0, 114, 204, 79, 216, 6, 164, 163, 214, 215, 161, 241, 20, 108, 0]: Error
2023-12-21 20:34:20 (key, value) failed to decode at [238, 198, 243, 193, 61, 38, 174, 37, 7, 201, 155, 103, 81, 225, 158, 118, 13, 72, 203, 53, 182, 108, 220, 238, 63, 151, 213, 0, 114, 204, 79, 216, 7, 99, 201, 131, 129, 220, 137, 171, 101, 0]: Error
[More with other at values]

```

Related to #1693 

# Discussion
<!-- List discussion items -->

# Checklist
- [X] try-runtime was updated

# verification
 The try-runtime works as expected

![Screenshot 2023-12-21 at 1 53 04 PM](https://github.com/LibertyDSNP/frequency/assets/9152501/48652d58-0a08-4133-bab3-4398fdbf999f)

