### PR TITLE
feat: add jq and curl to frequency docker images

### DIFF
--- a/docker/instant-seal-node.dockerfile
+++ b/docker/instant-seal-node.dockerfile
@@ -13,8 +13,10 @@ RUN apt-get update && apt-get install -y ca-certificates jq curl && update-ca-ce
 FROM --platform=linux/amd64 ubuntu:22.04
 
 # We want jq and curl in the final image, but we don't need the support files
-RUN apt-get update && apt-get install -y jq curl && apt-get clean
-RUN rm -rf /usr/share/doc /usr/share/man /usr/share/zsh
+RUN apt-get update && \
+	apt-get install -y jq curl && \
+	apt-get clean && \
+	rm -rf /usr/share/doc /usr/share/man /usr/share/zsh
 
 RUN useradd -m -u 1000 -U -s /bin/sh -d /frequency frequency && \
 	mkdir -p /data /frequency/.local/share && \

--- a/docker/instant-seal-node.dockerfile
+++ b/docker/instant-seal-node.dockerfile
@@ -7,10 +7,14 @@ FROM --platform=linux/amd64 ubuntu:22.04 AS base
 LABEL maintainer="Frequency"
 LABEL description="Frequency collator node in instant seal mode"
 
-RUN apt-get update && apt-get install -y ca-certificates && update-ca-certificates
+RUN apt-get update && apt-get install -y ca-certificates jq curl && update-ca-certificates
 
 # This is the 2nd stage: a very small image where we copy the Frequency binary
 FROM --platform=linux/amd64 ubuntu:22.04
+
+# We want jq and curl in the final image, but we don't need the support files
+RUN apt-get update && apt-get install -y jq curl && apt-get clean
+RUN rm -rf /usr/share/doc /usr/share/man /usr/share/zsh
 
 RUN useradd -m -u 1000 -U -s /bin/sh -d /frequency frequency && \
 	mkdir -p /data /frequency/.local/share && \

--- a/docker/parachain-node.dockerfile
+++ b/docker/parachain-node.dockerfile
@@ -11,6 +11,10 @@ RUN apt-get update && apt-get install -y ca-certificates && update-ca-certificat
 # This is the 2nd stage: a very small image where we copy the Frequency binary
 FROM --platform=linux/amd64 ubuntu:22.04
 
+# We want jq and curl in the final image, but we don't need the support files
+RUN apt-get update && apt-get install -y jq curl && apt-get clean
+RUN rm -rf /usr/share/doc /usr/share/man /usr/share/zsh
+
 RUN useradd -m -u 1000 -U -s /bin/sh -d /frequency frequency && \
 	mkdir -p /chain-data /frequency/.local/share && \
 	chown -R frequency:frequency /chain-data && \
@@ -34,5 +38,3 @@ ENTRYPOINT ["/frequency/frequency"]
 
 # Params which can be overriden from CLI
 # CMD ["", "", ...]
-
-

--- a/docker/parachain-node.dockerfile
+++ b/docker/parachain-node.dockerfile
@@ -12,8 +12,10 @@ RUN apt-get update && apt-get install -y ca-certificates && update-ca-certificat
 FROM --platform=linux/amd64 ubuntu:22.04
 
 # We want jq and curl in the final image, but we don't need the support files
-RUN apt-get update && apt-get install -y jq curl && apt-get clean
-RUN rm -rf /usr/share/doc /usr/share/man /usr/share/zsh
+RUN apt-get update && \
+	apt-get install -y jq curl && \
+	apt-get clean && \
+	rm -rf /usr/share/doc /usr/share/man /usr/share/zsh
 
 RUN useradd -m -u 1000 -U -s /bin/sh -d /frequency frequency && \
 	mkdir -p /chain-data /frequency/.local/share && \

--- a/docker/standalone-node.dockerfile
+++ b/docker/standalone-node.dockerfile
@@ -12,6 +12,10 @@ RUN apt-get update && apt-get install -y ca-certificates && update-ca-certificat
 # This is the 2nd stage: a very small image where we copy the Frequency binary
 FROM --platform=linux/amd64 ubuntu:22.04
 
+# We want jq and curl in the final image, but we don't need the support files
+RUN apt-get update && apt-get install -y jq curl && apt-get clean
+RUN rm -rf /usr/share/doc /usr/share/man /usr/share/zsh
+
 RUN useradd -m -u 1000 -U -s /bin/sh -d /frequency frequency && \
 	mkdir -p /data /frequency/.local/share && \
 	chown -R frequency:frequency /data && \

--- a/docker/standalone-node.dockerfile
+++ b/docker/standalone-node.dockerfile
@@ -13,8 +13,10 @@ RUN apt-get update && apt-get install -y ca-certificates && update-ca-certificat
 FROM --platform=linux/amd64 ubuntu:22.04
 
 # We want jq and curl in the final image, but we don't need the support files
-RUN apt-get update && apt-get install -y jq curl && apt-get clean
-RUN rm -rf /usr/share/doc /usr/share/man /usr/share/zsh
+RUN apt-get update && \
+	apt-get install -y jq curl && \
+	apt-get clean && \
+	rm -rf /usr/share/doc /usr/share/man /usr/share/zsh
 
 RUN useradd -m -u 1000 -U -s /bin/sh -d /frequency frequency && \
 	mkdir -p /data /frequency/.local/share && \


### PR DESCRIPTION
# Goal
The goal of this PR is to add the `jq` and `curl` binaries to our published Docker images for Frequency.

Closes #1865 

# Discussion
<!-- List discussion items -->

# Checklist
- [ ] Chain spec updated
- [ ] Custom RPC OR Runtime API added/changed? Updated js/api-augment.
- [ ] Design doc(s) updated
- [ ] Tests added
- [ ] Benchmarks added
- [ ] Weights updated
