### PR TITLE
fix: Update ci-base-image version and Rust toolchain

### DIFF
--- a/.github/workflows/merge-pr.yml
+++ b/.github/workflows/merge-pr.yml
@@ -84,7 +84,7 @@ jobs:
       # ci-base-image is published IF and ONLY IF ci-base-image.dockerfile changes
       # IMAGE_VERSION reflects the latest version of ci-base-image.dockerfile that has been published
       IMAGE_NAME: ci-base-image
-      IMAGE_VERSION: 1.2.0
+      IMAGE_VERSION: 1.3.0
       BRANCH_NAME: main
     runs-on: ubuntu-22.04
     steps:

--- a/tools/ci/docker/ci-base-image.dockerfile
+++ b/tools/ci/docker/ci-base-image.dockerfile
@@ -23,8 +23,8 @@ RUN curl https://sh.rustup.rs -sSf | bash -s -- -y
 ENV PATH="/home/runner/.cargo/bin:/root/.cargo/bin:${PATH}"
 ENV RUSTUP_HOME="/root/.cargo"
 ENV CARGO_HOME="/root/.cargo"
-RUN rustup toolchain install nightly-2024-02-04
-RUN rustup target add x86_64-unknown-linux-gnu --toolchain nightly-2024-02-04
-RUN rustup target add wasm32-unknown-unknown --toolchain nightly-2024-02-04
+RUN rustup toolchain install nightly-2024-03-01
+RUN rustup target add x86_64-unknown-linux-gnu --toolchain nightly-2024-03-01
+RUN rustup target add wasm32-unknown-unknown --toolchain nightly-2024-03-01
 
 RUN git config --system --add safe.directory /__w/frequency/frequency


### PR DESCRIPTION
# Goal
The goal of this PR is update nightly for ci-base-image.
Part of #1897 
  

# Checklist
- [ ] Chain spec updated
- [ ] Custom RPC OR Runtime API added/changed? Updated js/api-augment.
- [ ] Design doc(s) updated
- [ ] Tests added
- [ ] Benchmarks added
- [ ] Weights updated
