### PR TITLE
ci-base-image should get a version bump with the new base OS image = Ubuntu 22.04

### DIFF
--- a/.github/workflows/merge-pr.yml
+++ b/.github/workflows/merge-pr.yml
@@ -11,7 +11,7 @@ jobs:
   changes:
     name: Determine Changed Files
     runs-on: ubuntu-22.04
-    container: ghcr.io/libertydsnp/frequency/ci-base-image:1.1.0
+    container: ghcr.io/libertydsnp/frequency/ci-base-image:latest
     outputs:
       ci-base-image: ${{steps.filter.outputs.ci-base-image}}
     steps:
@@ -28,7 +28,7 @@ jobs:
   publish-js-api-augment-rc:
     name: Merge - Publish JS API Augment Release Candidate
     runs-on: [self-hosted, Linux, X64, build, v2]
-    container: ghcr.io/libertydsnp/frequency/ci-base-image:1.1.0
+    container: ghcr.io/libertydsnp/frequency/ci-base-image:latest
     steps:
       - name: Check Out Repo
         uses: actions/checkout@v4
@@ -65,7 +65,7 @@ jobs:
   calc-code-coverage:
     name: Merge - Calculate Code Coverage
     runs-on: [self-hosted, Linux, X64, build, v2]
-    container: ghcr.io/libertydsnp/frequency/ci-base-image:1.1.0
+    container: ghcr.io/libertydsnp/frequency/ci-base-image:latest
     steps:
       - name: Check Out Repo
         uses: actions/checkout@v4
@@ -80,6 +80,9 @@ jobs:
     if: needs.changes.outputs.ci-base-image == 'true'
     name: Publish CI Base Image
     env:
+      # NOTE: IMAGE_VERSION should be updated if ci-base-image.dockerfile is updated
+      # ci-base-image is published IF and ONLY IF ci-base-image.dockerfile changes
+      # IMAGE_VERSION reflects the latest version of ci-base-image.dockerfile that has been published
       IMAGE_NAME: ci-base-image
       IMAGE_VERSION: 1.1.0
       BRANCH_NAME: main

--- a/.github/workflows/merge-pr.yml
+++ b/.github/workflows/merge-pr.yml
@@ -11,7 +11,7 @@ jobs:
   changes:
     name: Determine Changed Files
     runs-on: ubuntu-22.04
-    container: ghcr.io/libertydsnp/frequency/ci-base-image:1.0.0
+    container: ghcr.io/libertydsnp/frequency/ci-base-image:1.1.0
     outputs:
       ci-base-image: ${{steps.filter.outputs.ci-base-image}}
     steps:
@@ -28,7 +28,7 @@ jobs:
   publish-js-api-augment-rc:
     name: Merge - Publish JS API Augment Release Candidate
     runs-on: [self-hosted, Linux, X64, build, v2]
-    container: ghcr.io/libertydsnp/frequency/ci-base-image:1.0.0
+    container: ghcr.io/libertydsnp/frequency/ci-base-image:1.1.0
     steps:
       - name: Check Out Repo
         uses: actions/checkout@v4
@@ -65,7 +65,7 @@ jobs:
   calc-code-coverage:
     name: Merge - Calculate Code Coverage
     runs-on: [self-hosted, Linux, X64, build, v2]
-    container: ghcr.io/libertydsnp/frequency/ci-base-image:1.0.0
+    container: ghcr.io/libertydsnp/frequency/ci-base-image:1.1.0
     steps:
       - name: Check Out Repo
         uses: actions/checkout@v4
@@ -81,7 +81,7 @@ jobs:
     name: Publish CI Base Image
     env:
       IMAGE_NAME: ci-base-image
-      IMAGE_VERSION: 1.0.0
+      IMAGE_VERSION: 1.1.0
       BRANCH_NAME: main
     runs-on: ubuntu-22.04
     steps:

--- a/.github/workflows/publish-dev-ci-base-image.yml
+++ b/.github/workflows/publish-dev-ci-base-image.yml
@@ -8,6 +8,7 @@ on:
     branches:
       - disabled-as-this-branch-does-not-exist
       # - 1639-upgrade-to-polkadot-release-v100
+      - 1862-ci-base-image-should-get-a-version-bump-with-the-new-base-os-image-=-ubuntu-2204
 env:
   BIN_DIR: target/release
 
@@ -47,4 +48,4 @@ jobs:
           push: true
           file: tools/ci/docker/ci-base-image.dockerfile
           tags: |
-            ${{steps.repo_slug.outputs.result}}/${{env.IMAGE_NAME}}:${{env.BRANCH_NAME}}
+            ${{steps.repo_slug.outputs.result}}/${{env.IMAGE_NAME}}:1862-test-container-description

--- a/.github/workflows/publish-dev-ci-base-image.yml
+++ b/.github/workflows/publish-dev-ci-base-image.yml
@@ -8,7 +8,6 @@ on:
     branches:
       - disabled-as-this-branch-does-not-exist
       # - 1639-upgrade-to-polkadot-release-v100
-      - 1862-ci-base-image-should-get-a-version-bump-with-the-new-base-os-image-=-ubuntu-2204
 env:
   BIN_DIR: target/release
 
@@ -48,4 +47,4 @@ jobs:
           push: true
           file: tools/ci/docker/ci-base-image.dockerfile
           tags: |
-            ${{steps.repo_slug.outputs.result}}/${{env.IMAGE_NAME}}:1862-test-container-description
+            ${{steps.repo_slug.outputs.result}}/${{env.IMAGE_NAME}}:${{env.BRANCH_NAME}}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -28,7 +28,7 @@ jobs:
   validate-release-version:
     name: Validate Release Version
     runs-on: ubuntu-22.04
-    container: ghcr.io/libertydsnp/frequency/ci-base-image:1.0.0
+    container: ghcr.io/libertydsnp/frequency/ci-base-image:1.1.0
     steps:
       - name: Validate
         if: env.NEW_RELEASE_TAG_FROM_UI != ''
@@ -47,7 +47,7 @@ jobs:
     needs: validate-release-version
     name: Create Release Branch
     runs-on: ubuntu-22.04
-    container: ghcr.io/libertydsnp/frequency/ci-base-image:1.0.0
+    container: ghcr.io/libertydsnp/frequency/ci-base-image:1.1.0
     steps:
       - name: Check Out Repo
         uses: actions/checkout@v4
@@ -115,7 +115,7 @@ jobs:
     needs: run-all-benchmarks
     name: Version Code
     runs-on: ubuntu-22.04
-    container: ghcr.io/libertydsnp/frequency/ci-base-image:1.0.0
+    container: ghcr.io/libertydsnp/frequency/ci-base-image:1.1.0
     steps:
       - name: Check Out Repo
         uses: actions/checkout@v4
@@ -178,7 +178,7 @@ jobs:
           # - os: [self-hosted, Linux, ARM64]
           #   arch: arm64
     runs-on: ${{matrix.os}}
-    container: ghcr.io/libertydsnp/frequency/ci-base-image:1.0.0
+    container: ghcr.io/libertydsnp/frequency/ci-base-image:1.1.0
     env:
       SIGNING_SUBKEY_FINGERPRINT: B6327D1474C6392032870E8EFA4FD1E73A0FE707
     steps:
@@ -351,7 +351,7 @@ jobs:
     needs: version-code
     name: Build Rust Developer Docs
     runs-on: [self-hosted, Linux, X64, build, v2]
-    container: ghcr.io/libertydsnp/frequency/ci-base-image:1.0.0
+    container: ghcr.io/libertydsnp/frequency/ci-base-image:1.1.0
     steps:
       - name: Check Out Repo
         uses: actions/checkout@v4
@@ -386,7 +386,7 @@ jobs:
       RELEASE_FILENAME_PREFIX: frequency-rococo-local
       ARCH: amd64
     runs-on: ubuntu-22.04
-    container: ghcr.io/libertydsnp/frequency/ci-base-image:1.0.0
+    container: ghcr.io/libertydsnp/frequency/ci-base-image:1.1.0
     steps:
       - name: Set Env Vars
         run: |
@@ -450,7 +450,7 @@ jobs:
           - os: ubuntu-22.04
             arch: amd64
     runs-on: ${{matrix.os}}
-    container: ghcr.io/libertydsnp/frequency/ci-base-image:1.0.0
+    container: ghcr.io/libertydsnp/frequency/ci-base-image:1.1.0
     steps:
       - name: Set Env Vars
         run: |
@@ -644,7 +644,7 @@ jobs:
     needs: wait-for-all-builds
     name: Release Built Artifacts
     runs-on: ubuntu-22.04
-    container: ghcr.io/libertydsnp/frequency/ci-base-image:1.0.0
+    container: ghcr.io/libertydsnp/frequency/ci-base-image:1.1.0
     steps:
       - name: Check Out Repo
         uses: actions/checkout@v4
@@ -818,7 +818,7 @@ jobs:
       DOCKER_HUB_PROFILE: frequencychain
       IMAGE_NAME: parachain-node
     runs-on: ubuntu-22.04
-    container: ghcr.io/libertydsnp/frequency/ci-base-image:1.0.0
+    container: ghcr.io/libertydsnp/frequency/ci-base-image:1.1.0
     steps:
       - name: Set Env Vars
         run: |
@@ -916,7 +916,7 @@ jobs:
     env:
       DOCKER_HUB_PROFILE: frequencychain
     runs-on: ubuntu-22.04
-    container: ghcr.io/libertydsnp/frequency/ci-base-image:1.0.0
+    container: ghcr.io/libertydsnp/frequency/ci-base-image:1.1.0
     steps:
       - name: Set Env Vars
         run: |
@@ -993,7 +993,7 @@ jobs:
     needs: wait-for-all-builds
     name: Release Rust Developer Docs
     runs-on: ubuntu-22.04
-    container: ghcr.io/libertydsnp/frequency/ci-base-image:1.0.0
+    container: ghcr.io/libertydsnp/frequency/ci-base-image:1.1.0
     permissions:
       contents: read
       pages: write
@@ -1011,7 +1011,7 @@ jobs:
     needs: wait-for-all-builds
     name: Release JS API Augment
     runs-on: ubuntu-22.04
-    container: ghcr.io/libertydsnp/frequency/ci-base-image:1.0.0
+    container: ghcr.io/libertydsnp/frequency/ci-base-image:1.1.0
     steps:
       - name: Check Out Repo
         uses: actions/checkout@v4

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -28,7 +28,7 @@ jobs:
   validate-release-version:
     name: Validate Release Version
     runs-on: ubuntu-22.04
-    container: ghcr.io/libertydsnp/frequency/ci-base-image:1.1.0
+    container: ghcr.io/libertydsnp/frequency/ci-base-image:latest
     steps:
       - name: Validate
         if: env.NEW_RELEASE_TAG_FROM_UI != ''
@@ -47,7 +47,7 @@ jobs:
     needs: validate-release-version
     name: Create Release Branch
     runs-on: ubuntu-22.04
-    container: ghcr.io/libertydsnp/frequency/ci-base-image:1.1.0
+    container: ghcr.io/libertydsnp/frequency/ci-base-image:latest
     steps:
       - name: Check Out Repo
         uses: actions/checkout@v4
@@ -115,7 +115,7 @@ jobs:
     needs: run-all-benchmarks
     name: Version Code
     runs-on: ubuntu-22.04
-    container: ghcr.io/libertydsnp/frequency/ci-base-image:1.1.0
+    container: ghcr.io/libertydsnp/frequency/ci-base-image:latest
     steps:
       - name: Check Out Repo
         uses: actions/checkout@v4
@@ -178,7 +178,7 @@ jobs:
           # - os: [self-hosted, Linux, ARM64]
           #   arch: arm64
     runs-on: ${{matrix.os}}
-    container: ghcr.io/libertydsnp/frequency/ci-base-image:1.1.0
+    container: ghcr.io/libertydsnp/frequency/ci-base-image:latest
     env:
       SIGNING_SUBKEY_FINGERPRINT: B6327D1474C6392032870E8EFA4FD1E73A0FE707
     steps:
@@ -351,7 +351,7 @@ jobs:
     needs: version-code
     name: Build Rust Developer Docs
     runs-on: [self-hosted, Linux, X64, build, v2]
-    container: ghcr.io/libertydsnp/frequency/ci-base-image:1.1.0
+    container: ghcr.io/libertydsnp/frequency/ci-base-image:latest
     steps:
       - name: Check Out Repo
         uses: actions/checkout@v4
@@ -386,7 +386,7 @@ jobs:
       RELEASE_FILENAME_PREFIX: frequency-rococo-local
       ARCH: amd64
     runs-on: ubuntu-22.04
-    container: ghcr.io/libertydsnp/frequency/ci-base-image:1.1.0
+    container: ghcr.io/libertydsnp/frequency/ci-base-image:latest
     steps:
       - name: Set Env Vars
         run: |
@@ -450,7 +450,7 @@ jobs:
           - os: ubuntu-22.04
             arch: amd64
     runs-on: ${{matrix.os}}
-    container: ghcr.io/libertydsnp/frequency/ci-base-image:1.1.0
+    container: ghcr.io/libertydsnp/frequency/ci-base-image:latest
     steps:
       - name: Set Env Vars
         run: |
@@ -644,7 +644,7 @@ jobs:
     needs: wait-for-all-builds
     name: Release Built Artifacts
     runs-on: ubuntu-22.04
-    container: ghcr.io/libertydsnp/frequency/ci-base-image:1.1.0
+    container: ghcr.io/libertydsnp/frequency/ci-base-image:latest
     steps:
       - name: Check Out Repo
         uses: actions/checkout@v4
@@ -818,7 +818,7 @@ jobs:
       DOCKER_HUB_PROFILE: frequencychain
       IMAGE_NAME: parachain-node
     runs-on: ubuntu-22.04
-    container: ghcr.io/libertydsnp/frequency/ci-base-image:1.1.0
+    container: ghcr.io/libertydsnp/frequency/ci-base-image:latest
     steps:
       - name: Set Env Vars
         run: |
@@ -916,7 +916,7 @@ jobs:
     env:
       DOCKER_HUB_PROFILE: frequencychain
     runs-on: ubuntu-22.04
-    container: ghcr.io/libertydsnp/frequency/ci-base-image:1.1.0
+    container: ghcr.io/libertydsnp/frequency/ci-base-image:latest
     steps:
       - name: Set Env Vars
         run: |
@@ -993,7 +993,7 @@ jobs:
     needs: wait-for-all-builds
     name: Release Rust Developer Docs
     runs-on: ubuntu-22.04
-    container: ghcr.io/libertydsnp/frequency/ci-base-image:1.1.0
+    container: ghcr.io/libertydsnp/frequency/ci-base-image:latest
     permissions:
       contents: read
       pages: write
@@ -1011,7 +1011,7 @@ jobs:
     needs: wait-for-all-builds
     name: Release JS API Augment
     runs-on: ubuntu-22.04
-    container: ghcr.io/libertydsnp/frequency/ci-base-image:1.1.0
+    container: ghcr.io/libertydsnp/frequency/ci-base-image:latest
     steps:
       - name: Check Out Repo
         uses: actions/checkout@v4

--- a/.github/workflows/rococo.yml
+++ b/.github/workflows/rococo.yml
@@ -17,7 +17,7 @@ jobs:
   run-e2e:
     name: Run E2E Tests
     runs-on: [self-hosted, Linux, X64, build, v2]
-    container: ghcr.io/libertydsnp/frequency/ci-base-image:1.0.0
+    container: ghcr.io/libertydsnp/frequency/ci-base-image:1.1.0
     steps:
       - name: Validate
         shell: bash

--- a/.github/workflows/rococo.yml
+++ b/.github/workflows/rococo.yml
@@ -17,7 +17,7 @@ jobs:
   run-e2e:
     name: Run E2E Tests
     runs-on: [self-hosted, Linux, X64, build, v2]
-    container: ghcr.io/libertydsnp/frequency/ci-base-image:1.1.0
+    container: ghcr.io/libertydsnp/frequency/ci-base-image:latest
     steps:
       - name: Validate
         shell: bash

--- a/.github/workflows/verify-pr-commit.yml
+++ b/.github/workflows/verify-pr-commit.yml
@@ -16,7 +16,7 @@ jobs:
   changes:
     name: Determine Changed Files
     runs-on: ubuntu-22.04
-    container: ghcr.io/libertydsnp/frequency/ci-base-image:1.0.0
+    container: ghcr.io/libertydsnp/frequency/ci-base-image:1.1.0
     outputs:
       rust: ${{steps.filter.outputs.rust}}
       build-binary: ${{steps.filter.outputs.build-binary}}
@@ -58,7 +58,7 @@ jobs:
   clear-metadata-labels:
     name: Clear Metadata Labels
     runs-on: ubuntu-22.04
-    container: ghcr.io/libertydsnp/frequency/ci-base-image:1.0.0
+    container: ghcr.io/libertydsnp/frequency/ci-base-image:1.1.0
     steps:
       - name: Clear Metadata Changed Label
         if: contains(github.event.pull_request.labels.*.name, env.PR_LABEL_METADATA_CHANGED)
@@ -132,7 +132,7 @@ jobs:
             spec: frequency
             branch_alias: pr
     runs-on: [self-hosted, Linux, X64, build, v2]
-    container: ghcr.io/libertydsnp/frequency/ci-base-image:1.0.0
+    container: ghcr.io/libertydsnp/frequency/ci-base-image:1.1.0
     env:
       NETWORK: mainnet
     steps:
@@ -178,7 +178,7 @@ jobs:
     if: needs.changes.outputs.cargo-lock == 'true'
     name: Check for Vulnerable Crates
     runs-on: ubuntu-22.04
-    container: ghcr.io/libertydsnp/frequency/ci-base-image:1.0.0
+    container: ghcr.io/libertydsnp/frequency/ci-base-image:1.1.0
     steps:
       - name: Check Out Repo
         uses: actions/checkout@v4
@@ -194,7 +194,7 @@ jobs:
     if: needs.changes.outputs.rust == 'true'
     name: Verify Rust Code Format
     runs-on: ubuntu-22.04
-    container: ghcr.io/libertydsnp/frequency/ci-base-image:1.0.0
+    container: ghcr.io/libertydsnp/frequency/ci-base-image:1.1.0
     steps:
       - name: Check Out Repo
         uses: actions/checkout@v4
@@ -207,7 +207,7 @@ jobs:
     if: needs.changes.outputs.rust == 'true'
     name: Lint Rust Code
     runs-on: [self-hosted, Linux, X64, build, v2]
-    container: ghcr.io/libertydsnp/frequency/ci-base-image:1.0.0
+    container: ghcr.io/libertydsnp/frequency/ci-base-image:1.1.0
     steps:
       - name: Check Out Repo
         uses: actions/checkout@v4
@@ -223,7 +223,7 @@ jobs:
     if: needs.changes.outputs.rust == 'true'
     name: Verify Rust Developer Docs
     runs-on: [self-hosted, Linux, X64, build, v2]
-    container: ghcr.io/libertydsnp/frequency/ci-base-image:1.0.0
+    container: ghcr.io/libertydsnp/frequency/ci-base-image:1.1.0
     steps:
       - name: Check Out Repo
         uses: actions/checkout@v4
@@ -237,7 +237,7 @@ jobs:
     if: needs.changes.outputs.rust == 'true'
     name: Verify Rust Packages and Dependencies
     runs-on: [self-hosted, Linux, X64, build, v2]
-    container: ghcr.io/libertydsnp/frequency/ci-base-image:1.0.0
+    container: ghcr.io/libertydsnp/frequency/ci-base-image:1.1.0
     steps:
       - name: Check Out Repo
         uses: actions/checkout@v4
@@ -249,7 +249,7 @@ jobs:
     if: needs.changes.outputs.rust == 'true'
     name: Run Rust Tests
     runs-on: [self-hosted, Linux, X64, build, v2]
-    container: ghcr.io/libertydsnp/frequency/ci-base-image:1.0.0
+    container: ghcr.io/libertydsnp/frequency/ci-base-image:1.1.0
     steps:
       - name: Check Out Repo
         uses: actions/checkout@v4
@@ -264,7 +264,7 @@ jobs:
     if: needs.changes.outputs.rust == 'true'
     name: Calculate Code Coverage
     runs-on: [self-hosted, Linux, X64, build, v2]
-    container: ghcr.io/libertydsnp/frequency/ci-base-image:1.0.0
+    container: ghcr.io/libertydsnp/frequency/ci-base-image:1.1.0
     steps:
       - name: Check Out Repo
         uses: actions/checkout@v4
@@ -389,7 +389,7 @@ jobs:
     needs: build-binaries
     name: Verify JS API Augment
     runs-on: ubuntu-22.04
-    container: ghcr.io/libertydsnp/frequency/ci-base-image:1.0.0
+    container: ghcr.io/libertydsnp/frequency/ci-base-image:1.1.0
     steps:
       - name: Check Out Repo
         uses: actions/checkout@v4
@@ -448,7 +448,7 @@ jobs:
     needs: build-binaries
     name: Verify Node Docker Images
     runs-on: ubuntu-22.04
-    container: ghcr.io/libertydsnp/frequency/ci-base-image:1.0.0
+    container: ghcr.io/libertydsnp/frequency/ci-base-image:1.1.0
     steps:
       - name: Check Out Repo
         uses: actions/checkout@v4
@@ -510,7 +510,7 @@ jobs:
     if: needs.changes.outputs.ci-docker-image == 'true'
     name: Verify CI Docker Image
     runs-on: ubuntu-22.04
-    container: ghcr.io/libertydsnp/frequency/ci-base-image:1.0.0
+    container: ghcr.io/libertydsnp/frequency/ci-base-image:1.1.0
     steps:
       - name: Check Out Repo
         uses: actions/checkout@v4
@@ -534,7 +534,7 @@ jobs:
     needs: build-binaries
     name: Execute Binary Checks
     runs-on: ubuntu-22.04
-    container: ghcr.io/libertydsnp/frequency/ci-base-image:1.0.0
+    container: ghcr.io/libertydsnp/frequency/ci-base-image:1.1.0
     steps:
       - name: Check Out Repo
         uses: actions/checkout@v4
@@ -565,7 +565,7 @@ jobs:
     needs: build-binaries
     name: Check Metadata and Spec Version
     runs-on: ubuntu-22.04
-    container: ghcr.io/libertydsnp/frequency/ci-base-image:1.0.0
+    container: ghcr.io/libertydsnp/frequency/ci-base-image:1.1.0
     steps:
       - name: Check Out Repo
         uses: actions/checkout@v4
@@ -719,7 +719,7 @@ jobs:
     needs: build-binaries
     name: Verify Genesis State
     runs-on: ubuntu-22.04
-    container: ghcr.io/libertydsnp/frequency/ci-base-image:1.0.0
+    container: ghcr.io/libertydsnp/frequency/ci-base-image:1.1.0
     steps:
       - name: Set Env Vars
         run: |
@@ -766,7 +766,7 @@ jobs:
     if: github.repository == 'LibertyDSNP/frequency'
     name: Run Benchmarks?
     runs-on: ubuntu-22.04
-    container: ghcr.io/libertydsnp/frequency/ci-base-image:1.0.0
+    container: ghcr.io/libertydsnp/frequency/ci-base-image:1.1.0
     outputs:
       should_run_benchmarks: ${{steps.run-benchmarks.outputs.run}}
       pallets: ${{steps.run-benchmarks.outputs.pallets}}

--- a/.github/workflows/verify-pr-commit.yml
+++ b/.github/workflows/verify-pr-commit.yml
@@ -16,7 +16,7 @@ jobs:
   changes:
     name: Determine Changed Files
     runs-on: ubuntu-22.04
-    container: ghcr.io/libertydsnp/frequency/ci-base-image:1.1.0
+    container: ghcr.io/libertydsnp/frequency/ci-base-image:latest
     outputs:
       rust: ${{steps.filter.outputs.rust}}
       build-binary: ${{steps.filter.outputs.build-binary}}
@@ -58,7 +58,7 @@ jobs:
   clear-metadata-labels:
     name: Clear Metadata Labels
     runs-on: ubuntu-22.04
-    container: ghcr.io/libertydsnp/frequency/ci-base-image:1.1.0
+    container: ghcr.io/libertydsnp/frequency/ci-base-image:latest
     steps:
       - name: Clear Metadata Changed Label
         if: contains(github.event.pull_request.labels.*.name, env.PR_LABEL_METADATA_CHANGED)
@@ -132,7 +132,7 @@ jobs:
             spec: frequency
             branch_alias: pr
     runs-on: [self-hosted, Linux, X64, build, v2]
-    container: ghcr.io/libertydsnp/frequency/ci-base-image:1.1.0
+    container: ghcr.io/libertydsnp/frequency/ci-base-image:latest
     env:
       NETWORK: mainnet
     steps:
@@ -178,7 +178,7 @@ jobs:
     if: needs.changes.outputs.cargo-lock == 'true'
     name: Check for Vulnerable Crates
     runs-on: ubuntu-22.04
-    container: ghcr.io/libertydsnp/frequency/ci-base-image:1.1.0
+    container: ghcr.io/libertydsnp/frequency/ci-base-image:latest
     steps:
       - name: Check Out Repo
         uses: actions/checkout@v4
@@ -194,7 +194,7 @@ jobs:
     if: needs.changes.outputs.rust == 'true'
     name: Verify Rust Code Format
     runs-on: ubuntu-22.04
-    container: ghcr.io/libertydsnp/frequency/ci-base-image:1.1.0
+    container: ghcr.io/libertydsnp/frequency/ci-base-image:latest
     steps:
       - name: Check Out Repo
         uses: actions/checkout@v4
@@ -207,7 +207,7 @@ jobs:
     if: needs.changes.outputs.rust == 'true'
     name: Lint Rust Code
     runs-on: [self-hosted, Linux, X64, build, v2]
-    container: ghcr.io/libertydsnp/frequency/ci-base-image:1.1.0
+    container: ghcr.io/libertydsnp/frequency/ci-base-image:latest
     steps:
       - name: Check Out Repo
         uses: actions/checkout@v4
@@ -223,7 +223,7 @@ jobs:
     if: needs.changes.outputs.rust == 'true'
     name: Verify Rust Developer Docs
     runs-on: [self-hosted, Linux, X64, build, v2]
-    container: ghcr.io/libertydsnp/frequency/ci-base-image:1.1.0
+    container: ghcr.io/libertydsnp/frequency/ci-base-image:latest
     steps:
       - name: Check Out Repo
         uses: actions/checkout@v4
@@ -237,7 +237,7 @@ jobs:
     if: needs.changes.outputs.rust == 'true'
     name: Verify Rust Packages and Dependencies
     runs-on: [self-hosted, Linux, X64, build, v2]
-    container: ghcr.io/libertydsnp/frequency/ci-base-image:1.1.0
+    container: ghcr.io/libertydsnp/frequency/ci-base-image:latest
     steps:
       - name: Check Out Repo
         uses: actions/checkout@v4
@@ -249,7 +249,7 @@ jobs:
     if: needs.changes.outputs.rust == 'true'
     name: Run Rust Tests
     runs-on: [self-hosted, Linux, X64, build, v2]
-    container: ghcr.io/libertydsnp/frequency/ci-base-image:1.1.0
+    container: ghcr.io/libertydsnp/frequency/ci-base-image:latest
     steps:
       - name: Check Out Repo
         uses: actions/checkout@v4
@@ -264,7 +264,7 @@ jobs:
     if: needs.changes.outputs.rust == 'true'
     name: Calculate Code Coverage
     runs-on: [self-hosted, Linux, X64, build, v2]
-    container: ghcr.io/libertydsnp/frequency/ci-base-image:1.1.0
+    container: ghcr.io/libertydsnp/frequency/ci-base-image:latest
     steps:
       - name: Check Out Repo
         uses: actions/checkout@v4
@@ -389,7 +389,7 @@ jobs:
     needs: build-binaries
     name: Verify JS API Augment
     runs-on: ubuntu-22.04
-    container: ghcr.io/libertydsnp/frequency/ci-base-image:1.1.0
+    container: ghcr.io/libertydsnp/frequency/ci-base-image:latest
     steps:
       - name: Check Out Repo
         uses: actions/checkout@v4
@@ -448,7 +448,7 @@ jobs:
     needs: build-binaries
     name: Verify Node Docker Images
     runs-on: ubuntu-22.04
-    container: ghcr.io/libertydsnp/frequency/ci-base-image:1.1.0
+    container: ghcr.io/libertydsnp/frequency/ci-base-image:latest
     steps:
       - name: Check Out Repo
         uses: actions/checkout@v4
@@ -510,7 +510,7 @@ jobs:
     if: needs.changes.outputs.ci-docker-image == 'true'
     name: Verify CI Docker Image
     runs-on: ubuntu-22.04
-    container: ghcr.io/libertydsnp/frequency/ci-base-image:1.1.0
+    container: ghcr.io/libertydsnp/frequency/ci-base-image:latest
     steps:
       - name: Check Out Repo
         uses: actions/checkout@v4
@@ -534,7 +534,7 @@ jobs:
     needs: build-binaries
     name: Execute Binary Checks
     runs-on: ubuntu-22.04
-    container: ghcr.io/libertydsnp/frequency/ci-base-image:1.1.0
+    container: ghcr.io/libertydsnp/frequency/ci-base-image:latest
     steps:
       - name: Check Out Repo
         uses: actions/checkout@v4
@@ -565,7 +565,7 @@ jobs:
     needs: build-binaries
     name: Check Metadata and Spec Version
     runs-on: ubuntu-22.04
-    container: ghcr.io/libertydsnp/frequency/ci-base-image:1.1.0
+    container: ghcr.io/libertydsnp/frequency/ci-base-image:latest
     steps:
       - name: Check Out Repo
         uses: actions/checkout@v4
@@ -719,7 +719,7 @@ jobs:
     needs: build-binaries
     name: Verify Genesis State
     runs-on: ubuntu-22.04
-    container: ghcr.io/libertydsnp/frequency/ci-base-image:1.1.0
+    container: ghcr.io/libertydsnp/frequency/ci-base-image:latest
     steps:
       - name: Set Env Vars
         run: |
@@ -766,7 +766,7 @@ jobs:
     if: github.repository == 'LibertyDSNP/frequency'
     name: Run Benchmarks?
     runs-on: ubuntu-22.04
-    container: ghcr.io/libertydsnp/frequency/ci-base-image:1.1.0
+    container: ghcr.io/libertydsnp/frequency/ci-base-image:latest
     outputs:
       should_run_benchmarks: ${{steps.run-benchmarks.outputs.run}}
       pallets: ${{steps.run-benchmarks.outputs.pallets}}

--- a/tools/ci/docker/ci-base-image.dockerfile
+++ b/tools/ci/docker/ci-base-image.dockerfile
@@ -1,8 +1,11 @@
+# NOTE: If you make changes in this file, be sure to update IMAGE_VERSION in merge-pr.yml
+# ci-base-image is published IF and ONLY IF changes are detected in this dockerfile.
+
 FROM --platform=linux/amd64 ubuntu:22.04
 ENV DEBIAN_FRONTEND=noninteractive
 LABEL maintainer="Frequency"
-LABEL description="Frequency CI Base Image"
-# Image version is set by the CI pipeline
+LABEL org.opencontainers.image.description="Frequency CI Base Image"
+# Image version is set by the CI pipeline in merge-pr.yml
 ARG IMAGE_VERSION
 LABEL version="{IMAGE_VERSION}"
 

--- a/tools/ci/docker/ci-base-image.dockerfile
+++ b/tools/ci/docker/ci-base-image.dockerfile
@@ -4,7 +4,7 @@
 FROM --platform=linux/amd64 ubuntu:22.04
 ENV DEBIAN_FRONTEND=noninteractive
 LABEL maintainer="Frequency"
-LABEL org.opencontainers.image.description="Frequency CI Base Image"
+LABEL description="Frequency CI Base Image"
 # Image version is set by the CI pipeline in merge-pr.yml
 ARG IMAGE_VERSION
 LABEL version="{IMAGE_VERSION}"


### PR DESCRIPTION
# Goal
When ci-base-image container changes, the version number should be bumped.

The base os for the container was bumped from Ubuntu 20.04 to 22.04.

The ci-base-image version should be bumped to 1.1.0

Closes #1862 

# Checklist
- [ ] Chain spec updated
- [ ] Custom RPC OR Runtime API added/changed? Updated js/api-augment.
- [ ] Design doc(s) updated
- [ ] Tests added
- [ ] Benchmarks added
- [ ] Weights updated
