### PR TITLE
Remove deprecated method try_runtime_cli::TryRuntimeCmd::run

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -13956,9 +13956,9 @@ dependencies = [
 
 [[package]]
 name = "wasmi"
-version = "0.31.1"
+version = "0.31.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "acfc1e384a36ca532d070a315925887247f3c7e23567e23e0ac9b1c5d6b8bf76"
+checksum = "77a8281d1d660cdf54c76a3efa9ddd0c270cada1383a995db3ccb43d166456c7"
 dependencies = [
  "smallvec",
  "spin 0.9.8",
@@ -13969,9 +13969,9 @@ dependencies = [
 
 [[package]]
 name = "wasmi_arena"
-version = "0.4.0"
+version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "401c1f35e413fac1846d4843745589d9ec678977ab35a384db8ae7830525d468"
+checksum = "104a7f73be44570cac297b3035d76b169d6599637631cf37a1703326a0727073"
 
 [[package]]
 name = "wasmi_core"

--- a/node/cli/src/cli.rs
+++ b/node/cli/src/cli.rs
@@ -49,10 +49,6 @@ pub enum Subcommand {
 	#[clap(subcommand)]
 	Benchmark(frame_benchmarking_cli::BenchmarkCmd),
 
-	/// Try some testing command against a specified runtime state.
-	#[cfg(feature = "try-runtime")]
-	TryRuntime(try_runtime_cli::TryRuntimeCmd),
-
 	/// Get current runtime spec version.
 	ExportRuntimeVersion(ExportRuntimeVersionCmd),
 }

--- a/node/cli/src/command.rs
+++ b/node/cli/src/command.rs
@@ -369,28 +369,6 @@ pub fn run() -> Result<()> {
 			}
 		},
 
-		#[cfg(feature = "try-runtime")]
-		Some(Subcommand::TryRuntime(cmd)) => {
-			use common_runtime::constants::MILLISECS_PER_BLOCK;
-			use try_runtime_cli::block_building_info::timestamp_with_aura_info;
-
-			let runner = cli.create_runner(cmd)?;
-
-			type HostFunctions =
-				(sp_io::SubstrateHostFunctions, frame_benchmarking::benchmarking::HostFunctions);
-
-			// grab the task manager.
-			let registry = &runner.config().prometheus_config.as_ref().map(|cfg| &cfg.registry);
-			let task_manager =
-				sc_service::TaskManager::new(runner.config().tokio_handle.clone(), *registry)
-					.map_err(|e| format!("Error: {:?}", e))?;
-
-			let info_provider = timestamp_with_aura_info(MILLISECS_PER_BLOCK);
-
-			runner.async_run(|_| {
-				Ok((cmd.run::<Block, HostFunctions, _>(Some(info_provider)), task_manager))
-			})
-		},
 		Some(Subcommand::ExportRuntimeVersion(cmd)) => {
 			let runner = cli.create_runner(cmd)?;
 


### PR DESCRIPTION
# Goal
The goal of this PR is to remove deprecated code.

Closes #1814 

# Changes
- [x] Remove `try-runtime` command-line option
- [x] `cargo update -p wasmi wasmi_arena` to fix lint-audit problems
- [x] Makefile updates for `try-runtime` and `.PHONY` targets

# How to test
- Building with `features=try-runtime` does not complain about deprecation.
- Run `make try-runtime-XXX` commands and confirm they work. As runtime upgrades take quite a long time, maybe focus on the snapshots, and use the files from Google Drive:`Initiatives/Projects/Labs/Developers/Frequency Snapshots`
- Are there any other places in the repo that might be affected by removing the `try-runtime` command line option?

# Checklist
- [ ] Chain spec updated
- [ ] Custom RPC OR Runtime API added/changed? Updated js/api-augment.
- [ ] Design doc(s) updated
- [ ] Tests added
- [ ] Benchmarks added
- [ ] Weights updated
