### PR TITLE
Update cid crate to remove special handling in `Cargo.toml`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1223,17 +1223,18 @@ dependencies = [
  "multibase",
  "multihash 0.17.0",
  "serde",
- "unsigned-varint",
+ "unsigned-varint 0.7.2",
 ]
 
 [[package]]
 name = "cid"
-version = "0.10.1"
-source = "git+https://github.com/multiformats/rust-cid?rev=86c79126d851316350ad106d0df3e4ae69071874#86c79126d851316350ad106d0df3e4ae69071874"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "472ac98592f38dfd48f188d5713a328422ed22fa39eb52b8bca495370134762a"
 dependencies = [
  "core2",
  "multihash 0.19.1",
- "unsigned-varint",
+ "unsigned-varint 0.8.0",
 ]
 
 [[package]]
@@ -4163,7 +4164,7 @@ dependencies = [
  "httpdate",
  "itoa",
  "pin-project-lite 0.2.13",
- "socket2 0.4.10",
+ "socket2 0.5.5",
  "tokio",
  "tower-service",
  "tracing",
@@ -4837,7 +4838,7 @@ dependencies = [
  "rw-stream-sink",
  "smallvec",
  "thiserror",
- "unsigned-varint",
+ "unsigned-varint 0.7.2",
  "void",
 ]
 
@@ -4919,7 +4920,7 @@ dependencies = [
  "smallvec",
  "thiserror",
  "uint",
- "unsigned-varint",
+ "unsigned-varint 0.7.2",
  "void",
 ]
 
@@ -5619,7 +5620,7 @@ dependencies = [
  "percent-encoding",
  "serde",
  "static_assertions",
- "unsigned-varint",
+ "unsigned-varint 0.7.2",
  "url",
 ]
 
@@ -5648,7 +5649,7 @@ dependencies = [
  "multihash-derive",
  "sha2 0.10.8",
  "sha3",
- "unsigned-varint",
+ "unsigned-varint 0.7.2",
 ]
 
 [[package]]
@@ -5658,7 +5659,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "076d548d76a0e2a0d4ab471d0b1c36c577786dfc4471242035d97a12a735c492"
 dependencies = [
  "core2",
- "unsigned-varint",
+ "unsigned-varint 0.7.2",
 ]
 
 [[package]]
@@ -5692,7 +5693,7 @@ dependencies = [
  "log",
  "pin-project",
  "smallvec",
- "unsigned-varint",
+ "unsigned-varint 0.7.2",
 ]
 
 [[package]]
@@ -6612,7 +6613,7 @@ dependencies = [
 name = "pallet-messages"
 version = "0.0.0"
 dependencies = [
- "cid 0.10.1",
+ "cid 0.11.0",
  "common-primitives",
  "common-runtime",
  "frame-benchmarking",
@@ -9313,7 +9314,7 @@ dependencies = [
  "bytes",
  "quick-protobuf",
  "thiserror",
- "unsigned-varint",
+ "unsigned-varint 0.7.2",
 ]
 
 [[package]]
@@ -10610,7 +10611,7 @@ dependencies = [
  "sp-runtime",
  "substrate-prometheus-endpoint",
  "thiserror",
- "unsigned-varint",
+ "unsigned-varint 0.7.2",
  "wasm-timer",
  "zeroize",
 ]
@@ -10632,7 +10633,7 @@ dependencies = [
  "sp-blockchain",
  "sp-runtime",
  "thiserror",
- "unsigned-varint",
+ "unsigned-varint 0.7.2",
 ]
 
 [[package]]
@@ -11446,9 +11447,9 @@ dependencies = [
 
 [[package]]
 name = "shlex"
-version = "1.2.0"
+version = "1.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a7cee0529a6d40f580e7a5e6c495c8fbfe21b7b52795ed4bb5e62cdf92bc6380"
+checksum = "0fda2ff0d084019ba4d7c6f371c95d8fd75ce3524c3cb8fb653a3023f6323e64"
 
 [[package]]
 name = "signal-hook-registry"
@@ -13717,6 +13718,12 @@ dependencies = [
  "futures-io",
  "futures-util",
 ]
+
+[[package]]
+name = "unsigned-varint"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eb066959b24b5196ae73cb057f45598450d2c5f71460e98c49b738086eff9c06"
 
 [[package]]
 name = "untrusted"

--- a/deny.toml
+++ b/deny.toml
@@ -275,7 +275,7 @@ allow-git = []
 
 [sources.allow-org]
 # 1 or more github.com organizations to allow git sources for
-github = ["paritytech", "w3f", "multiformats"]
+github = ["paritytech", "w3f"]
 # 1 or more gitlab.com organizations to allow git sources for
 # gitlab = [""]
 # 1 or more bitbucket.org organizations to allow git sources for

--- a/docker/collator-node-local.dockerfile
+++ b/docker/collator-node-local.dockerfile
@@ -9,7 +9,7 @@ WORKDIR /frequency
 RUN apt-get update && \
 	apt-get install -y jq apt-utils apt-transport-https \
 		software-properties-common readline-common curl vim wget gnupg gnupg2 \
-		gnupg-agent ca-certificates tini && \
+		gnupg-agent ca-certificates tini file && \
 	rm -rf /var/lib/apt/lists/*
 
 # For local testing only

--- a/e2e/package-lock.json
+++ b/e2e/package-lock.json
@@ -307,7 +307,7 @@
         "node_modules/@frequency-chain/api-augment": {
             "version": "0.0.0",
             "resolved": "file:../js/api-augment/dist/frequency-chain-api-augment-0.0.0.tgz",
-            "integrity": "sha512-TYffQ2eMmwREY6yoKEVmFnFu2rSWdzzYpoLDi+8E7ks9Xe0PFkO8JYEZOr8SP8POr2eJJ2EoSXjPgcWSMKczrA==",
+            "integrity": "sha512-SMZfR2D7UP5SO7v8wX2Py2StCweXpq8CDhiLrk51jDEprC1FuQaLFTlrMlc3GrI1SnkE3MLU0LUr9gKxhcdWZw==",
             "license": "Apache-2.0",
             "dependencies": {
                 "@polkadot/api": "^10.9.1",

--- a/pallets/messages/Cargo.toml
+++ b/pallets/messages/Cargo.toml
@@ -30,8 +30,7 @@ sp-runtime = { workspace = true }
 sp-std = { workspace = true }
 # Frequency related dependencies
 common-primitives = { default-features = false, path = "../../common/primitives" }
-# Pinning a specific commit to fix an unwrap-panic issue: REVIEW: remove when cid > 0.10.1 
-cid = { git = "https://github.com/multiformats/rust-cid", rev = "86c79126d851316350ad106d0df3e4ae69071874", default-features = false }
+cid = { version = "0.11", default-features = false }
 multibase = { version ="0.9", default-features = false }
 
 [dev-dependencies]


### PR DESCRIPTION
# Goal
The goal of this PR is to update the cid crate in the messages pallet and remove special handling.

Closes #1720

# Discussion

- `spec_version` update not needed: the compiled artifacts are essentially the same, as the cid crate version that was being used has been published to crates.io as referenced in `Cargo.toml`

# How to Test

1. Confirm that unit tests pass (unit tests cover the vulnerability)


