### PR TITLE
fix: Update cargo install commands to use --locked flag

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -319,7 +319,7 @@ jobs:
           echo "runtime_filename_${{matrix.network}}=$release_wasm_filename" >> $GITHUB_OUTPUT
       - name: Install srtool-cli
         run: |
-          cargo install --git https://github.com/chevdor/srtool-cli
+          cargo install --locked --git https://github.com/chevdor/srtool-cli
           srtool --version
       - name: Build Deterministic WASM
         run: |
@@ -666,7 +666,7 @@ jobs:
           echo "PREVIOUS_RELEASE_TAG=${{steps.get-previous-full-release-version.outputs.version}}" >> $GITHUB_ENV
       - name: Install Tera CLI
         run: |
-          cargo install --git https://github.com/chevdor/tera-cli
+          cargo install --locked --git https://github.com/chevdor/tera-cli
           echo "PATH=$HOME/.cargo/bin:$PATH" >> $GITHUB_ENV
       - name: Verify Tera CLI Install
         run: |

--- a/.github/workflows/verify-pr-commit.yml
+++ b/.github/workflows/verify-pr-commit.yml
@@ -358,7 +358,7 @@ jobs:
         if: steps.cache-wasm.outputs.cache-hit != 'true'
         run: |
           rustup show
-          cargo install --git https://github.com/chevdor/srtool-cli
+          cargo install --locked --git https://github.com/chevdor/srtool-cli
           echo "PATH=$HOME/.cargo/bin:$PATH" >> $GITHUB_ENV
       - name: Test srtool-cli Install
         run: |


### PR DESCRIPTION
# Goal
The goal of this PR is prevent `cargo` dependency issues by using `--locked` with all `cargo install` commands.

Closes #1879

# Discussion
When using cargo install to install development tools, `--locked` should be used.
This requires cargo to use the crates that are specified in the tool's Cargo.lock file.

If `--locked` is not specified, cargo will use the latest version of the crate, and this can cause dependency issues.

# Changes

- add `--locked` to all `cargo install` commands in the github workflows

# How to Test

- confirm that CI passes
- Find any instances of `cargo install` that have not been updated to include `--locked` [searched for `cargo.*install` and updated all instances found]

# Checklist
- [ ] Chain spec updated
- [ ] Custom RPC OR Runtime API added/changed? Updated js/api-augment.
- [ ] Design doc(s) updated
- [ ] Tests added
- [ ] Benchmarks added
- [ ] Weights updated
