### PR TITLE
Update Release tag checking to support v1.10.0

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -36,7 +36,7 @@ jobs:
         run: |
           version=${{env.NEW_RELEASE_TAG_FROM_UI}}
           echo "Release version entered in UI: $version"
-          regex='^v(0|[1-9]\d*)\.(0|[1-9]\d*)\.(0|[1-9]\d*)(-rc[1-9]\d*)?$'
+          regex='^v([0-9]+)\.(0|([1-9][0-9]+))\.(0|([1-9][0-9]+))(-rc[1-9][0-9]*)?$'
           if [[ ! $version =~ $regex ]]; then
             echo "ERROR: Entered version $version is not valid."
             echo "Please use v#.#.#[-rc#] format."

--- a/.github/workflows/rococo.yml
+++ b/.github/workflows/rococo.yml
@@ -24,7 +24,7 @@ jobs:
         run: |
           version=${{env.TAG_FROM_UI}}
           echo "Release version entered in UI: $version"
-          regex='^v(0|[1-9]\d*)\.(0|[1-9]\d*)\.(0|[1-9]\d*)(-rc[1-9]\d*)?$'
+          regex='^v([0-9]+)\.(0|([1-9][0-9]+))\.(0|([1-9][0-9]+))(-rc[1-9][0-9]*)?$'
           if [[ ! $version =~ $regex ]]; then
             echo "ERROR: Entered version $version is not valid."
             echo "Please use v#.#.#[-rc#] format."


### PR DESCRIPTION
\d doesn't work as expected. Using [0-9] instead

# Goal
The goal of this PR is to fix a release tagging issue

Test in bash:

```bash
[[ "v1.10.0" =~ ^v([0-9]+)\.(0|([1-9][0-9]+))\.(0|([1-9][0-9]+))(-rc[1-9][0-9]*)?$ ]] && echo "works"
[[ "v1.0.0" =~ ^v([0-9]+)\.(0|([1-9][0-9]+))\.(0|([1-9][0-9]+))(-rc[1-9][0-9]*)?$ ]] && echo "works"
[[ "v1.01.0" =~ ^v([0-9]+)\.(0|([1-9][0-9]+))\.(0|([1-9][0-9]+))(-rc[1-9][0-9]*)?$ ]] || echo "fails correctly"
[[ "v1.1.01" =~ ^v([0-9]+)\.(0|([1-9][0-9]+))\.(0|([1-9][0-9]+))(-rc[1-9][0-9]*)?$ ]] || echo "fails correctly"
[[ "v1.1.1-rc0" =~ ^v([0-9]+)\.(0|([1-9][0-9]+))\.(0|([1-9][0-9]+))(-rc[1-9][0-9]*)?$ ]] || echo "fails correctly"
```