### PR TITLE
fix: Update CI Base Image version to 1.1.0

### DIFF
--- a/.github/workflows/merge-pr.yml
+++ b/.github/workflows/merge-pr.yml
@@ -81,7 +81,7 @@ jobs:
     name: Publish CI Base Image
     env:
       IMAGE_NAME: ci-base-image
-      IMAGE_VERSION: 1.0.0
+      IMAGE_VERSION: 1.1.0
       BRANCH_NAME: main
     runs-on: ubuntu-22.04
     steps:

--- a/tools/ci/docker/ci-base-image.dockerfile
+++ b/tools/ci/docker/ci-base-image.dockerfile
@@ -2,6 +2,7 @@ FROM --platform=linux/amd64 ubuntu:22.04
 ENV DEBIAN_FRONTEND=noninteractive
 LABEL maintainer="Frequency"
 LABEL description="Frequency CI Base Image"
+# Image version is set by the CI pipeline
 ARG IMAGE_VERSION
 LABEL version="{IMAGE_VERSION}"
 


### PR DESCRIPTION
# Goal
The goal of this PR is to publish a new version of ci-base-image with version 1.1.0.

# Checklist
- [ ] Chain spec updated
- [ ] Custom RPC OR Runtime API added/changed? Updated js/api-augment.
- [ ] Design doc(s) updated
- [ ] Tests added
- [ ] Benchmarks added
- [ ] Weights updated
